### PR TITLE
421 mutations over time add delay for proportion filter

### DIFF
--- a/components/src/preact/components/percent-input.stories.tsx
+++ b/components/src/preact/components/percent-input.stories.tsx
@@ -1,0 +1,93 @@
+import { type Meta, type StoryObj } from '@storybook/preact';
+import { expect, fn, userEvent, waitFor, within } from '@storybook/test';
+import { type FunctionComponent } from 'preact';
+import { useState } from 'preact/hooks';
+
+import { PercentInput, type PercentInputProps } from './percent-intput';
+
+const meta: Meta<PercentInputProps> = {
+    title: 'Component/Percent input',
+    component: PercentInput,
+    parameters: { fetchMock: {} },
+};
+
+export default meta;
+
+const WrapperWithState: FunctionComponent<{
+    value: number;
+    setValue: (value: number) => void;
+}> = ({ value: initialValue, setValue: setExternalValue }) => {
+    const [value, setValue] = useState(initialValue);
+
+    return (
+        <PercentInput
+            percentage={value}
+            setPercentage={(value: number) => {
+                setValue(value);
+                setExternalValue(value);
+            }}
+        />
+    );
+};
+
+export const PercentInputStory: StoryObj<{
+    value: number;
+    setValue: (value: number) => void;
+}> = {
+    render: (args) => {
+        return <WrapperWithState {...args} />;
+    },
+    args: {
+        value: 5,
+        setValue: fn(),
+    },
+    play: async ({ canvasElement, step, args }) => {
+        const canvas = within(canvasElement);
+
+        const input = () => canvas.getByLabelText('%');
+
+        await step('Expect initial value to be 5%', async () => {
+            await expect(input()).toHaveValue(5);
+        });
+
+        await step('Add digits', async () => {
+            await userEvent.type(input(), '1');
+            await waitFor(() => expect(args.setValue).toHaveBeenCalledWith(51));
+            await expect(input()).toHaveValue(51);
+        });
+
+        await step('Remove digits', async () => {
+            await userEvent.type(input(), '{backspace}');
+            await waitFor(() => expect(args.setValue).toHaveBeenCalledWith(5));
+            await expect(input()).toHaveValue(5);
+        });
+
+        await step('Entering a dot should not trigger the external update function', async () => {
+            await waitFor(() => expect(args.setValue).toHaveBeenCalledTimes(2));
+            await userEvent.type(input(), '.');
+            await waitFor(() => expect(args.setValue).toHaveBeenCalledTimes(2));
+        });
+
+        await step('Deleting all digits should not trigger the external update function', async () => {
+            await waitFor(() => expect(args.setValue).toHaveBeenCalledTimes(2));
+            await userEvent.clear(input());
+            await waitFor(() => expect(args.setValue).toHaveBeenCalledTimes(2));
+        });
+
+        await step('Entering a number outside the range should not trigger the external update function', async () => {
+            await userEvent.type(input(), '10');
+            await waitFor(() => expect(args.setValue).toHaveBeenCalledTimes(4));
+            await userEvent.type(input(), '1');
+            await waitFor(() => expect(args.setValue).toHaveBeenCalledTimes(4));
+        });
+
+        await step(
+            'Removing digits until a valid number is reached triggers the external update function',
+            async () => {
+                await userEvent.type(input(), '{backspace}');
+                await waitFor(() => expect(args.setValue).toHaveBeenCalledWith(10));
+                await expect(input()).toHaveValue(10);
+            },
+        );
+    },
+};

--- a/components/src/preact/components/percent-intput.tsx
+++ b/components/src/preact/components/percent-intput.tsx
@@ -21,6 +21,10 @@ export const PercentInput: FunctionComponent<PercentInputProps> = ({ percentage,
         const input = event.target as HTMLInputElement;
         const value = Number(input.value);
 
+        if (value === internalPercentage || input.value === '') {
+            return;
+        }
+
         const inRange = percentageInRange(value);
 
         if (inRange) {

--- a/components/src/preact/components/proportion-selector-dropdown.stories.tsx
+++ b/components/src/preact/components/proportion-selector-dropdown.stories.tsx
@@ -1,5 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/preact';
-import { expect, fn, userEvent, within } from '@storybook/test';
+import { expect, fn, userEvent, waitFor, within } from '@storybook/test';
 import { type FunctionComponent } from 'preact';
 import { useState } from 'preact/hooks';
 
@@ -59,7 +59,7 @@ export const ProportionSelectorStory: StoryObj<ProportionSelectorDropdownProps> 
             await userEvent.clear(minInput);
             await userEvent.type(minInput, '10');
 
-            await expect(button).toHaveTextContent('Proportion 10.0% - 100.0%');
+            await waitFor(() => expect(button).toHaveTextContent('Proportion 10.0% - 100.0%'));
             await expect(args.setMinProportion).toHaveBeenCalledWith(0.1);
         });
     },

--- a/components/src/preact/components/proportion-selector.stories.tsx
+++ b/components/src/preact/components/proportion-selector.stories.tsx
@@ -54,27 +54,27 @@ export const ProportionSelectorStory: StoryObj<ProportionSelectorProps> = {
             const minInput = canvas.getAllByLabelText('%')[0];
             await userEvent.clear(minInput);
             await userEvent.type(minInput, '10');
-            await expect(args.setMinProportion).toHaveBeenCalledWith(0.1);
+            await waitFor(() => expect(args.setMinProportion).toHaveBeenCalledWith(0.1));
         });
 
         await step('Change max proportion to 50%', async () => {
             const maxInput = canvas.getAllByLabelText('%')[1];
             await userEvent.clear(maxInput);
             await userEvent.type(maxInput, '50');
-            await expect(args.setMaxProportion).toHaveBeenCalledWith(0.5);
+            await waitFor(() => expect(args.setMaxProportion).toHaveBeenCalledWith(0.5));
         });
 
         await step('Move min proportion silder to 20%', async () => {
             const minSlider = canvas.getAllByRole('slider')[0];
             await fireEvent.input(minSlider, { target: { value: '20' } });
-            await expect(args.setMinProportion).toHaveBeenCalledWith(0.2);
+            await waitFor(() => expect(args.setMinProportion).toHaveBeenCalledWith(0.2));
             await waitFor(() => expect(canvas.getAllByLabelText('%')[0]).toHaveValue(20));
         });
 
         await step('Move max proportion silder to 80%', async () => {
             const maxSlider = canvas.getAllByRole('slider')[1];
             await fireEvent.input(maxSlider, { target: { value: '80' } });
-            await expect(args.setMaxProportion).toHaveBeenCalledWith(0.8);
+            await waitFor(() => expect(args.setMaxProportion).toHaveBeenCalledWith(0.8));
             await waitFor(() => expect(canvas.getAllByLabelText('%')[1]).toHaveValue(80));
         });
     },

--- a/components/src/preact/mutations/mutations-grid.tsx
+++ b/components/src/preact/mutations/mutations-grid.tsx
@@ -1,5 +1,6 @@
 import { type Row } from 'gridjs';
 import { type FunctionComponent } from 'preact';
+import { useMemo } from 'preact/hooks';
 
 import { getMutationsGridData } from './getMutationsGridData';
 import { type SequenceType, type SubstitutionOrDeletionEntry } from '../../types';
@@ -84,7 +85,10 @@ export const MutationsGrid: FunctionComponent<MutationsGridProps> = ({
         return {};
     };
 
-    const tableData = getMutationsGridData(data, sequenceType, proportionInterval).map((row) => Object.values(row));
+    const tableData = useMemo(
+        () => getMutationsGridData(data, sequenceType, proportionInterval).map((row) => Object.values(row)),
+        [data, proportionInterval, sequenceType],
+    );
 
     return <Table data={tableData} columns={getHeaders()} pageSize={pageSize} />;
 };


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #421 

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
This introduces a fix for the proportion selector, so users can input values with a comma/dot. Also this adds a delay to the proportion filter. It will now update the `setMinProportion` and `setMaxProportion` after that delay with the latest value. This way only one filter action will be performed by the `mutations-over-time` component and the `mutations` component.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~ But the storybook test will now wait for the new value to be set. 
