### PR TITLE
segment selector make it possible to deselect all values at once

### DIFF
--- a/components/src/preact/components/checkbox-selector.tsx
+++ b/components/src/preact/components/checkbox-selector.tsx
@@ -18,6 +18,25 @@ export const CheckboxSelector = <Item extends CheckboxItem>({
 }: CheckboxSelectorProps<Item>) => {
     return (
         <Dropdown buttonTitle={label} placement={'bottom-start'}>
+            <button
+                className='btn btn-xs btn-ghost'
+                onClick={() => {
+                    const newItems = items.map((item) => ({ ...item, checked: true }));
+                    setItems(newItems);
+                }}
+            >
+                Select all
+            </button>
+            <button
+                className='btn btn-xs btn-ghost'
+                onClick={() => {
+                    const newItems = items.map((item) => ({ ...item, checked: false }));
+                    setItems(newItems);
+                }}
+            >
+                Select none
+            </button>
+            <div className='divider mt-0 mb-0' />
             <ul>
                 {items.map((item, index) => (
                     <li className='flex flex-row items-center' key={item.label}>


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #361

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
This adds two buttons to the checkbox dropdown so users can select all or none of the checkboxes.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
For the screenshot I hovered over the 'Select none' button.
![grafik](https://github.com/user-attachments/assets/aab112a9-0ac4-477c-8c77-32338b7d655c)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
