### PR TITLE
353 mutations over time add tooltip

### DIFF
--- a/components/src/preact/components/tooltip.stories.tsx
+++ b/components/src/preact/components/tooltip.stories.tsx
@@ -1,0 +1,54 @@
+import { type Meta, type StoryObj } from '@storybook/preact';
+import { expect, waitFor, within } from '@storybook/test';
+
+import Tooltip, { type TooltipProps } from './tooltip';
+
+const meta: Meta<TooltipProps> = {
+    title: 'Component/Tooltip',
+    component: Tooltip,
+    parameters: { fetchMock: {} },
+};
+
+export default meta;
+
+const tooltipContent = 'This is some content.';
+
+export const TooltipStory: StoryObj<TooltipProps> = {
+    render: (args) => (
+        <div class='flex justify-center px-4 py-16'>
+            <Tooltip {...args}>
+                <div>Hover me</div>
+            </Tooltip>
+        </div>
+    ),
+    args: {
+        content: tooltipContent,
+    },
+};
+
+export const RendersStringContent: StoryObj<TooltipProps> = {
+    ...TooltipStory,
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const tooltipBase = canvas.getByText('Hover me');
+
+        await waitFor(() => expect(tooltipBase).toBeInTheDocument());
+
+        await waitFor(() => expect(canvas.queryByText(tooltipContent, { exact: false })).toBeInTheDocument());
+    },
+};
+
+export const RendersComponentConent: StoryObj<TooltipProps> = {
+    ...TooltipStory,
+    args: {
+        content: <div>{tooltipContent}</div>,
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const tooltipBase = canvas.getByText('Hover me');
+
+        await waitFor(() => expect(tooltipBase).toBeInTheDocument());
+
+        await waitFor(() => expect(canvas.queryByText(tooltipContent, { exact: false })).toBeInTheDocument());
+    },
+};

--- a/components/src/preact/components/tooltip.tsx
+++ b/components/src/preact/components/tooltip.tsx
@@ -1,0 +1,31 @@
+import { flip, offset, shift } from '@floating-ui/dom';
+import { type FunctionComponent } from 'preact';
+import { useRef } from 'preact/hooks';
+import { type JSXInternal } from 'preact/src/jsx';
+
+import { dropdownClass } from './dropdown';
+import { useFloatingUi } from '../shared/floating-ui/hooks';
+
+export type TooltipProps = {
+    content: string | JSXInternal.Element;
+};
+
+const Tooltip: FunctionComponent<TooltipProps> = ({ children, content }) => {
+    const referenceRef = useRef<HTMLDivElement>(null);
+    const floatingRef = useRef<HTMLDivElement>(null);
+
+    useFloatingUi(referenceRef, floatingRef, [offset(5), shift(), flip()]);
+
+    return (
+        <div className='relative'>
+            <div className='peer' ref={referenceRef}>
+                {children}
+            </div>
+            <div ref={floatingRef} className={`${dropdownClass} hidden peer-hover:block`}>
+                {content}
+            </div>
+        </div>
+    );
+};
+
+export default Tooltip;

--- a/components/src/preact/mutationsOverTime/getFilteredMutationsOverTime.spec.ts
+++ b/components/src/preact/mutationsOverTime/getFilteredMutationsOverTime.spec.ts
@@ -12,8 +12,14 @@ describe('getFilteredMutationOverTimeData', () => {
         it('should filter by displayed segments', () => {
             const data = new Map2d<Substitution | Deletion, Temporal, MutationOverTimeMutationValue>();
 
-            data.set(new Substitution('someSegment', 'A', 'T', 123), yearMonthDay('2021-01-01'), 1);
-            data.set(new Substitution('someOtherSegment', 'A', 'T', 123), yearMonthDay('2021-01-01'), 2);
+            data.set(new Substitution('someSegment', 'A', 'T', 123), yearMonthDay('2021-01-01'), {
+                count: 1,
+                proportion: 0.1,
+            });
+            data.set(new Substitution('someOtherSegment', 'A', 'T', 123), yearMonthDay('2021-01-01'), {
+                count: 2,
+                proportion: 0.2,
+            });
 
             filterDisplayedSegments(
                 [
@@ -32,8 +38,14 @@ describe('getFilteredMutationOverTimeData', () => {
         it('should filter by mutation types', () => {
             const data = new Map2d<Substitution | Deletion, Temporal, MutationOverTimeMutationValue>();
 
-            data.set(new Substitution('someSegment', 'A', 'T', 123), yearMonthDay('2021-01-01'), 1);
-            data.set(new Deletion('someOtherSegment', 'A', 123), yearMonthDay('2021-01-01'), 2);
+            data.set(new Substitution('someSegment', 'A', 'T', 123), yearMonthDay('2021-01-01'), {
+                count: 1,
+                proportion: 0.1,
+            });
+            data.set(new Deletion('someOtherSegment', 'A', 123), yearMonthDay('2021-01-01'), {
+                count: 2,
+                proportion: 0.2,
+            });
 
             filterMutationTypes(
                 [
@@ -52,8 +64,8 @@ describe('getFilteredMutationOverTimeData', () => {
         it('should filter by proportion', () => {
             const data = new Map2d<Substitution | Deletion, Temporal, MutationOverTimeMutationValue>();
 
-            const belowFilter = 0.1;
-            const aboveFilter = 0.99;
+            const belowFilter = { count: 1, proportion: 0.1 };
+            const aboveFilter = { count: 99, proportion: 0.99 };
             const proportionInterval = { min: 0.2, max: 0.9 };
 
             const someSubstitution = new Substitution('someSegment', 'A', 'T', 123);
@@ -62,15 +74,15 @@ describe('getFilteredMutationOverTimeData', () => {
 
             filterProportion(data, proportionInterval);
 
-            expect(data.getAsArray(0).length).to.equal(0);
+            expect(data.getAsArray({ count: 0, proportion: 0 }).length).to.equal(0);
         });
 
         it('should not filter if one proportion is within the interval', () => {
             const data = new Map2d<Substitution | Deletion, Temporal, MutationOverTimeMutationValue>();
 
-            const belowFilter = 0.1;
-            const aboveFilter = 0.99;
-            const inFilter = 0.5;
+            const belowFilter = { count: 1, proportion: 0.1 };
+            const aboveFilter = { count: 99, proportion: 0.99 };
+            const inFilter = { count: 5, proportion: 0.5 };
             const proportionInterval = { min: 0.2, max: 0.9 };
 
             const someSubstitution = new Substitution('someSegment', 'A', 'T', 123);
@@ -80,7 +92,7 @@ describe('getFilteredMutationOverTimeData', () => {
 
             filterProportion(data, proportionInterval);
 
-            expect(data.getRow(someSubstitution, 0).length).to.equal(3);
+            expect(data.getRow(someSubstitution, { count: 0, proportion: 0 }).length).to.equal(3);
         });
     });
 });

--- a/components/src/preact/mutationsOverTime/getFilteredMutationsOverTimeData.ts
+++ b/components/src/preact/mutationsOverTime/getFilteredMutationsOverTimeData.ts
@@ -54,8 +54,12 @@ export function filterProportion(
     },
 ) {
     data.getFirstAxisKeys().forEach((mutation) => {
-        const row = data.getRow(mutation, 0);
-        if (!row.some((value) => value >= proportionInterval.min && value <= proportionInterval.max)) {
+        const row = data.getRow(mutation, { count: 0, proportion: 0 });
+        if (
+            !row.some(
+                (value) => value.proportion >= proportionInterval.min && value.proportion <= proportionInterval.max,
+            )
+        ) {
             data.deleteRow(mutation);
         }
     });

--- a/components/src/query/queryMutationsOverTime.spec.ts
+++ b/components/src/query/queryMutationsOverTime.spec.ts
@@ -27,7 +27,7 @@ describe('queryMutationsOverTime', () => {
                         dateFieldTo: '2023-01-01',
                         minProportion: 0.001,
                     },
-                    response: { data: [getSomeTestMutation(0.1), getSomeOtherTestMutation(0.4)] },
+                    response: { data: [getSomeTestMutation(0.1, 1), getSomeOtherTestMutation(0.4, 4)] },
                 },
                 {
                     body: {
@@ -36,7 +36,7 @@ describe('queryMutationsOverTime', () => {
                         dateFieldTo: '2023-01-02',
                         minProportion: 0.001,
                     },
-                    response: { data: [getSomeTestMutation(0.2)] },
+                    response: { data: [getSomeTestMutation(0.2, 2)] },
                 },
                 {
                     body: {
@@ -45,7 +45,7 @@ describe('queryMutationsOverTime', () => {
                         dateFieldTo: '2023-01-03',
                         minProportion: 0.001,
                     },
-                    response: { data: [getSomeTestMutation(0.3)] },
+                    response: { data: [getSomeTestMutation(0.3, 3)] },
                 },
             ],
             'nucleotide',
@@ -53,9 +53,17 @@ describe('queryMutationsOverTime', () => {
 
         const result = await queryMutationsOverTimeData(lapisFilter, 'nucleotide', DUMMY_LAPIS_URL, dateField, 'day');
 
-        expect(result.getAsArray(0)).to.deep.equal([
-            [0.1, 0.2, 0.3],
-            [0.4, 0, 0],
+        expect(result.getAsArray({ count: 0, proportion: 0 })).to.deep.equal([
+            [
+                { proportion: 0.1, count: 1 },
+                { proportion: 0.2, count: 2 },
+                { proportion: 0.3, count: 3 },
+            ],
+            [
+                { proportion: 0.4, count: 4 },
+                { proportion: 0, count: 0 },
+                { proportion: 0, count: 0 },
+            ],
         ]);
 
         const sequences = result.getFirstAxisKeys();
@@ -91,7 +99,7 @@ describe('queryMutationsOverTime', () => {
                         dateFieldTo: '2023-01-01',
                         minProportion: 0.001,
                     },
-                    response: { data: [getSomeTestMutation(0.1), getSomeOtherTestMutation(0.4)] },
+                    response: { data: [getSomeTestMutation(0.1, 1), getSomeOtherTestMutation(0.4, 4)] },
                 },
                 {
                     body: {
@@ -109,7 +117,7 @@ describe('queryMutationsOverTime', () => {
                         dateFieldTo: '2023-01-03',
                         minProportion: 0.001,
                     },
-                    response: { data: [getSomeTestMutation(0.3)] },
+                    response: { data: [getSomeTestMutation(0.3, 3)] },
                 },
             ],
             'nucleotide',
@@ -117,9 +125,17 @@ describe('queryMutationsOverTime', () => {
 
         const result = await queryMutationsOverTimeData(lapisFilter, 'nucleotide', DUMMY_LAPIS_URL, dateField, 'day');
 
-        expect(result.getAsArray(0)).to.deep.equal([
-            [0.1, 0.3, 0],
-            [0.4, 0, 0],
+        expect(result.getAsArray({ count: 0, proportion: 0 })).to.deep.equal([
+            [
+                { proportion: 0.1, count: 1 },
+                { proportion: 0.3, count: 3 },
+                { proportion: 0, count: 0 },
+            ],
+            [
+                { proportion: 0.4, count: 4 },
+                { proportion: 0, count: 0 },
+                { proportion: 0, count: 0 },
+            ],
         ]);
 
         const sequences = result.getFirstAxisKeys();
@@ -181,7 +197,7 @@ describe('queryMutationsOverTime', () => {
 
         const result = await queryMutationsOverTimeData(lapisFilter, 'nucleotide', DUMMY_LAPIS_URL, dateField, 'day');
 
-        expect(result.getAsArray(0)).to.deep.equal([]);
+        expect(result.getAsArray({ count: 0, proportion: 0 })).to.deep.equal([]);
         expect(result.getFirstAxisKeys()).to.deep.equal([]);
         expect(result.getSecondAxisKeys()).to.deep.equal([]);
     });
@@ -209,7 +225,7 @@ describe('queryMutationsOverTime', () => {
                         dateFieldTo: '2023-01-02',
                         minProportion: 0.001,
                     },
-                    response: { data: [getSomeTestMutation(0.2)] },
+                    response: { data: [getSomeTestMutation(0.2, 2)] },
                 },
                 {
                     body: {
@@ -218,7 +234,7 @@ describe('queryMutationsOverTime', () => {
                         dateFieldTo: '2023-01-03',
                         minProportion: 0.001,
                     },
-                    response: { data: [getSomeTestMutation(0.3)] },
+                    response: { data: [getSomeTestMutation(0.3, 3)] },
                 },
             ],
             'nucleotide',
@@ -226,7 +242,12 @@ describe('queryMutationsOverTime', () => {
 
         const result = await queryMutationsOverTimeData(lapisFilter, 'nucleotide', DUMMY_LAPIS_URL, dateField, 'day');
 
-        expect(result.getAsArray(0)).to.deep.equal([[0.2, 0.3]]);
+        expect(result.getAsArray({ count: 0, proportion: 0 })).to.deep.equal([
+            [
+                { proportion: 0.2, count: 2 },
+                { proportion: 0.3, count: 3 },
+            ],
+        ]);
 
         const sequences = result.getFirstAxisKeys();
         expect(sequences[0].code).toBe('sequenceName:A123T');
@@ -259,7 +280,7 @@ describe('queryMutationsOverTime', () => {
                         dateFieldTo: '2023-01-01',
                         minProportion: 0.001,
                     },
-                    response: { data: [getSomeTestMutation(0.1)] },
+                    response: { data: [getSomeTestMutation(0.1, 1)] },
                 },
                 {
                     body: {
@@ -268,7 +289,7 @@ describe('queryMutationsOverTime', () => {
                         dateFieldTo: '2023-01-02',
                         minProportion: 0.001,
                     },
-                    response: { data: [getSomeTestMutation(0.2)] },
+                    response: { data: [getSomeTestMutation(0.2, 2)] },
                 },
             ],
             'nucleotide',
@@ -276,7 +297,12 @@ describe('queryMutationsOverTime', () => {
 
         const result = await queryMutationsOverTimeData(lapisFilter, 'nucleotide', DUMMY_LAPIS_URL, dateField, 'day');
 
-        expect(result.getAsArray(0)).to.deep.equal([[0.1, 0.2]]);
+        expect(result.getAsArray({ count: 0, proportion: 0 })).to.deep.equal([
+            [
+                { proportion: 0.1, count: 1 },
+                { proportion: 0.2, count: 2 },
+            ],
+        ]);
 
         const sequences = result.getFirstAxisKeys();
         expect(sequences[0].code).toBe('sequenceName:A123T');
@@ -309,7 +335,7 @@ describe('queryMutationsOverTime', () => {
                         dateFieldTo: '2023-01-02',
                         minProportion: 0.001,
                     },
-                    response: { data: [getSomeTestMutation(0.2)] },
+                    response: { data: [getSomeTestMutation(0.2, 2)] },
                 },
             ],
             'nucleotide',
@@ -317,7 +343,7 @@ describe('queryMutationsOverTime', () => {
 
         const result = await queryMutationsOverTimeData(lapisFilter, 'nucleotide', DUMMY_LAPIS_URL, dateField, 'day');
 
-        expect(result.getAsArray(0)).to.deep.equal([[0.2]]);
+        expect(result.getAsArray({ count: 0, proportion: 0 })).to.deep.equal([[{ proportion: 0.2, count: 2 }]]);
 
         const sequences = result.getFirstAxisKeys();
         expect(sequences[0].code).toBe('sequenceName:A123T');
@@ -326,11 +352,11 @@ describe('queryMutationsOverTime', () => {
         expect(dates[0].toString()).toBe('2023-01-02');
     });
 
-    function getSomeTestMutation(proportion: number) {
+    function getSomeTestMutation(proportion: number, count: number) {
         return {
             mutation: 'sequenceName:A123T',
             proportion,
-            count: 1,
+            count,
             sequenceName: 'sequenceName',
             mutationFrom: 'A',
             mutationTo: 'T',
@@ -338,11 +364,11 @@ describe('queryMutationsOverTime', () => {
         };
     }
 
-    function getSomeOtherTestMutation(proportion: number) {
+    function getSomeOtherTestMutation(proportion: number, count: number) {
         return {
             mutation: 'otherSequenceName:A123T',
             proportion,
-            count: 1,
+            count,
             sequenceName: 'otherSequenceName',
             mutationFrom: 'G',
             mutationTo: 'C',

--- a/components/src/query/queryMutationsOverTime.ts
+++ b/components/src/query/queryMutationsOverTime.ts
@@ -172,7 +172,7 @@ function addZeroValuesForDatesWithNoMutationData(
         const someMutation = dataArray.getFirstAxisKeys()[0];
         data.forEach((mutationData) => {
             if (mutationData.mutations.length === 0) {
-                dataArray.set(someMutation, mutationData.date, {count: 0, proportion: 0});
+                dataArray.set(someMutation, mutationData.date, { count: 0, proportion: 0 });
             }
         });
     }

--- a/components/src/query/queryMutationsOverTime.ts
+++ b/components/src/query/queryMutationsOverTime.ts
@@ -27,7 +27,7 @@ export type MutationOverTimeData = {
     mutations: SubstitutionOrDeletionEntry[];
 };
 
-export type MutationOverTimeMutationValue = number;
+export type MutationOverTimeMutationValue = { proportion: number; count: number };
 export type MutationOverTimeDataGroupedByMutation = Map2d<
     Substitution | Deletion,
     Temporal,
@@ -145,14 +145,17 @@ function fetchAndPrepareSubstitutionsOrDeletions(filter: LapisFilter, sequenceTy
 }
 
 export function groupByMutation(data: MutationOverTimeData[]) {
-    const dataArray = new Map2d<Substitution | Deletion, Temporal, number>(
+    const dataArray = new Map2d<Substitution | Deletion, Temporal, MutationOverTimeMutationValue>(
         (mutation) => mutation.code,
         (date) => date.toString(),
     );
 
     data.forEach((mutationData) => {
         mutationData.mutations.forEach((mutationEntry) => {
-            dataArray.set(mutationEntry.mutation, mutationData.date, mutationEntry.proportion);
+            dataArray.set(mutationEntry.mutation, mutationData.date, {
+                count: mutationEntry.count,
+                proportion: mutationEntry.proportion,
+            });
         });
     });
 
@@ -162,14 +165,14 @@ export function groupByMutation(data: MutationOverTimeData[]) {
 }
 
 function addZeroValuesForDatesWithNoMutationData(
-    dataArray: Map2d<Substitution | Deletion, Temporal, number>,
+    dataArray: Map2d<Substitution | Deletion, Temporal, MutationOverTimeMutationValue>,
     data: MutationOverTimeData[],
 ) {
     if (dataArray.getFirstAxisKeys().length !== 0) {
         const someMutation = dataArray.getFirstAxisKeys()[0];
         data.forEach((mutationData) => {
             if (mutationData.mutations.length === 0) {
-                dataArray.set(someMutation, mutationData.date, 0);
+                dataArray.set(someMutation, mutationData.date, {count: 0, proportion: 0});
             }
         });
     }

--- a/components/src/utils/temporal.spec.ts
+++ b/components/src/utils/temporal.spec.ts
@@ -60,6 +60,8 @@ describe('YearMonthDay', () => {
         // seems to be a bug in dayjs: https://github.com/iamkun/dayjs/issues/2620
         expect(underTest.week.text).equal('2019-01');
         expect(underTest.text).equal('2020-01-01');
+        expect(underTest.firstDay.text).equal('2020-01-01');
+        expect(underTest.lastDay.text).equal('2020-01-01');
     });
 });
 
@@ -71,6 +73,7 @@ describe('YearWeek', () => {
         expect(underTest.isoWeekNumber).equal(2);
         expect(underTest.firstDay.text).equal('2020-01-06');
         expect(underTest.text).equal('2020-02');
+        expect(underTest.lastDay.text).equal('2020-01-12');
     });
 });
 
@@ -82,6 +85,7 @@ describe('YearMonth', () => {
         expect(underTest.monthNumber).equal(1);
         expect(underTest.text).equal('2020-01');
         expect(underTest.firstDay.text).equal('2020-01-01');
+        expect(underTest.lastDay.text).equal('2020-01-31');
     });
 });
 
@@ -93,5 +97,6 @@ describe('Year', () => {
         expect(underTest.text).equal('2020');
         expect(underTest.firstDay.text).equal('2020-01-01');
         expect(underTest.firstMonth.text).equal('2020-01');
+        expect(underTest.lastDay.text).equal('2020-12-31');
     });
 });

--- a/components/src/utils/temporal.ts
+++ b/components/src/utils/temporal.ts
@@ -72,6 +72,10 @@ export class YearMonthDay {
         return this.text;
     }
 
+    englishName(): string {
+        return this.dayjs.format('dddd, MMMM D, YYYY');
+    }
+
     get firstDay(): YearMonthDay {
         return this;
     }
@@ -121,6 +125,10 @@ export class YearWeek {
 
     toString(): string {
         return this.text;
+    }
+
+    englishName(): string {
+        return `Week ${this.isoWeekNumber}, ${this.isoYearNumber}`
     }
 
     get firstDay(): YearMonthDay {
@@ -179,6 +187,10 @@ export class YearMonth {
         return this.text;
     }
 
+    englishName(): string {
+        return `${monthName(this.monthNumber)} ${this.yearNumber}`;
+    }
+
     get firstDay(): YearMonthDay {
         return this.cache.getYearMonthDay(dayjs(`${this.yearNumber}-${this.monthNumber}-01`).format('YYYY-MM-DD'));
     }
@@ -223,6 +235,10 @@ export class Year {
         return this.text;
     }
 
+    englishName(): string {
+        return this.year.toString();
+    }
+
     get firstMonth(): YearMonth {
         return this.cache.getYearMonth(`${this.year}-01`);
     }
@@ -253,6 +269,10 @@ export class Year {
         const year = parseInt(s, 10);
         return new Year(year, cache);
     }
+}
+
+function monthName(month: number): string {
+    return dayjs().month(month - 1).format('MMMM');
 }
 
 export type Temporal = YearMonthDay | YearWeek | YearMonth | Year;

--- a/components/src/utils/temporal.ts
+++ b/components/src/utils/temporal.ts
@@ -128,7 +128,7 @@ export class YearWeek {
     }
 
     englishName(): string {
-        return `Week ${this.isoWeekNumber}, ${this.isoYearNumber}`
+        return `Week ${this.isoWeekNumber}, ${this.isoYearNumber}`;
     }
 
     get firstDay(): YearMonthDay {
@@ -143,12 +143,14 @@ export class YearWeek {
     }
 
     get lastDay(): YearMonthDay {
-        const lastDay = dayjs()
+        const firstDay = dayjs()
             .year(this.isoYearNumber)
-            .month(12)
-            .date(31)
-            .isoWeek(this.isoWeekNumber)
-            .endOf('isoWeek');
+            .startOf('year')
+            .add((this.isoWeekNumber - 1) * 7, 'day')
+            .startOf('week')
+            .add(1, 'day');
+        const lastDay = firstDay.add(6, 'day');
+
         return this.cache.getYearMonthDay(lastDay.format('YYYY-MM-DD'));
     }
 
@@ -272,7 +274,9 @@ export class Year {
 }
 
 function monthName(month: number): string {
-    return dayjs().month(month - 1).format('MMMM');
+    return dayjs()
+        .month(month - 1)
+        .format('MMMM');
 }
 
 export type Temporal = YearMonthDay | YearWeek | YearMonth | Year;


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #353 

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Adds a tooltip for each cell of the mutation over time component. Also fixes the wrong calculation of the last day of the iso week.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![Bildschirmfoto vom 2024-07-22 10-29-48](https://github.com/user-attachments/assets/dacd6356-56f9-42fb-9ec9-41cf18f7c865)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
