### PR TITLE
fix(components): correct sorting with null values in gs-aggregate

### DIFF
--- a/components/src/preact/aggregatedData/aggregate-table.tsx
+++ b/components/src/preact/aggregatedData/aggregate-table.tsx
@@ -1,6 +1,6 @@
 import { type FunctionComponent } from 'preact';
 
-import { type AggregateData } from '../../query/queryAggregateData';
+import { type AggregateData, compareAscending } from '../../query/queryAggregateData';
 import { Table } from '../components/table';
 import { formatProportion } from '../shared/table/formatProportion';
 
@@ -15,7 +15,9 @@ export const AggregateTable: FunctionComponent<AggregateTableProps> = ({ data, f
         ...fields.map((field) => {
             return {
                 name: field,
-                sort: true,
+                sort: {
+                    compare: compareAscending,
+                },
             };
         }),
         {

--- a/components/src/query/queryAggregateData.ts
+++ b/components/src/query/queryAggregateData.ts
@@ -8,7 +8,7 @@ export type AggregateData = (Record<string, string | null | number | boolean> & 
     proportion: number;
 })[];
 
-const compareAscending = (a: string | null | number, b: string | null | number) => {
+export const compareAscending = (a: string | null | number, b: string | null | number) => {
     if (typeof a === 'number' && typeof b === 'number') {
         return a - b;
     }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #270

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
This fixes the issue, that the sorting with null values did not work. It seems to be a bug in gridjs.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
Ascending
![grafik](https://github.com/GenSpectrum/dashboard-components/assets/122305307/cc77a50d-e56f-47e0-8f22-8446fe65f590)

Descending
![grafik](https://github.com/GenSpectrum/dashboard-components/assets/122305307/75b3323e-7e65-4009-af8d-840066072b54)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
