### PR TITLE
feat(components): reduce the smallest size of the date picker in two row design

### DIFF
--- a/components/src/preact/dateRangeSelector/date-range-selector.tsx
+++ b/components/src/preact/dateRangeSelector/date-range-selector.tsx
@@ -182,7 +182,7 @@ export const DateRangeSelectorInner = <CustomLabel extends string>({
             <Select
                 items={getSelectableOptions(customSelectOptions)}
                 selected={selectedDateRange}
-                selectStyle='select-bordered rounded-none flex-grow w-40'
+                selectStyle='select-bordered rounded-none flex-grow min-w-[7.5rem]'
                 onChange={(event: Event) => {
                     event.preventDefault();
                     const select = event.target as HTMLSelectElement;
@@ -192,18 +192,16 @@ export const DateRangeSelectorInner = <CustomLabel extends string>({
             />
             <div className={'flex flex-wrap flex-grow'}>
                 <input
-                    class='input input-bordered rounded-none flex-grow min-w-40'
+                    class='input input-bordered rounded-none flex-grow w-[7.5rem]'
                     type='text'
-                    size={10}
                     placeholder='Date from'
                     ref={fromDatePickerRef}
                     onChange={onChangeDateFrom}
                     onBlur={onChangeDateFrom}
                 />
                 <input
-                    class='input input-bordered rounded-none flex-grow min-w-40'
+                    class='input input-bordered rounded-none flex-grow w-[7.5rem]'
                     type='text'
-                    size={10}
                     placeholder='Date to'
                     ref={toDatePickerRef}
                     onChange={onChangeDateTo}


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #284

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
This reduces the smallest size of the datepicker for the two row design. The limit is now 240px. Below that it will be the stacked design. This change was made possible by reducing the size prop of the input component. The size of the Select component was adjusted, so it matches the min-width of the input fields with size 7.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
This is now the element, with a width of 240px. 

![grafik](https://github.com/GenSpectrum/dashboard-components/assets/122305307/53986e27-8c18-4fde-aee4-83f619fec63d)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
