### PR TITLE
Position tooltip for mutation over time using css not floatingUi

### DIFF
--- a/components/src/preact/components/tooltip.stories.tsx
+++ b/components/src/preact/components/tooltip.stories.tsx
@@ -7,6 +7,15 @@ const meta: Meta<TooltipProps> = {
     title: 'Component/Tooltip',
     component: Tooltip,
     parameters: { fetchMock: {} },
+    argTypes: {
+        content: { control: 'text' },
+        position: {
+            control: {
+                type: 'radio',
+            },
+            options: ['top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end', 'left', 'right'],
+        },
+    },
 };
 
 export default meta;
@@ -17,12 +26,13 @@ export const TooltipStory: StoryObj<TooltipProps> = {
     render: (args) => (
         <div class='flex justify-center px-4 py-16'>
             <Tooltip {...args}>
-                <div>Hover me</div>
+                <div className='bg-red-200'>Hover me</div>
             </Tooltip>
         </div>
     ),
     args: {
         content: tooltipContent,
+        position: 'bottom',
     },
 };
 
@@ -38,7 +48,7 @@ export const RendersStringContent: StoryObj<TooltipProps> = {
     },
 };
 
-export const RendersComponentConent: StoryObj<TooltipProps> = {
+export const RendersComponentContent: StoryObj<TooltipProps> = {
     ...TooltipStory,
     args: {
         content: <div>{tooltipContent}</div>,

--- a/components/src/preact/components/tooltip.tsx
+++ b/components/src/preact/components/tooltip.tsx
@@ -1,27 +1,51 @@
-import { flip, offset, shift } from '@floating-ui/dom';
 import { type FunctionComponent } from 'preact';
-import { useRef } from 'preact/hooks';
 import { type JSXInternal } from 'preact/src/jsx';
 
-import { dropdownClass } from './dropdown';
-import { useFloatingUi } from '../shared/floating-ui/hooks';
+export type TooltipPosition =
+    | 'top'
+    | 'top-start'
+    | 'top-end'
+    | 'bottom'
+    | 'bottom-start'
+    | 'bottom-end'
+    | 'left'
+    | 'right';
 
 export type TooltipProps = {
     content: string | JSXInternal.Element;
+    position?: TooltipPosition;
 };
 
-const Tooltip: FunctionComponent<TooltipProps> = ({ children, content }) => {
-    const referenceRef = useRef<HTMLDivElement>(null);
-    const floatingRef = useRef<HTMLDivElement>(null);
+function getPositionCss(position?: TooltipPosition) {
+    switch (position) {
+        case 'top':
+            return 'bottom-full translate-x-[-50%] left-1/2 mb-1';
+        case 'top-start':
+            return 'bottom-full mr-1 mb-1';
+        case 'top-end':
+            return 'bottom-full right-0 ml-1 mb-1';
+        case 'bottom':
+            return 'top-full translate-x-[-50%] left-1/2 mt-1';
+        case 'bottom-start':
+            return 'mr-1 mt-1';
+        case 'bottom-end':
+            return 'right-0 ml-1 mt-1';
+        case 'left':
+            return 'right-full translate-y-[-50%] top-1/2 mr-1';
+        case 'right':
+            return 'left-full translate-y-[-50%] top-1/2 ml-1';
+        case undefined:
+            return '';
+    }
+}
 
-    useFloatingUi(referenceRef, floatingRef, [offset(5), shift(), flip()]);
-
+const Tooltip: FunctionComponent<TooltipProps> = ({ children, content, position = 'bottom' }) => {
     return (
         <div className='relative'>
-            <div className='peer' ref={referenceRef}>
-                {children}
-            </div>
-            <div ref={floatingRef} className={`${dropdownClass} hidden peer-hover:block`}>
+            <div className='peer'>{children}</div>
+            <div
+                className={`absolute z-10 w-max bg-white p-4 border border-gray-200 rounded-md invisible peer-hover:visible ${getPositionCss(position)}`}
+            >
                 {content}
             </div>
         </div>


### PR DESCRIPTION
### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
We switched from using floatingUi to position the tooltip to css only. This uses now less computing power. However, this current also means that the tooltip takes up space at the bottom and at the left of the grid (See screenshot). 

This is a draft to show a possible solution

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
Tooltip in center of grid
![grafik](https://github.com/user-attachments/assets/599ef175-46ef-455f-9cea-ac3f584736d0)

Tooltip at bottom left of grid
![grafik](https://github.com/user-attachments/assets/fca084e3-1069-477c-ac1d-a811fe64a356)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
