### PR TITLE
feat(components): set min proportion for initial query to 0.001

### DIFF
--- a/components/src/query/queryMutationsOverTime.spec.ts
+++ b/components/src/query/queryMutationsOverTime.spec.ts
@@ -21,15 +21,30 @@ describe('queryMutationsOverTime', () => {
         lapisRequestMocks.multipleMutations(
             [
                 {
-                    body: { ...lapisFilter, dateFieldFrom: '2023-01-01', dateFieldTo: '2023-01-01', minProportion: 0 },
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-01',
+                        dateFieldTo: '2023-01-01',
+                        minProportion: 0.001,
+                    },
                     response: { data: [getSomeTestMutation(0.1), getSomeOtherTestMutation(0.4)] },
                 },
                 {
-                    body: { ...lapisFilter, dateFieldFrom: '2023-01-02', dateFieldTo: '2023-01-02', minProportion: 0 },
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-02',
+                        dateFieldTo: '2023-01-02',
+                        minProportion: 0.001,
+                    },
                     response: { data: [getSomeTestMutation(0.2)] },
                 },
                 {
-                    body: { ...lapisFilter, dateFieldFrom: '2023-01-03', dateFieldTo: '2023-01-03', minProportion: 0 },
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-03',
+                        dateFieldTo: '2023-01-03',
+                        minProportion: 0.001,
+                    },
                     response: { data: [getSomeTestMutation(0.3)] },
                 },
             ],
@@ -70,15 +85,30 @@ describe('queryMutationsOverTime', () => {
         lapisRequestMocks.multipleMutations(
             [
                 {
-                    body: { ...lapisFilter, dateFieldFrom: '2023-01-01', dateFieldTo: '2023-01-01', minProportion: 0 },
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-01',
+                        dateFieldTo: '2023-01-01',
+                        minProportion: 0.001,
+                    },
                     response: { data: [getSomeTestMutation(0.1), getSomeOtherTestMutation(0.4)] },
                 },
                 {
-                    body: { ...lapisFilter, dateFieldFrom: '2023-01-02', dateFieldTo: '2023-01-02', minProportion: 0 },
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-02',
+                        dateFieldTo: '2023-01-02',
+                        minProportion: 0.001,
+                    },
                     response: { data: [] },
                 },
                 {
-                    body: { ...lapisFilter, dateFieldFrom: '2023-01-03', dateFieldTo: '2023-01-03', minProportion: 0 },
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-03',
+                        dateFieldTo: '2023-01-03',
+                        minProportion: 0.001,
+                    },
                     response: { data: [getSomeTestMutation(0.3)] },
                 },
             ],
@@ -119,15 +149,30 @@ describe('queryMutationsOverTime', () => {
         lapisRequestMocks.multipleMutations(
             [
                 {
-                    body: { ...lapisFilter, dateFieldFrom: '2023-01-01', dateFieldTo: '2023-01-01', minProportion: 0 },
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-01',
+                        dateFieldTo: '2023-01-01',
+                        minProportion: 0.001,
+                    },
                     response: { data: [] },
                 },
                 {
-                    body: { ...lapisFilter, dateFieldFrom: '2023-01-02', dateFieldTo: '2023-01-02', minProportion: 0 },
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-02',
+                        dateFieldTo: '2023-01-02',
+                        minProportion: 0.001,
+                    },
                     response: { data: [] },
                 },
                 {
-                    body: { ...lapisFilter, dateFieldFrom: '2023-01-03', dateFieldTo: '2023-01-03', minProportion: 0 },
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-03',
+                        dateFieldTo: '2023-01-03',
+                        minProportion: 0.001,
+                    },
                     response: { data: [] },
                 },
             ],
@@ -158,11 +203,21 @@ describe('queryMutationsOverTime', () => {
         lapisRequestMocks.multipleMutations(
             [
                 {
-                    body: { ...lapisFilter, dateFieldFrom: '2023-01-02', dateFieldTo: '2023-01-02', minProportion: 0 },
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-02',
+                        dateFieldTo: '2023-01-02',
+                        minProportion: 0.001,
+                    },
                     response: { data: [getSomeTestMutation(0.2)] },
                 },
                 {
-                    body: { ...lapisFilter, dateFieldFrom: '2023-01-03', dateFieldTo: '2023-01-03', minProportion: 0 },
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-03',
+                        dateFieldTo: '2023-01-03',
+                        minProportion: 0.001,
+                    },
                     response: { data: [getSomeTestMutation(0.3)] },
                 },
             ],
@@ -198,11 +253,21 @@ describe('queryMutationsOverTime', () => {
         lapisRequestMocks.multipleMutations(
             [
                 {
-                    body: { ...lapisFilter, dateFieldFrom: '2023-01-01', dateFieldTo: '2023-01-01', minProportion: 0 },
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-01',
+                        dateFieldTo: '2023-01-01',
+                        minProportion: 0.001,
+                    },
                     response: { data: [getSomeTestMutation(0.1)] },
                 },
                 {
-                    body: { ...lapisFilter, dateFieldFrom: '2023-01-02', dateFieldTo: '2023-01-02', minProportion: 0 },
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-02',
+                        dateFieldTo: '2023-01-02',
+                        minProportion: 0.001,
+                    },
                     response: { data: [getSomeTestMutation(0.2)] },
                 },
             ],
@@ -238,7 +303,12 @@ describe('queryMutationsOverTime', () => {
         lapisRequestMocks.multipleMutations(
             [
                 {
-                    body: { ...lapisFilter, dateFieldFrom: '2023-01-02', dateFieldTo: '2023-01-02', minProportion: 0 },
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-02',
+                        dateFieldTo: '2023-01-02',
+                        minProportion: 0.001,
+                    },
                     response: { data: [getSomeTestMutation(0.2)] },
                 },
             ],

--- a/components/src/query/queryMutationsOverTime.ts
+++ b/components/src/query/queryMutationsOverTime.ts
@@ -129,7 +129,7 @@ function fetchAndPrepareDates<LapisDateField extends string>(
 }
 
 function fetchAndPrepareSubstitutionsOrDeletions(filter: LapisFilter, sequenceType: SequenceType) {
-    return new FetchSubstitutionsOrDeletionsOperator(filter, sequenceType, 0);
+    return new FetchSubstitutionsOrDeletionsOperator(filter, sequenceType, 0.001);
 }
 
 export function groupByMutation(data: MutationOverTimeData[]) {

--- a/components/src/web-components/visualization/gs-mutations-over-time.stories.ts
+++ b/components/src/web-components/visualization/gs-mutations-over-time.stories.ts
@@ -114,7 +114,7 @@ export const Default: StoryObj<Required<MutationsOverTimeProps>> = {
                             pangoLineage: 'JN.1*',
                             dateFrom: '2024-01-01',
                             dateTo: '2024-01-31',
-                            minProportion: 0,
+                            minProportion: 0.001,
                         },
                     },
                     response: {
@@ -130,7 +130,7 @@ export const Default: StoryObj<Required<MutationsOverTimeProps>> = {
                             pangoLineage: 'JN.1*',
                             dateFrom: '2024-02-01',
                             dateTo: '2024-02-29',
-                            minProportion: 0,
+                            minProportion: 0.001,
                         },
                     },
                     response: {
@@ -146,7 +146,7 @@ export const Default: StoryObj<Required<MutationsOverTimeProps>> = {
                             pangoLineage: 'JN.1*',
                             dateFrom: '2024-03-01',
                             dateTo: '2024-03-31',
-                            minProportion: 0,
+                            minProportion: 0.001,
                         },
                         response: {
                             status: 200,
@@ -162,7 +162,7 @@ export const Default: StoryObj<Required<MutationsOverTimeProps>> = {
                             pangoLineage: 'JN.1*',
                             dateFrom: '2024-04-01',
                             dateTo: '2024-04-30',
-                            minProportion: 0,
+                            minProportion: 0.001,
                         },
                         response: {
                             status: 200,
@@ -178,7 +178,7 @@ export const Default: StoryObj<Required<MutationsOverTimeProps>> = {
                             pangoLineage: 'JN.1*',
                             dateFrom: '2024-05-01',
                             dateTo: '2024-05-31',
-                            minProportion: 0,
+                            minProportion: 0.001,
                         },
                         response: {
                             status: 200,
@@ -194,7 +194,7 @@ export const Default: StoryObj<Required<MutationsOverTimeProps>> = {
                             pangoLineage: 'JN.1*',
                             dateFrom: '2024-06-01',
                             dateTo: '2024-06-30',
-                            minProportion: 0,
+                            minProportion: 0.001,
                         },
                         response: {
                             status: 200,
@@ -211,7 +211,7 @@ export const Default: StoryObj<Required<MutationsOverTimeProps>> = {
                             pangoLineage: 'JN.1*',
                             dateFrom: '2024-07-01',
                             dateTo: '2024-07-31',
-                            minProportion: 0,
+                            minProportion: 0.001,
                         },
                         response: {
                             status: 200,


### PR DESCRIPTION
### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Sets the min proportion to 0.001 of the initial mutations queries, so we don't overload the browser with data. This is now the same as in covSpectrum.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
