### PR TITLE
feat(components): make y-axis max value configurable

### DIFF
--- a/components/src/preact/prevalenceOverTime/prevalence-over-time-bar-chart.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time-bar-chart.tsx
@@ -1,17 +1,20 @@
 import { Chart, type ChartConfiguration, registerables, type TooltipItem } from 'chart.js';
 import { BarWithErrorBar, BarWithErrorBarsController } from 'chartjs-chart-error-bars';
 
+import { maxInData } from './prevalence-over-time';
 import { type PrevalenceOverTimeData, type PrevalenceOverTimeVariantData } from '../../query/queryPrevalenceOverTime';
 import GsChart from '../components/chart';
 import { LogitScale } from '../shared/charts/LogitScale';
 import { singleGraphColorRGBAById } from '../shared/charts/colors';
 import { type ConfidenceIntervalMethod, wilson95PercentConfidenceInterval } from '../shared/charts/confideceInterval';
+import { getYAxisMax, type YAxisMaxConfig } from '../shared/charts/getYAxisMax';
 import { getYAxisScale, type ScaleType } from '../shared/charts/getYAxisScale';
 
 interface PrevalenceOverTimeBarChartProps {
     data: PrevalenceOverTimeData;
     yAxisScaleType: ScaleType;
     confidenceIntervalMethod: ConfidenceIntervalMethod;
+    yAxisMaxConfig?: YAxisMaxConfig;
 }
 
 Chart.register(...registerables, LogitScale, BarWithErrorBarsController, BarWithErrorBar);
@@ -20,7 +23,11 @@ const PrevalenceOverTimeBarChart = ({
     data,
     yAxisScaleType,
     confidenceIntervalMethod,
+    yAxisMaxConfig,
 }: PrevalenceOverTimeBarChartProps) => {
+    const maxY =
+        yAxisScaleType !== 'logit' ? getYAxisMax(maxInData(data), yAxisMaxConfig?.[yAxisScaleType]) : undefined;
+
     const config: ChartConfiguration = {
         type: BarWithErrorBarsController.id,
         data: {
@@ -31,7 +38,7 @@ const PrevalenceOverTimeBarChart = ({
             maintainAspectRatio: false,
             animation: false,
             scales: {
-                y: getYAxisScale(yAxisScaleType),
+                y: { ...getYAxisScale(yAxisScaleType), max: maxY },
             },
             plugins: {
                 legend: {

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time-bar-chart.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time-bar-chart.tsx
@@ -14,7 +14,7 @@ interface PrevalenceOverTimeBarChartProps {
     data: PrevalenceOverTimeData;
     yAxisScaleType: ScaleType;
     confidenceIntervalMethod: ConfidenceIntervalMethod;
-    yAxisMaxConfig?: YAxisMaxConfig;
+    yAxisMaxConfig: YAxisMaxConfig;
 }
 
 Chart.register(...registerables, LogitScale, BarWithErrorBarsController, BarWithErrorBar);

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time-bubble-chart.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time-bubble-chart.tsx
@@ -13,7 +13,7 @@ import { getYAxisScale, type ScaleType } from '../shared/charts/getYAxisScale';
 interface PrevalenceOverTimeBubbleChartProps {
     data: PrevalenceOverTimeData;
     yAxisScaleType: ScaleType;
-    yAxisMaxConfig?: YAxisMaxConfig;
+    yAxisMaxConfig: YAxisMaxConfig;
 }
 
 Chart.register(...registerables, LogitScale);

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time-line-chart.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time-line-chart.tsx
@@ -18,7 +18,7 @@ interface PrevalenceOverTimeLineChartProps {
     data: PrevalenceOverTimeData;
     yAxisScaleType: ScaleType;
     confidenceIntervalMethod: ConfidenceIntervalMethod;
-    yAxisMaxConfig?: YAxisMaxConfig;
+    yAxisMaxConfig: YAxisMaxConfig;
 }
 
 Chart.register(...registerables, LogitScale);

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.stories.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.stories.tsx
@@ -33,6 +33,7 @@ export default {
         height: { control: 'text' },
         headline: { control: 'text' },
         pageSize: { control: 'object' },
+        yAxisMaxConfig: { control: 'object' },
     },
 };
 
@@ -51,6 +52,7 @@ const Template = {
                 headline={args.headline}
                 lapisDateField={args.lapisDateField}
                 pageSize={args.pageSize}
+                yAxisMaxConfig={args.yAxisMaxConfig}
             />
         </LapisUrlContext.Provider>
     ),
@@ -73,6 +75,10 @@ export const TwoVariants = {
         headline: 'Prevalence over time',
         lapisDateField: 'date',
         pageSize: 10,
+        yAxisMaxConfig: {
+            linear: 1,
+            logarithmic: 1,
+        },
     },
     parameters: {
         fetchMock: {
@@ -146,6 +152,10 @@ export const OneVariant = {
         headline: 'Prevalence over time',
         lapisDateField: 'date',
         pageSize: 10,
+        yAxisMaxConfig: {
+            linear: 1,
+            logarithmic: 1,
+        },
     },
     parameters: {
         fetchMock: {

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
@@ -42,7 +42,7 @@ export interface PrevalenceOverTimeInnerProps {
     confidenceIntervalMethods: ConfidenceIntervalMethod[];
     lapisDateField: string;
     pageSize: boolean | number;
-    yAxisMaxConfig?: YAxisMaxConfig;
+    yAxisMaxConfig: YAxisMaxConfig;
 }
 
 export const PrevalenceOverTime: FunctionComponent<PrevalenceOverTimeProps> = ({
@@ -130,7 +130,7 @@ type PrevalenceOverTimeTabsProps = {
     granularity: TemporalGranularity;
     confidenceIntervalMethods: ConfidenceIntervalMethod[];
     pageSize: boolean | number;
-    yAxisMaxConfig?: YAxisMaxConfig;
+    yAxisMaxConfig: YAxisMaxConfig;
 };
 
 const PrevalenceOverTimeTabs: FunctionComponent<PrevalenceOverTimeTabsProps> = ({

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
@@ -21,6 +21,7 @@ import { ResizeContainer } from '../components/resize-container';
 import { ScalingSelector } from '../components/scaling-selector';
 import Tabs from '../components/tabs';
 import { type ConfidenceIntervalMethod } from '../shared/charts/confideceInterval';
+import type { YAxisMaxConfig } from '../shared/charts/getYAxisMax';
 import { type ScaleType } from '../shared/charts/getYAxisScale';
 import { useQuery } from '../useQuery';
 
@@ -41,6 +42,7 @@ export interface PrevalenceOverTimeInnerProps {
     confidenceIntervalMethods: ConfidenceIntervalMethod[];
     lapisDateField: string;
     pageSize: boolean | number;
+    yAxisMaxConfig?: YAxisMaxConfig;
 }
 
 export const PrevalenceOverTime: FunctionComponent<PrevalenceOverTimeProps> = ({
@@ -55,6 +57,7 @@ export const PrevalenceOverTime: FunctionComponent<PrevalenceOverTimeProps> = ({
     headline = 'Prevalence over time',
     lapisDateField,
     pageSize,
+    yAxisMaxConfig,
 }) => {
     const size = { height, width };
 
@@ -71,6 +74,7 @@ export const PrevalenceOverTime: FunctionComponent<PrevalenceOverTimeProps> = ({
                         confidenceIntervalMethods={confidenceIntervalMethods}
                         lapisDateField={lapisDateField}
                         pageSize={pageSize}
+                        yAxisMaxConfig={yAxisMaxConfig}
                     />
                 </Headline>
             </ResizeContainer>
@@ -87,6 +91,7 @@ export const PrevalenceOverTimeInner: FunctionComponent<PrevalenceOverTimeInnerP
     confidenceIntervalMethods,
     lapisDateField,
     pageSize,
+    yAxisMaxConfig,
 }) => {
     const lapis = useContext(LapisUrlContext);
 
@@ -114,6 +119,7 @@ export const PrevalenceOverTimeInner: FunctionComponent<PrevalenceOverTimeInnerP
             granularity={granularity}
             confidenceIntervalMethods={confidenceIntervalMethods}
             pageSize={pageSize}
+            yAxisMaxConfig={yAxisMaxConfig}
         />
     );
 };
@@ -124,6 +130,7 @@ type PrevalenceOverTimeTabsProps = {
     granularity: TemporalGranularity;
     confidenceIntervalMethods: ConfidenceIntervalMethod[];
     pageSize: boolean | number;
+    yAxisMaxConfig?: YAxisMaxConfig;
 };
 
 const PrevalenceOverTimeTabs: FunctionComponent<PrevalenceOverTimeTabsProps> = ({
@@ -132,6 +139,7 @@ const PrevalenceOverTimeTabs: FunctionComponent<PrevalenceOverTimeTabsProps> = (
     granularity,
     confidenceIntervalMethods,
     pageSize,
+    yAxisMaxConfig,
 }) => {
     const [yAxisScaleType, setYAxisScaleType] = useState<ScaleType>('linear');
     const [confidenceIntervalMethod, setConfidenceIntervalMethod] = useState<ConfidenceIntervalMethod>(
@@ -148,6 +156,7 @@ const PrevalenceOverTimeTabs: FunctionComponent<PrevalenceOverTimeTabsProps> = (
                             data={data}
                             yAxisScaleType={yAxisScaleType}
                             confidenceIntervalMethod={confidenceIntervalMethod}
+                            yAxisMaxConfig={yAxisMaxConfig}
                         />
                     ),
                 };
@@ -159,13 +168,20 @@ const PrevalenceOverTimeTabs: FunctionComponent<PrevalenceOverTimeTabsProps> = (
                             data={data}
                             yAxisScaleType={yAxisScaleType}
                             confidenceIntervalMethod={confidenceIntervalMethod}
+                            yAxisMaxConfig={yAxisMaxConfig}
                         />
                     ),
                 };
             case 'bubble':
                 return {
                     title: 'Bubble',
-                    content: <PrevalenceOverTimeBubbleChart data={data} yAxisScaleType={yAxisScaleType} />,
+                    content: (
+                        <PrevalenceOverTimeBubbleChart
+                            data={data}
+                            yAxisScaleType={yAxisScaleType}
+                            yAxisMaxConfig={yAxisMaxConfig}
+                        />
+                    ),
                 };
             case 'table':
                 return {
@@ -245,3 +261,6 @@ const PrevalenceOverTimeInfo: FunctionComponent = () => {
         </Info>
     );
 };
+
+export const maxInData = (data: PrevalenceOverTimeData) =>
+    Math.max(...data.flatMap((variant) => variant.content.map((dataPoint) => dataPoint.prevalence)));

--- a/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage-chart.tsx
+++ b/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage-chart.tsx
@@ -5,6 +5,7 @@ import GsChart from '../components/chart';
 import { LogitScale } from '../shared/charts/LogitScale';
 import { singleGraphColorRGBByName } from '../shared/charts/colors';
 import { confidenceIntervalDataLabel } from '../shared/charts/confideceInterval';
+import { getYAxisMax, type YAxisMaxConfig } from '../shared/charts/getYAxisMax';
 import { getYAxisScale, type ScaleType } from '../shared/charts/getYAxisScale';
 
 interface RelativeGrowthAdvantageChartData {
@@ -25,11 +26,17 @@ interface RelativeGrowthAdvantageChartData {
 interface RelativeGrowthAdvantageChartProps {
     data: RelativeGrowthAdvantageChartData;
     yAxisScaleType: ScaleType;
+    yAxisMaxConfig?: YAxisMaxConfig;
 }
 
 Chart.register(...registerables, LogitScale);
 
-const RelativeGrowthAdvantageChart = ({ data, yAxisScaleType }: RelativeGrowthAdvantageChartProps) => {
+const RelativeGrowthAdvantageChart = ({ data, yAxisScaleType, yAxisMaxConfig }: RelativeGrowthAdvantageChartProps) => {
+    const maxY =
+        yAxisScaleType !== 'logit'
+            ? getYAxisMax(Math.max(...data.proportion), yAxisMaxConfig?.[yAxisScaleType])
+            : undefined;
+
     const config: ChartConfiguration = {
         type: 'line',
         data: {
@@ -39,8 +46,9 @@ const RelativeGrowthAdvantageChart = ({ data, yAxisScaleType }: RelativeGrowthAd
         options: {
             maintainAspectRatio: false,
             animation: false,
+
             scales: {
-                y: getYAxisScale(yAxisScaleType),
+                y: { ...getYAxisScale(yAxisScaleType), max: maxY },
             },
             plugins: {
                 legend: {

--- a/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage-chart.tsx
+++ b/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage-chart.tsx
@@ -26,7 +26,7 @@ interface RelativeGrowthAdvantageChartData {
 interface RelativeGrowthAdvantageChartProps {
     data: RelativeGrowthAdvantageChartData;
     yAxisScaleType: ScaleType;
-    yAxisMaxConfig?: YAxisMaxConfig;
+    yAxisMaxConfig: YAxisMaxConfig;
 }
 
 Chart.register(...registerables, LogitScale);

--- a/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.stories.tsx
+++ b/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.stories.tsx
@@ -21,6 +21,7 @@ export default {
         width: { control: 'text' },
         height: { control: 'text' },
         headline: { control: 'text' },
+        yAxisMaxConfig: { control: 'object' },
     },
 };
 
@@ -36,6 +37,7 @@ export const Primary = {
                 height={args.height}
                 headline={args.headline}
                 lapisDateField={args.lapisDateField}
+                yAxisMaxConfig={args.yAxisMaxConfig}
             />
         </LapisUrlContext.Provider>
     ),
@@ -48,6 +50,10 @@ export const Primary = {
         height: '700px',
         headline: 'Relative growth advantage',
         lapisDateField: 'date',
+        yAxisMaxConfig: {
+            linear: 1,
+            logarithmic: 1,
+        },
     },
     parameters: {
         fetchMock: {

--- a/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
+++ b/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
@@ -17,6 +17,7 @@ import { NoDataDisplay } from '../components/no-data-display';
 import { ResizeContainer } from '../components/resize-container';
 import { ScalingSelector } from '../components/scaling-selector';
 import Tabs from '../components/tabs';
+import { type YAxisMaxConfig } from '../shared/charts/getYAxisMax';
 import { type ScaleType } from '../shared/charts/getYAxisScale';
 import { useQuery } from '../useQuery';
 
@@ -34,6 +35,7 @@ export interface RelativeGrowthAdvantagePropsInner {
     generationTime: number;
     views: View[];
     lapisDateField: string;
+    yAxisMaxConfig?: YAxisMaxConfig;
 }
 
 export const RelativeGrowthAdvantage: FunctionComponent<RelativeGrowthAdvantageProps> = ({
@@ -45,6 +47,7 @@ export const RelativeGrowthAdvantage: FunctionComponent<RelativeGrowthAdvantageP
     generationTime,
     headline = 'Relative growth advantage',
     lapisDateField,
+    yAxisMaxConfig,
 }) => {
     const size = { height, width };
 
@@ -58,6 +61,7 @@ export const RelativeGrowthAdvantage: FunctionComponent<RelativeGrowthAdvantageP
                         denominator={denominator}
                         generationTime={generationTime}
                         lapisDateField={lapisDateField}
+                        yAxisMaxConfig={yAxisMaxConfig}
                     />
                 </Headline>
             </ResizeContainer>
@@ -71,6 +75,7 @@ export const RelativeGrowthAdvantageInner: FunctionComponent<RelativeGrowthAdvan
     generationTime,
     views,
     lapisDateField,
+    yAxisMaxConfig,
 }) => {
     const lapis = useContext(LapisUrlContext);
     const [yAxisScaleType, setYAxisScaleType] = useState<ScaleType>('linear');
@@ -99,6 +104,7 @@ export const RelativeGrowthAdvantageInner: FunctionComponent<RelativeGrowthAdvan
             setYAxisScaleType={setYAxisScaleType}
             views={views}
             generationTime={generationTime}
+            yAxisMaxConfig={yAxisMaxConfig}
         />
     );
 };
@@ -109,6 +115,7 @@ type RelativeGrowthAdvantageTabsProps = {
     setYAxisScaleType: (scaleType: ScaleType) => void;
     views: View[];
     generationTime: number;
+    yAxisMaxConfig?: YAxisMaxConfig;
 };
 
 const RelativeGrowthAdvantageTabs: FunctionComponent<RelativeGrowthAdvantageTabsProps> = ({
@@ -117,6 +124,7 @@ const RelativeGrowthAdvantageTabs: FunctionComponent<RelativeGrowthAdvantageTabs
     setYAxisScaleType,
     views,
     generationTime,
+    yAxisMaxConfig,
 }) => {
     const getTab = (view: View) => {
         switch (view) {
@@ -131,6 +139,7 @@ const RelativeGrowthAdvantageTabs: FunctionComponent<RelativeGrowthAdvantageTabs
                                 params: data.params,
                             }}
                             yAxisScaleType={yAxisScaleType}
+                            yAxisMaxConfig={yAxisMaxConfig}
                         />
                     ),
                 };

--- a/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
+++ b/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
@@ -35,7 +35,7 @@ export interface RelativeGrowthAdvantagePropsInner {
     generationTime: number;
     views: View[];
     lapisDateField: string;
-    yAxisMaxConfig?: YAxisMaxConfig;
+    yAxisMaxConfig: YAxisMaxConfig;
 }
 
 export const RelativeGrowthAdvantage: FunctionComponent<RelativeGrowthAdvantageProps> = ({
@@ -115,7 +115,7 @@ type RelativeGrowthAdvantageTabsProps = {
     setYAxisScaleType: (scaleType: ScaleType) => void;
     views: View[];
     generationTime: number;
-    yAxisMaxConfig?: YAxisMaxConfig;
+    yAxisMaxConfig: YAxisMaxConfig;
 };
 
 const RelativeGrowthAdvantageTabs: FunctionComponent<RelativeGrowthAdvantageTabsProps> = ({

--- a/components/src/preact/shared/charts/getYAxisMax.ts
+++ b/components/src/preact/shared/charts/getYAxisMax.ts
@@ -1,0 +1,24 @@
+export interface YAxisMaxConfig {
+    linear?: AxisMax;
+    logarithmic?: AxisMax;
+}
+
+export type AxisMax = 'maxInData' | 'limitTo1' | number;
+
+export const getYAxisMax = (maxInData: number, axisMax?: AxisMax) => {
+    if (!axisMax) {
+        return 1;
+    }
+
+    switch (axisMax) {
+        case 'limitTo1': {
+            return maxInData > 1 ? 1 : maxInData;
+        }
+        case 'maxInData': {
+            return maxInData;
+        }
+        default: {
+            return axisMax;
+        }
+    }
+};

--- a/components/src/preact/shared/charts/getYAxisScale.ts
+++ b/components/src/preact/shared/charts/getYAxisScale.ts
@@ -6,11 +6,9 @@ export function getYAxisScale(scaleType: ScaleType) {
             return { beginAtZero: true, type: 'linear' as const, min: 0, max: 1 };
         }
         case 'logarithmic': {
-            return { type: 'logarithmic' as const };
+            return { type: 'logarithmic' as const, max: 1 };
         }
         case 'logit':
             return { type: 'logit' as const };
-        default:
-            return { beginAtZero: true, type: 'linear' as const };
     }
 }

--- a/components/src/web-components/visualization/gs-prevalence-over-time.stories.ts
+++ b/components/src/web-components/visualization/gs-prevalence-over-time.stories.ts
@@ -4,6 +4,8 @@ import { html } from 'lit';
 
 import '../app';
 import './gs-prevalence-over-time';
+// eslint-disable-next-line no-duplicate-imports
+import { type PrevalenceOverTimeComponentProps } from './gs-prevalence-over-time';
 import { withComponentDocs } from '../../../.storybook/ComponentDocsBlock';
 import { AGGREGATED_ENDPOINT, LAPIS_URL } from '../../constants';
 import denominator from '../../preact/prevalenceOverTime/__mockData__/denominator.json';
@@ -11,7 +13,6 @@ import denominatorOneVariant from '../../preact/prevalenceOverTime/__mockData__/
 import numeratorEG from '../../preact/prevalenceOverTime/__mockData__/numeratorEG.json';
 import numeratorJN1 from '../../preact/prevalenceOverTime/__mockData__/numeratorJN1.json';
 import numeratorOneVariant from '../../preact/prevalenceOverTime/__mockData__/numeratorOneVariant.json';
-import { type PrevalenceOverTimeProps } from '../../preact/prevalenceOverTime/prevalence-over-time';
 import { withinShadowRoot } from '../withinShadowRoot.story';
 
 const codeExample = String.raw`
@@ -27,9 +28,11 @@ const codeExample = String.raw`
     height="700px"
     lapisDateField="date"
     pageSize="10"
+    yAxisMaxLinear="1"
+    yAxisMaxLogarithmic="limitTo1"    
 ></gs-prevalence-over-time>`;
 
-const meta: Meta<Required<PrevalenceOverTimeProps>> = {
+const meta: Meta<Required<PrevalenceOverTimeComponentProps>> = {
     title: 'Visualization/Prevalence over time',
     component: 'gs-prevalence-over-time',
     argTypes: {
@@ -52,6 +55,8 @@ const meta: Meta<Required<PrevalenceOverTimeProps>> = {
         height: { control: 'text' },
         headline: { control: 'text' },
         pageSize: { control: 'object' },
+        yAxisMaxLinear: { control: 'object' },
+        yAxisMaxLogarithmic: { control: 'object' },
     },
     parameters: withComponentDocs({
         componentDocs: {
@@ -65,7 +70,7 @@ const meta: Meta<Required<PrevalenceOverTimeProps>> = {
 
 export default meta;
 
-const Template: StoryObj<Required<PrevalenceOverTimeProps>> = {
+const Template: StoryObj<Required<PrevalenceOverTimeComponentProps>> = {
     render: (args) => html`
         <gs-app lapis="${LAPIS_URL}">
             <gs-prevalence-over-time
@@ -80,12 +85,14 @@ const Template: StoryObj<Required<PrevalenceOverTimeProps>> = {
                 .headline=${args.headline}
                 .lapisDateField=${args.lapisDateField}
                 .pageSize=${args.pageSize}
+                .yAxisMaxLinear=${args.yAxisMaxLinear}
+                .yAxisMaxLogarithmic=${args.yAxisMaxLogarithmic}
             ></gs-prevalence-over-time>
         </gs-app>
     `,
 };
 
-export const TwoVariants: StoryObj<Required<PrevalenceOverTimeProps>> = {
+export const TwoVariants: StoryObj<Required<PrevalenceOverTimeComponentProps>> = {
     ...Template,
     args: {
         numerator: [
@@ -102,6 +109,8 @@ export const TwoVariants: StoryObj<Required<PrevalenceOverTimeProps>> = {
         headline: 'Prevalence over time',
         lapisDateField: 'date',
         pageSize: 10,
+        yAxisMaxLinear: 1,
+        yAxisMaxLogarithmic: 'limitTo1',
     },
     parameters: {
         fetchMock: {
@@ -158,7 +167,7 @@ export const TwoVariants: StoryObj<Required<PrevalenceOverTimeProps>> = {
     },
 };
 
-export const OneVariant: StoryObj<Required<PrevalenceOverTimeProps>> = {
+export const OneVariant: StoryObj<Required<PrevalenceOverTimeComponentProps>> = {
     ...Template,
     args: {
         numerator: {
@@ -175,6 +184,8 @@ export const OneVariant: StoryObj<Required<PrevalenceOverTimeProps>> = {
         headline: 'Prevalence over time',
         lapisDateField: 'date',
         pageSize: 10,
+        yAxisMaxLinear: 1,
+        yAxisMaxLogarithmic: 'limitTo1',
     },
     parameters: {
         fetchMock: {
@@ -215,7 +226,7 @@ export const OneVariant: StoryObj<Required<PrevalenceOverTimeProps>> = {
     },
 };
 
-export const OneVariantOnLineTab: StoryObj<Required<PrevalenceOverTimeProps>> = {
+export const OneVariantOnLineTab: StoryObj<Required<PrevalenceOverTimeComponentProps>> = {
     ...OneVariant,
     play: async ({ canvasElement }) => {
         const canvas = await withinShadowRoot(canvasElement, 'gs-prevalence-over-time');
@@ -226,7 +237,7 @@ export const OneVariantOnLineTab: StoryObj<Required<PrevalenceOverTimeProps>> = 
     },
 };
 
-export const OneVariantOnBubbleTab: StoryObj<Required<PrevalenceOverTimeProps>> = {
+export const OneVariantOnBubbleTab: StoryObj<Required<PrevalenceOverTimeComponentProps>> = {
     ...OneVariant,
     play: async ({ canvasElement }) => {
         const canvas = await withinShadowRoot(canvasElement, 'gs-prevalence-over-time');
@@ -237,7 +248,7 @@ export const OneVariantOnBubbleTab: StoryObj<Required<PrevalenceOverTimeProps>> 
     },
 };
 
-export const OneVariantOnTableTab: StoryObj<Required<PrevalenceOverTimeProps>> = {
+export const OneVariantOnTableTab: StoryObj<Required<PrevalenceOverTimeComponentProps>> = {
     ...OneVariant,
     play: async ({ canvasElement }) => {
         const canvas = await withinShadowRoot(canvasElement, 'gs-prevalence-over-time');

--- a/components/src/web-components/visualization/gs-prevalence-over-time.tsx
+++ b/components/src/web-components/visualization/gs-prevalence-over-time.tsx
@@ -148,21 +148,21 @@ export class PrevalenceOverTimeComponent extends PreactLitAdapterWithGridJsStyle
      * The maximum value for the y-axis on all graphs in linear view.
      * If set to a number, the maximum value is set to this number.
      * If set to `maxInData`, the maximum value is set to the maximum value in the data.
-     * If set to `limitTo1`, the maximum value is set to the lower value of 1 or the maximum value in the data.
+     * If set to `limitTo1`, the maximum value is set to `min(1, the maximum value in the data)`.
      * If not set, the maximum value is set to the default value (1).
      */
     @property({ type: String })
-    yAxisMaxLinear: 'maxInData' | 'limitTo1' | number | undefined = undefined;
+    yAxisMaxLinear: 'maxInData' | 'limitTo1' | number = 1;
 
     /**
      * The maximum value for the y-axis on all graphs in logarithmic view.
      * If set to a number, the maximum value is set to this number.
      * If set to `maxInData`, the maximum value is set to the maximum value in the data.
-     * If set to `limitTo1`, the maximum value is set to the lower value of 1 or the maximum value in the data.
+     * If set to `limitTo1`, the maximum value is set to `min(1, the maximum value in the data)`.
      * If not set, the maximum value is set to the default value (1).
      */
     @property({ type: String })
-    yAxisMaxLogarithmic: 'maxInData' | 'limitTo1' | number | undefined = undefined;
+    yAxisMaxLogarithmic: 'maxInData' | 'limitTo1' | number = 1;
 
     override render() {
         return (

--- a/components/src/web-components/visualization/gs-prevalence-over-time.tsx
+++ b/components/src/web-components/visualization/gs-prevalence-over-time.tsx
@@ -1,6 +1,7 @@
 import { customElement, property } from 'lit/decorators.js';
 
 import { PrevalenceOverTime, type PrevalenceOverTimeProps } from '../../preact/prevalenceOverTime/prevalence-over-time';
+import { type AxisMax } from '../../preact/shared/charts/getYAxisMax';
 import { type Equals, type Expect } from '../../utils/typeAssertions';
 import { PreactLitAdapterWithGridJsStyles } from '../PreactLitAdapterWithGridJsStyles';
 
@@ -143,6 +144,26 @@ export class PrevalenceOverTimeComponent extends PreactLitAdapterWithGridJsStyle
     @property({ type: Object })
     pageSize: boolean | number = false;
 
+    /**
+     * The maximum value for the y-axis on all graphs in linear view.
+     * If set to a number, the maximum value is set to this number.
+     * If set to `maxInData`, the maximum value is set to the maximum value in the data.
+     * If set to `limitTo1`, the maximum value is set to the lower value of 1 or the maximum value in the data.
+     * If not set, the maximum value is set to the default value (1).
+     */
+    @property({ type: String })
+    yAxisMaxLinear: 'maxInData' | 'limitTo1' | number | undefined = undefined;
+
+    /**
+     * The maximum value for the y-axis on all graphs in logarithmic view.
+     * If set to a number, the maximum value is set to this number.
+     * If set to `maxInData`, the maximum value is set to the maximum value in the data.
+     * If set to `limitTo1`, the maximum value is set to the lower value of 1 or the maximum value in the data.
+     * If not set, the maximum value is set to the default value (1).
+     */
+    @property({ type: String })
+    yAxisMaxLogarithmic: 'maxInData' | 'limitTo1' | number | undefined = undefined;
+
     override render() {
         return (
             <PrevalenceOverTime
@@ -157,9 +178,18 @@ export class PrevalenceOverTimeComponent extends PreactLitAdapterWithGridJsStyle
                 headline={this.headline}
                 lapisDateField={this.lapisDateField}
                 pageSize={this.pageSize}
+                yAxisMaxConfig={{
+                    linear: this.yAxisMaxLinear,
+                    logarithmic: this.yAxisMaxLogarithmic,
+                }}
             />
         );
     }
+}
+
+export interface PrevalenceOverTimeComponentProps extends Omit<PrevalenceOverTimeProps, 'yAxisMaxConfig'> {
+    yAxisMaxLinear?: AxisMax;
+    yAxisMaxLogarithmic?: AxisMax;
 }
 
 declare global {

--- a/components/src/web-components/visualization/gs-relative-growth-advantage.stories.ts
+++ b/components/src/web-components/visualization/gs-relative-growth-advantage.stories.ts
@@ -3,11 +3,12 @@ import { html } from 'lit';
 
 import './gs-relative-growth-advantage';
 import '../app';
+// eslint-disable-next-line no-duplicate-imports
+import { type RelativeGrowthAdvantageComponentProps } from './gs-relative-growth-advantage';
 import { withComponentDocs } from '../../../.storybook/ComponentDocsBlock';
 import { AGGREGATED_ENDPOINT, LAPIS_URL } from '../../constants';
 import denominator from '../../preact/relativeGrowthAdvantage/__mockData__/denominator.json';
 import numerator from '../../preact/relativeGrowthAdvantage/__mockData__/numerator.json';
-import { type RelativeGrowthAdvantageProps } from '../../preact/relativeGrowthAdvantage/relative-growth-advantage';
 
 const codeExample = String.raw`
 <gs-relative-growth-advantage
@@ -19,9 +20,11 @@ const codeExample = String.raw`
     height='700px'
     headline="Relative growth advantage"
     lapisDateField="date"
+    yAxisMaxLinear="1"
+    yAxisMaxLogarithmic="limitTo1"    
 ></gs-relative-growth-advantage>`;
 
-const meta: Meta<RelativeGrowthAdvantageProps> = {
+const meta: Meta<RelativeGrowthAdvantageComponentProps> = {
     title: 'Visualization/Relative growth advantage',
     component: 'gs-relative-growth-advantage',
     argTypes: {
@@ -35,6 +38,8 @@ const meta: Meta<RelativeGrowthAdvantageProps> = {
         width: { control: 'text' },
         height: { control: 'text' },
         headline: { control: 'text' },
+        yAxisMaxLinear: { control: 'object' },
+        yAxisMaxLogarithmic: { control: 'object' },
     },
     parameters: withComponentDocs({
         componentDocs: {
@@ -48,7 +53,7 @@ const meta: Meta<RelativeGrowthAdvantageProps> = {
 
 export default meta;
 
-const Template: StoryObj<Required<RelativeGrowthAdvantageProps>> = {
+const Template: StoryObj<Required<RelativeGrowthAdvantageComponentProps>> = {
     render: (args) => html`
         <gs-app lapis="${LAPIS_URL}">
             <gs-relative-growth-advantage
@@ -60,12 +65,14 @@ const Template: StoryObj<Required<RelativeGrowthAdvantageProps>> = {
                 .height=${args.height}
                 .headline=${args.headline}
                 .lapisDateField=${args.lapisDateField}
+                .yAxisMaxLinear=${args.yAxisMaxLinear}
+                .yAxisMaxLogarithmic=${args.yAxisMaxLogarithmic}
             ></gs-relative-growth-advantage>
         </gs-app>
     `,
 };
 
-export const Default: StoryObj<Required<RelativeGrowthAdvantageProps>> = {
+export const Default: StoryObj<Required<RelativeGrowthAdvantageComponentProps>> = {
     ...Template,
     args: {
         numerator: { country: 'Switzerland', pangoLineage: 'B.1.1.7', dateFrom: '2020-12-01', dateTo: '2021-03-01' },
@@ -76,6 +83,8 @@ export const Default: StoryObj<Required<RelativeGrowthAdvantageProps>> = {
         height: '700px',
         headline: 'Relative growth advantage',
         lapisDateField: 'date',
+        yAxisMaxLinear: 1,
+        yAxisMaxLogarithmic: 'limitTo1',
     },
     parameters: {
         fetchMock: {

--- a/components/src/web-components/visualization/gs-relative-growth-advantage.tsx
+++ b/components/src/web-components/visualization/gs-relative-growth-advantage.tsx
@@ -1,6 +1,11 @@
 import { customElement, property } from 'lit/decorators.js';
 
-import { RelativeGrowthAdvantage, type View } from '../../preact/relativeGrowthAdvantage/relative-growth-advantage';
+import {
+    RelativeGrowthAdvantage,
+    type RelativeGrowthAdvantageProps,
+    type View,
+} from '../../preact/relativeGrowthAdvantage/relative-growth-advantage';
+import { type AxisMax } from '../../preact/shared/charts/getYAxisMax';
 import type { LapisFilter } from '../../types';
 import { type Equals, type Expect } from '../../utils/typeAssertions';
 import { PreactLitAdapter } from '../PreactLitAdapter';
@@ -94,6 +99,26 @@ export class RelativeGrowthAdvantageComponent extends PreactLitAdapter {
     @property({ type: String })
     lapisDateField: string = 'date';
 
+    /**
+     * The maximum value for the y-axis on all graphs in linear view.
+     * If set to a number, the maximum value is set to this number.
+     * If set to `maxInData`, the maximum value is set to the maximum value in the data.
+     * If set to `limitTo1`, the maximum value is set to the lower value of 1 or the maximum value in the data.
+     * If not set, the maximum value is set to the default value (1).
+     */
+    @property({ type: String })
+    yAxisMaxLinear: 'maxInData' | 'limitTo1' | number | undefined = undefined;
+
+    /**
+     * The maximum value for the y-axis on all graphs in logarithmic view.
+     * If set to a number, the maximum value is set to this number.
+     * If set to `maxInData`, the maximum value is set to the maximum value in the data.
+     * If set to `limitTo1`, the maximum value is set to the lower value of 1 or the maximum value in the data.
+     * If not set, the maximum value is set to the default value (1).
+     */
+    @property({ type: String })
+    yAxisMaxLogarithmic: 'maxInData' | 'limitTo1' | number | undefined = undefined;
+
     override render() {
         return (
             <RelativeGrowthAdvantage
@@ -105,9 +130,18 @@ export class RelativeGrowthAdvantageComponent extends PreactLitAdapter {
                 height={this.height}
                 headline={this.headline}
                 lapisDateField={this.lapisDateField}
+                yAxisMaxConfig={{
+                    linear: this.yAxisMaxLinear,
+                    logarithmic: this.yAxisMaxLogarithmic,
+                }}
             />
         );
     }
+}
+
+export interface RelativeGrowthAdvantageComponentProps extends Omit<RelativeGrowthAdvantageProps, 'yAxisMaxConfig'> {
+    yAxisMaxLinear?: AxisMax;
+    yAxisMaxLogarithmic?: AxisMax;
 }
 
 declare global {

--- a/components/src/web-components/visualization/gs-relative-growth-advantage.tsx
+++ b/components/src/web-components/visualization/gs-relative-growth-advantage.tsx
@@ -103,21 +103,21 @@ export class RelativeGrowthAdvantageComponent extends PreactLitAdapter {
      * The maximum value for the y-axis on all graphs in linear view.
      * If set to a number, the maximum value is set to this number.
      * If set to `maxInData`, the maximum value is set to the maximum value in the data.
-     * If set to `limitTo1`, the maximum value is set to the lower value of 1 or the maximum value in the data.
+     * If set to `limitTo1`, the maximum value is set to `min(1, the maximum value in the data)`.
      * If not set, the maximum value is set to the default value (1).
      */
     @property({ type: String })
-    yAxisMaxLinear: 'maxInData' | 'limitTo1' | number | undefined = undefined;
+    yAxisMaxLinear: 'maxInData' | 'limitTo1' | number = 1;
 
     /**
      * The maximum value for the y-axis on all graphs in logarithmic view.
      * If set to a number, the maximum value is set to this number.
      * If set to `maxInData`, the maximum value is set to the maximum value in the data.
-     * If set to `limitTo1`, the maximum value is set to the lower value of 1 or the maximum value in the data.
+     * If set to `limitTo1`, the maximum value is set to `min(1, the maximum value in the data)`.
      * If not set, the maximum value is set to the default value (1).
      */
     @property({ type: String })
-    yAxisMaxLogarithmic: 'maxInData' | 'limitTo1' | number | undefined = undefined;
+    yAxisMaxLogarithmic: 'maxInData' | 'limitTo1' | number = 1;
 
     override render() {
         return (


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #264

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Lets the maintainer select the maximum on the y axis for linear and logarithmic view. The logit scale is untouched. This will be addressed by another PR.
The max value can either be a number, or set to `maxInData`, which uses the maximum of the data in the chart as a max value for the y-axis, or set to `limitTo1`, which uses the lower value of the maximum of the data or 1.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![grafik](https://github.com/GenSpectrum/dashboards/assets/122305307/cb74a3d0-1d06-45cb-b429-fbde8ceb0999)

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
