### PR TITLE
feat(components): add code example and link to codepen to info box

### DIFF
--- a/components/src/preact/components/info.tsx
+++ b/components/src/preact/components/info.tsx
@@ -16,7 +16,7 @@ const Info: FunctionComponent<InfoProps> = ({ children }) => {
                 ?
             </button>
             <dialog ref={dialogRef} className={'modal modal-bottom sm:modal-middle'}>
-                <div className='modal-box'>
+                <div className='modal-box sm:max-w-5xl'>
                     <form method='dialog'>
                         <button className='btn btn-sm btn-circle btn-ghost absolute right-2 top-2'>✕</button>
                     </form>
@@ -55,4 +55,91 @@ export const InfoLink: FunctionComponent<{ href: string }> = ({ children, href }
     );
 };
 
+export type InfoComponentCodeProps = {
+    componentName: string;
+    params: object;
+    lapisUrl: string;
+};
+
+export const InfoComponentCode: FunctionComponent<InfoComponentCodeProps> = ({ componentName, params, lapisUrl }) => {
+    const componentCode = componentParametersToCode(componentName, params, lapisUrl);
+    const codePenData = {
+        title: 'GenSpectrum dashboard component',
+        html: generateFullExampleCode(componentCode, componentName),
+        layout: 'left',
+        editors: '100',
+    };
+    return (
+        <>
+            <InfoHeadline2>Use this component yourself</InfoHeadline2>
+            <InfoParagraph>
+                This component was created using the following parameters:
+                <div className='p-4 border border-gray-200 rounded-lg overflow-x-auto'>
+                    <pre>
+                        <code>{componentCode}</code>
+                    </pre>
+                </div>
+            </InfoParagraph>
+            <InfoParagraph>
+                You can add this component to your own website using the{' '}
+                <InfoLink href='https://github.com/GenSpectrum/dashboard-components'>
+                    GenSpectrum dashboard components library
+                </InfoLink>{' '}
+                and the code from above.
+            </InfoParagraph>
+            <InfoParagraph>
+                <form action='https://codepen.io/pen/define' method='POST' target='_blank'>
+                    <input
+                        type='hidden'
+                        name='data'
+                        value={JSON.stringify(codePenData).replace(/"/g, '&quot;').replace(/'/g, '&apos;')}
+                    />
+
+                    <button className='text-blue-600 hover:text-blue-800' type='submit'>
+                        Click here to try it out on CodePen.
+                    </button>
+                </form>
+            </InfoParagraph>
+        </>
+    );
+};
+
 export default Info;
+
+function componentParametersToCode(componentName: string, params: object, lapisUrl: string) {
+    const stringifyIfNeeded = (value: unknown) => {
+        return typeof value === 'object' ? JSON.stringify(value) : value;
+    };
+
+    const attributes = indentLines(
+        Object.entries(params)
+            .map(([key, value]) => `${key}='${stringifyIfNeeded(value)}'`)
+            .join('\n'),
+        4,
+    );
+    return `<gs-app lapis="${lapisUrl}">\n  <gs-${componentName}\n${attributes}\n  />\n</gs-app>`;
+}
+
+function generateFullExampleCode(componentCode: string, componentName: string) {
+    const storyBookPath = `/docs/visualization-${componentName}--docs`;
+    return `<html>
+<head>
+  <script type="module" src="https://unpkg.com/@genspectrum/dashboard-components@latest/dist/dashboard-components.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/@genspectrum/dashboard-components@latest/dist/style.css" />
+</head>
+
+<body>
+  <!-- Component documentation: https://genspectrum.github.io/dashboard-components/?path=${storyBookPath} -->
+${indentLines(componentCode, 2)}
+</body>
+</html>
+`;
+}
+
+function indentLines(text: string, numberSpaces: number) {
+    const spaces = ' '.repeat(numberSpaces);
+    return text
+        .split('\n')
+        .map((line) => spaces + line)
+        .join('\n');
+}

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.stories.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.stories.tsx
@@ -51,7 +51,8 @@ const Template = {
                 height={args.height}
                 lapisDateField={args.lapisDateField}
                 pageSize={args.pageSize}
-                yAxisMaxConfig={args.yAxisMaxConfig}
+                yAxisMaxLinear={args.yAxisMaxLinear}
+                yAxisMaxLogarithmic={args.yAxisMaxLogarithmic}
             />
         </LapisUrlContext.Provider>
     ),

--- a/components/src/web-components/visualization/gs-prevalence-over-time.tsx
+++ b/components/src/web-components/visualization/gs-prevalence-over-time.tsx
@@ -175,10 +175,8 @@ export class PrevalenceOverTimeComponent extends PreactLitAdapterWithGridJsStyle
                 height={this.height}
                 lapisDateField={this.lapisDateField}
                 pageSize={this.pageSize}
-                yAxisMaxConfig={{
-                    linear: this.yAxisMaxLinear,
-                    logarithmic: this.yAxisMaxLogarithmic,
-                }}
+                yAxisMaxLinear={this.yAxisMaxLinear}
+                yAxisMaxLogarithmic={this.yAxisMaxLogarithmic}
             />
         );
     }


### PR DESCRIPTION

### Summary

This adds, for the prevalence-over-time component, the exact code of the component to the info box and adds a link to CodePen to try it out.

### Screenshot

Info box:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/2fb82b73-5e32-4233-9b91-6a47ed11ee6c">

CodePen:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/758a56f5-ee2c-476d-bc9b-40c617f786c9">



### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
