### PR TITLE
feat(components): mutations over time: also show total number of available sequences in tooltip

### DIFF
--- a/components/src/operator/FetchAggregatedOperator.ts
+++ b/components/src/operator/FetchAggregatedOperator.ts
@@ -5,16 +5,11 @@ import { type AggregatedItem } from '../lapisApi/lapisTypes';
 import { type LapisFilter } from '../types';
 
 export class FetchAggregatedOperator<Fields extends Record<string, unknown>>
-    implements
-        Operator<
-            Fields & {
-                count: number;
-            }
-        >
+    implements Operator<Fields & { count: number }>
 {
     constructor(
         private filter: LapisFilter,
-        private fields: string[],
+        private fields: string[] = [],
     ) {}
 
     async evaluate(lapisUrl: string, signal?: AbortSignal): Promise<Dataset<Fields & { count: number }>> {

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_2024_01.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_2024_01.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 25800
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_2024_02.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_2024_02.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 16673
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_2024_03.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_2024_03.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 7931
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_2024_04.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_2024_04.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 2947
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_2024_05.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_2024_05.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 2424
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_2024_06.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_2024_06.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 2890
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_2024_07.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_2024_07.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 0
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_20_01_2024.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_20_01_2024.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 456
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_21_01_2024.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_21_01_2024.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 533
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_22_01_2024.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_22_01_2024.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 1107
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_23_01_2024.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_23_01_2024.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 1020
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_24_01_2024.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_24_01_2024.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 880
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_25_01_2024.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_25_01_2024.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 832
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_26_01_2024.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_26_01_2024.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 635
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_tooManyMutations_total.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_tooManyMutations_total.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 503198
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_week3_2024.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_week3_2024.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 5213
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_week4_2024.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_week4_2024.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 5311
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_week5_2024.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_week5_2024.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 5264
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/__mockData__/aggregated_week6_2024.json
+++ b/components/src/preact/mutationsOverTime/__mockData__/aggregated_week6_2024.json
@@ -1,0 +1,13 @@
+{
+    "data": [
+        {
+            "count": 4954
+        }
+    ],
+    "info": {
+        "dataVersion": "1722452937",
+        "requestId": "aede768e-d9d1-4273-9a74-992986554995",
+        "requestInfo": "sars_cov-2_nextstrain_open on lapis.cov-spectrum.org at 2024-08-02T06:57:09.319474043",
+        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. Please include the request ID and the requestInfo in your report."
+    }
+}

--- a/components/src/preact/mutationsOverTime/getFilteredMutationsOverTime.spec.ts
+++ b/components/src/preact/mutationsOverTime/getFilteredMutationsOverTime.spec.ts
@@ -15,10 +15,12 @@ describe('getFilteredMutationOverTimeData', () => {
             data.set(new Substitution('someSegment', 'A', 'T', 123), yearMonthDay('2021-01-01'), {
                 count: 1,
                 proportion: 0.1,
+                totalCount: 10,
             });
             data.set(new Substitution('someOtherSegment', 'A', 'T', 123), yearMonthDay('2021-01-01'), {
                 count: 2,
                 proportion: 0.2,
+                totalCount: 10,
             });
 
             filterDisplayedSegments(
@@ -41,10 +43,12 @@ describe('getFilteredMutationOverTimeData', () => {
             data.set(new Substitution('someSegment', 'A', 'T', 123), yearMonthDay('2021-01-01'), {
                 count: 1,
                 proportion: 0.1,
+                totalCount: 10,
             });
             data.set(new Deletion('someOtherSegment', 'A', 123), yearMonthDay('2021-01-01'), {
                 count: 2,
                 proportion: 0.2,
+                totalCount: 10,
             });
 
             filterMutationTypes(
@@ -76,7 +80,13 @@ describe('getFilteredMutationOverTimeData', () => {
 
             filterProportion(data, getOverallMutationData(belowFilter), proportionInterval);
 
-            expect(data.getAsArray({ count: 0, proportion: 0 })).to.toHaveLength(0);
+            expect(
+                data.getAsArray({
+                    count: 0,
+                    proportion: 0,
+                    totalCount: 10,
+                }),
+            ).to.toHaveLength(0);
         });
 
         it('should remove mutations where overall proportion is above filter', () => {
@@ -84,7 +94,13 @@ describe('getFilteredMutationOverTimeData', () => {
 
             filterProportion(data, getOverallMutationData(aboveFilter), proportionInterval);
 
-            expect(data.getAsArray({ count: 0, proportion: 0 })).to.toHaveLength(0);
+            expect(
+                data.getAsArray({
+                    count: 0,
+                    proportion: 0,
+                    totalCount: 10,
+                }),
+            ).to.toHaveLength(0);
         });
 
         it('should remove mutations where overall proportion is missing', () => {
@@ -92,7 +108,13 @@ describe('getFilteredMutationOverTimeData', () => {
 
             filterProportion(data, getOverallMutationData(aboveFilter, someOtherMutation), proportionInterval);
 
-            expect(data.getAsArray({ count: 0, proportion: 0 })).to.toHaveLength(0);
+            expect(
+                data.getAsArray({
+                    count: 0,
+                    proportion: 0,
+                    totalCount: 10,
+                }),
+            ).to.toHaveLength(0);
         });
 
         it('should not remove mutation where overall proportion is at lower border of filter', () => {
@@ -100,7 +122,13 @@ describe('getFilteredMutationOverTimeData', () => {
 
             filterProportion(data, getOverallMutationData(inFilter), proportionInterval);
 
-            expect(data.getRow(someSubstitution, { count: 0, proportion: 0 })).to.toHaveLength(2);
+            expect(
+                data.getRow(someSubstitution, {
+                    count: 0,
+                    proportion: 0,
+                    totalCount: 10,
+                }),
+            ).to.toHaveLength(2);
         });
 
         it('should not remove mutation where overall proportion is within filter', () => {
@@ -108,7 +136,13 @@ describe('getFilteredMutationOverTimeData', () => {
 
             filterProportion(data, getOverallMutationData(inFilter), proportionInterval);
 
-            expect(data.getRow(someSubstitution, { count: 0, proportion: 0 })).to.toHaveLength(2);
+            expect(
+                data.getRow(someSubstitution, {
+                    count: 0,
+                    proportion: 0,
+                    totalCount: 10,
+                }),
+            ).to.toHaveLength(2);
         });
 
         it('should not remove mutation where overall proportion is at upper border of filter', () => {
@@ -116,13 +150,27 @@ describe('getFilteredMutationOverTimeData', () => {
 
             filterProportion(data, getOverallMutationData(inFilter), proportionInterval);
 
-            expect(data.getRow(someSubstitution, { count: 0, proportion: 0 })).to.toHaveLength(2);
+            expect(
+                data.getRow(someSubstitution, {
+                    count: 0,
+                    proportion: 0,
+                    totalCount: 10,
+                }),
+            ).to.toHaveLength(2);
         });
 
         function getMutationOverTimeData() {
             const data = new Map2dBase<Substitution | Deletion, Temporal, MutationOverTimeMutationValue>();
-            data.set(someSubstitution, yearMonthDay('2021-01-01'), { count: 1, proportion: 0.1 });
-            data.set(someSubstitution, yearMonthDay('2021-02-02'), { count: 99, proportion: 0.99 });
+            data.set(someSubstitution, yearMonthDay('2021-01-01'), {
+                count: 1,
+                proportion: 0.1,
+                totalCount: 10,
+            });
+            data.set(someSubstitution, yearMonthDay('2021-02-02'), {
+                count: 99,
+                proportion: 0.99,
+                totalCount: 10,
+            });
             return data;
         }
 

--- a/components/src/preact/mutationsOverTime/mutations-over-time-grid.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time-grid.tsx
@@ -56,7 +56,7 @@ const MutationsOverTimeGrid: FunctionComponent<MutationsOverTimeGridProps> = ({ 
                                 <MutationCell mutation={mutation} />
                             </div>
                             {dates.map((date, columnIndex) => {
-                                const value = data.get(mutation, date) ?? { proportion: 0, count: 0 };
+                                const value = data.get(mutation, date) ?? { proportion: 0, count: 0, totalCount: 0 };
                                 const tooltipPosition = getTooltipPosition(
                                     rowIndex,
                                     shownMutations.length,
@@ -136,7 +136,9 @@ const ProportionCell: FunctionComponent<{
             <p>({timeIntervalDisplay(date)})</p>
             <p>{mutation.code}</p>
             <p>Proportion: {formatProportion(value.proportion)}</p>
-            <p>Count: {value.count}</p>
+            <p>
+                Count: {value.count} / {value.totalCount} total
+            </p>
         </div>
     );
 

--- a/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
@@ -1,8 +1,16 @@
 import { type Meta, type StoryObj } from '@storybook/preact';
 import { expect, waitFor } from '@storybook/test';
 
+import aggregated_01 from './__mockData__/aggregated_2024_01.json';
+import aggregated_02 from './__mockData__/aggregated_2024_02.json';
+import aggregated_03 from './__mockData__/aggregated_2024_03.json';
+import aggregated_04 from './__mockData__/aggregated_2024_04.json';
+import aggregated_05 from './__mockData__/aggregated_2024_05.json';
+import aggregated_06 from './__mockData__/aggregated_2024_06.json';
+import aggregated_07 from './__mockData__/aggregated_2024_07.json';
 import aggregated_date from './__mockData__/aggregated_date.json';
 import aggregated_tooManyMutations from './__mockData__/aggregated_tooManyMutations.json';
+import aggregated_tooManyMutations_total from './__mockData__/aggregated_tooManyMutations_total.json';
 import nucleotideMutation_01 from './__mockData__/nucleotideMutations_2024_01.json';
 import nucleotideMutation_02 from './__mockData__/nucleotideMutations_2024_02.json';
 import nucleotideMutation_03 from './__mockData__/nucleotideMutations_2024_03.json';
@@ -89,6 +97,118 @@ export const Default: StoryObj<MutationsOverTimeProps> = {
                     response: {
                         status: 200,
                         body: aggregated_date,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_01',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2024-01-01',
+                            dateTo: '2024-01-31',
+                            fields: [],
+                            pangoLineage: 'JN.1*',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_01,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_02',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2024-02-01',
+                            dateTo: '2024-02-29',
+                            fields: [],
+                            pangoLineage: 'JN.1*',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_02,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_03',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2024-03-01',
+                            dateTo: '2024-03-31',
+                            fields: [],
+                            pangoLineage: 'JN.1*',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_03,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_04',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2024-04-01',
+                            dateTo: '2024-04-30',
+                            fields: [],
+                            pangoLineage: 'JN.1*',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_04,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_05',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2024-05-01',
+                            dateTo: '2024-05-31',
+                            fields: [],
+                            pangoLineage: 'JN.1*',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_05,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_06',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2024-06-01',
+                            dateTo: '2024-06-30',
+                            fields: [],
+                            pangoLineage: 'JN.1*',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_06,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_07',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2024-07-01',
+                            dateTo: '2024-07-31',
+                            fields: [],
+                            pangoLineage: 'JN.1*',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_07,
                     },
                 },
                 {
@@ -251,6 +371,21 @@ export const ShowsMessageWhenTooManyMutations: StoryObj<MutationsOverTimeProps> 
                     response: {
                         status: 200,
                         body: aggregated_tooManyMutations,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_total',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2023-01-01',
+                            dateTo: '2023-12-31',
+                            fields: [],
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_tooManyMutations_total,
                     },
                 },
                 {

--- a/components/src/query/queryMutationsOverTime.spec.ts
+++ b/components/src/query/queryMutationsOverTime.spec.ts
@@ -8,15 +8,44 @@ describe('queryMutationsOverTime', () => {
         const lapisFilter = { field1: 'value1', field2: 'value2' };
         const dateField = 'dateField';
 
-        lapisRequestMocks.aggregated(
-            { ...lapisFilter, fields: [dateField] },
+        lapisRequestMocks.multipleAggregated([
             {
-                data: [
-                    { count: 1, [dateField]: '2023-01-01' },
-                    { count: 2, [dateField]: '2023-01-03' },
-                ],
+                body: { ...lapisFilter, fields: [dateField] },
+                response: {
+                    data: [
+                        { count: 1, [dateField]: '2023-01-01' },
+                        { count: 2, [dateField]: '2023-01-03' },
+                    ],
+                },
             },
-        );
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-01',
+                    dateFieldTo: '2023-01-01',
+                    fields: [],
+                },
+                response: { data: [{ count: 11 }] },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-02',
+                    dateFieldTo: '2023-01-02',
+                    fields: [],
+                },
+                response: { data: [{ count: 12 }] },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-03',
+                    dateFieldTo: '2023-01-03',
+                    fields: [],
+                },
+                response: { data: [{ count: 13 }] },
+            },
+        ]);
 
         lapisRequestMocks.multipleMutations(
             [
@@ -53,16 +82,16 @@ describe('queryMutationsOverTime', () => {
 
         const result = await queryMutationsOverTimeData(lapisFilter, 'nucleotide', DUMMY_LAPIS_URL, dateField, 'day');
 
-        expect(result.getAsArray({ count: 0, proportion: 0 })).to.deep.equal([
+        expect(result.getAsArray({ count: 0, proportion: 0, totalCount: 0 })).to.deep.equal([
             [
-                { proportion: 0.1, count: 1 },
-                { proportion: 0.2, count: 2 },
-                { proportion: 0.3, count: 3 },
+                { proportion: 0.1, count: 1, totalCount: 11 },
+                { proportion: 0.2, count: 2, totalCount: 12 },
+                { proportion: 0.3, count: 3, totalCount: 13 },
             ],
             [
-                { proportion: 0.4, count: 4 },
-                { proportion: 0, count: 0 },
-                { proportion: 0, count: 0 },
+                { proportion: 0.4, count: 4, totalCount: 11 },
+                { proportion: 0, count: 0, totalCount: 0 },
+                { proportion: 0, count: 0, totalCount: 0 },
             ],
         ]);
 
@@ -80,15 +109,44 @@ describe('queryMutationsOverTime', () => {
         const lapisFilter = { field1: 'value1', field2: 'value2' };
         const dateField = 'dateField';
 
-        lapisRequestMocks.aggregated(
-            { ...lapisFilter, fields: [dateField] },
+        lapisRequestMocks.multipleAggregated([
             {
-                data: [
-                    { count: 1, [dateField]: '2023-01-01' },
-                    { count: 2, [dateField]: '2023-01-03' },
-                ],
+                body: { ...lapisFilter, fields: [dateField] },
+                response: {
+                    data: [
+                        { count: 1, [dateField]: '2023-01-01' },
+                        { count: 2, [dateField]: '2023-01-03' },
+                    ],
+                },
             },
-        );
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-01',
+                    dateFieldTo: '2023-01-01',
+                    fields: [],
+                },
+                response: { data: [{ count: 11 }] },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-02',
+                    dateFieldTo: '2023-01-02',
+                    fields: [],
+                },
+                response: { data: [{ count: 12 }] },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-03',
+                    dateFieldTo: '2023-01-03',
+                    fields: [],
+                },
+                response: { data: [{ count: 13 }] },
+            },
+        ]);
 
         lapisRequestMocks.multipleMutations(
             [
@@ -125,16 +183,16 @@ describe('queryMutationsOverTime', () => {
 
         const result = await queryMutationsOverTimeData(lapisFilter, 'nucleotide', DUMMY_LAPIS_URL, dateField, 'day');
 
-        expect(result.getAsArray({ count: 0, proportion: 0 })).to.deep.equal([
+        expect(result.getAsArray({ count: 0, proportion: 0, totalCount: 0 })).to.deep.equal([
             [
-                { proportion: 0.1, count: 1 },
-                { proportion: 0.3, count: 3 },
-                { proportion: 0, count: 0 },
+                { proportion: 0.1, count: 1, totalCount: 11 },
+                { proportion: 0.3, count: 3, totalCount: 13 },
+                { proportion: 0, count: 0, totalCount: 0 },
             ],
             [
-                { proportion: 0.4, count: 4 },
-                { proportion: 0, count: 0 },
-                { proportion: 0, count: 0 },
+                { proportion: 0.4, count: 4, totalCount: 11 },
+                { proportion: 0, count: 0, totalCount: 0 },
+                { proportion: 0, count: 0, totalCount: 0 },
             ],
         ]);
 
@@ -152,15 +210,44 @@ describe('queryMutationsOverTime', () => {
         const lapisFilter = { field1: 'value1', field2: 'value2' };
         const dateField = 'dateField';
 
-        lapisRequestMocks.aggregated(
-            { ...lapisFilter, fields: [dateField] },
+        lapisRequestMocks.multipleAggregated([
             {
-                data: [
-                    { count: 1, [dateField]: '2023-01-01' },
-                    { count: 2, [dateField]: '2023-01-03' },
-                ],
+                body: { ...lapisFilter, fields: [dateField] },
+                response: {
+                    data: [
+                        { count: 1, [dateField]: '2023-01-01' },
+                        { count: 2, [dateField]: '2023-01-03' },
+                    ],
+                },
             },
-        );
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-01',
+                    dateFieldTo: '2023-01-01',
+                    fields: [],
+                },
+                response: { data: [{ count: 11 }] },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-02',
+                    dateFieldTo: '2023-01-02',
+                    fields: [],
+                },
+                response: { data: [{ count: 12 }] },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-03',
+                    dateFieldTo: '2023-01-03',
+                    fields: [],
+                },
+                response: { data: [{ count: 13 }] },
+            },
+        ]);
 
         lapisRequestMocks.multipleMutations(
             [
@@ -197,7 +284,7 @@ describe('queryMutationsOverTime', () => {
 
         const result = await queryMutationsOverTimeData(lapisFilter, 'nucleotide', DUMMY_LAPIS_URL, dateField, 'day');
 
-        expect(result.getAsArray({ count: 0, proportion: 0 })).to.deep.equal([]);
+        expect(result.getAsArray({ count: 0, proportion: 0, totalCount: 0 })).to.deep.equal([]);
         expect(result.getFirstAxisKeys()).to.deep.equal([]);
         expect(result.getSecondAxisKeys()).to.deep.equal([]);
     });
@@ -206,15 +293,35 @@ describe('queryMutationsOverTime', () => {
         const dateField = 'dateField';
         const lapisFilter = { field1: 'value1', field2: 'value2', [`${dateField}From`]: '2023-01-02' };
 
-        lapisRequestMocks.aggregated(
-            { ...lapisFilter, fields: [dateField] },
+        lapisRequestMocks.multipleAggregated([
             {
-                data: [
-                    { count: 1, [dateField]: '2023-01-01' },
-                    { count: 2, [dateField]: '2023-01-03' },
-                ],
+                body: { ...lapisFilter, fields: [dateField] },
+                response: {
+                    data: [
+                        { count: 1, [dateField]: '2023-01-01' },
+                        { count: 2, [dateField]: '2023-01-03' },
+                    ],
+                },
             },
-        );
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-02',
+                    dateFieldTo: '2023-01-02',
+                    fields: [],
+                },
+                response: { data: [{ count: 11 }] },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-03',
+                    dateFieldTo: '2023-01-03',
+                    fields: [],
+                },
+                response: { data: [{ count: 12 }] },
+            },
+        ]);
 
         lapisRequestMocks.multipleMutations(
             [
@@ -242,10 +349,10 @@ describe('queryMutationsOverTime', () => {
 
         const result = await queryMutationsOverTimeData(lapisFilter, 'nucleotide', DUMMY_LAPIS_URL, dateField, 'day');
 
-        expect(result.getAsArray({ count: 0, proportion: 0 })).to.deep.equal([
+        expect(result.getAsArray({ count: 0, proportion: 0, totalCount: 0 })).to.deep.equal([
             [
-                { proportion: 0.2, count: 2 },
-                { proportion: 0.3, count: 3 },
+                { proportion: 0.2, count: 2, totalCount: 11 },
+                { proportion: 0.3, count: 3, totalCount: 12 },
             ],
         ]);
 
@@ -261,15 +368,35 @@ describe('queryMutationsOverTime', () => {
         const dateField = 'dateField';
         const lapisFilter = { field1: 'value1', field2: 'value2', [`${dateField}To`]: '2023-01-02' };
 
-        lapisRequestMocks.aggregated(
-            { ...lapisFilter, fields: [dateField] },
+        lapisRequestMocks.multipleAggregated([
             {
-                data: [
-                    { count: 1, [dateField]: '2023-01-01' },
-                    { count: 2, [dateField]: '2023-01-03' },
-                ],
+                body: { ...lapisFilter, fields: [dateField] },
+                response: {
+                    data: [
+                        { count: 1, [dateField]: '2023-01-01' },
+                        { count: 2, [dateField]: '2023-01-03' },
+                    ],
+                },
             },
-        );
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-01',
+                    dateFieldTo: '2023-01-01',
+                    fields: [],
+                },
+                response: { data: [{ count: 11 }] },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-02',
+                    dateFieldTo: '2023-01-02',
+                    fields: [],
+                },
+                response: { data: [{ count: 12 }] },
+            },
+        ]);
 
         lapisRequestMocks.multipleMutations(
             [
@@ -297,10 +424,10 @@ describe('queryMutationsOverTime', () => {
 
         const result = await queryMutationsOverTimeData(lapisFilter, 'nucleotide', DUMMY_LAPIS_URL, dateField, 'day');
 
-        expect(result.getAsArray({ count: 0, proportion: 0 })).to.deep.equal([
+        expect(result.getAsArray({ count: 0, proportion: 0, totalCount: 0 })).to.deep.equal([
             [
-                { proportion: 0.1, count: 1 },
-                { proportion: 0.2, count: 2 },
+                { proportion: 0.1, count: 1, totalCount: 11 },
+                { proportion: 0.2, count: 2, totalCount: 12 },
             ],
         ]);
 
@@ -316,15 +443,26 @@ describe('queryMutationsOverTime', () => {
         const dateField = 'dateField';
         const lapisFilter = { field1: 'value1', field2: 'value2', [dateField]: '2023-01-02' };
 
-        lapisRequestMocks.aggregated(
-            { ...lapisFilter, fields: [dateField] },
+        lapisRequestMocks.multipleAggregated([
             {
-                data: [
-                    { count: 1, [dateField]: '2023-01-01' },
-                    { count: 2, [dateField]: '2023-01-03' },
-                ],
+                body: { ...lapisFilter, fields: [dateField] },
+                response: {
+                    data: [
+                        { count: 1, [dateField]: '2023-01-01' },
+                        { count: 2, [dateField]: '2023-01-03' },
+                    ],
+                },
             },
-        );
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-02',
+                    dateFieldTo: '2023-01-02',
+                    fields: [],
+                },
+                response: { data: [{ count: 11 }] },
+            },
+        ]);
 
         lapisRequestMocks.multipleMutations(
             [
@@ -343,7 +481,15 @@ describe('queryMutationsOverTime', () => {
 
         const result = await queryMutationsOverTimeData(lapisFilter, 'nucleotide', DUMMY_LAPIS_URL, dateField, 'day');
 
-        expect(result.getAsArray({ count: 0, proportion: 0 })).to.deep.equal([[{ proportion: 0.2, count: 2 }]]);
+        expect(result.getAsArray({ count: 0, proportion: 0, totalCount: 0 })).to.deep.equal([
+            [
+                {
+                    proportion: 0.2,
+                    count: 2,
+                    totalCount: 11,
+                },
+            ],
+        ]);
 
         const sequences = result.getFirstAxisKeys();
         expect(sequences[0].code).toBe('sequenceName:A123T');

--- a/components/src/web-components/visualization/gs-mutations-over-time.stories.ts
+++ b/components/src/web-components/visualization/gs-mutations-over-time.stories.ts
@@ -10,9 +10,27 @@ import {
     LAPIS_URL,
     NUCLEOTIDE_MUTATIONS_ENDPOINT,
 } from '../../constants';
+import aggregated_01 from '../../preact/mutationsOverTime/__mockData__/aggregated_2024_01.json';
+import aggregated_02 from '../../preact/mutationsOverTime/__mockData__/aggregated_2024_02.json';
+import aggregated_03 from '../../preact/mutationsOverTime/__mockData__/aggregated_2024_03.json';
+import aggregated_04 from '../../preact/mutationsOverTime/__mockData__/aggregated_2024_04.json';
+import aggregated_05 from '../../preact/mutationsOverTime/__mockData__/aggregated_2024_05.json';
+import aggregated_06 from '../../preact/mutationsOverTime/__mockData__/aggregated_2024_06.json';
+import aggregated_07 from '../../preact/mutationsOverTime/__mockData__/aggregated_2024_07.json';
+import aggregated_20_01_2024 from '../../preact/mutationsOverTime/__mockData__/aggregated_20_01_2024.json';
+import aggregated_21_01_2024 from '../../preact/mutationsOverTime/__mockData__/aggregated_21_01_2024.json';
+import aggregated_22_01_2024 from '../../preact/mutationsOverTime/__mockData__/aggregated_22_01_2024.json';
+import aggregated_23_01_2024 from '../../preact/mutationsOverTime/__mockData__/aggregated_23_01_2024.json';
+import aggregated_24_01_2024 from '../../preact/mutationsOverTime/__mockData__/aggregated_24_01_2024.json';
+import aggregated_25_01_2024 from '../../preact/mutationsOverTime/__mockData__/aggregated_25_01_2024.json';
+import aggregated_26_01_2024 from '../../preact/mutationsOverTime/__mockData__/aggregated_26_01_2024.json';
 import aggregated_byDay from '../../preact/mutationsOverTime/__mockData__/aggregated_byDay.json';
 import aggregated_byWeek from '../../preact/mutationsOverTime/__mockData__/aggregated_byWeek.json';
 import aggregated_date from '../../preact/mutationsOverTime/__mockData__/aggregated_date.json';
+import aggregated_week3 from '../../preact/mutationsOverTime/__mockData__/aggregated_week3_2024.json';
+import aggregated_week4 from '../../preact/mutationsOverTime/__mockData__/aggregated_week4_2024.json';
+import aggregated_week5 from '../../preact/mutationsOverTime/__mockData__/aggregated_week5_2024.json';
+import aggregated_week6 from '../../preact/mutationsOverTime/__mockData__/aggregated_week6_2024.json';
 import aminoAcidMutations_20_01_2024 from '../../preact/mutationsOverTime/__mockData__/aminoAcidMutations_20_01_2024.json';
 import aminoAcidMutations_21_01_2024 from '../../preact/mutationsOverTime/__mockData__/aminoAcidMutations_21_01_2024.json';
 import aminoAcidMutations_22_01_2024 from '../../preact/mutationsOverTime/__mockData__/aminoAcidMutations_22_01_2024.json';
@@ -124,6 +142,118 @@ export const ByMonth: StoryObj<Required<MutationsOverTimeProps>> = {
                     response: {
                         status: 200,
                         body: aggregated_date,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_01',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2024-01-01',
+                            dateTo: '2024-01-31',
+                            fields: [],
+                            pangoLineage: 'JN.1*',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_01,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_02',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2024-02-01',
+                            dateTo: '2024-02-29',
+                            fields: [],
+                            pangoLineage: 'JN.1*',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_02,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_03',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2024-03-01',
+                            dateTo: '2024-03-31',
+                            fields: [],
+                            pangoLineage: 'JN.1*',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_03,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_04',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2024-04-01',
+                            dateTo: '2024-04-30',
+                            fields: [],
+                            pangoLineage: 'JN.1*',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_04,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_05',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2024-05-01',
+                            dateTo: '2024-05-31',
+                            fields: [],
+                            pangoLineage: 'JN.1*',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_05,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_06',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2024-06-01',
+                            dateTo: '2024-06-30',
+                            fields: [],
+                            pangoLineage: 'JN.1*',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_06,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_07',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2024-07-01',
+                            dateTo: '2024-07-31',
+                            fields: [],
+                            pangoLineage: 'JN.1*',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_07,
                     },
                 },
                 {
@@ -288,6 +418,70 @@ export const ByWeek: StoryObj<Required<MutationsOverTimeProps>> = {
                 },
                 {
                     matcher: {
+                        name: 'aggregated_week3',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2024-01-15',
+                            dateTo: '2024-01-21',
+                            fields: [],
+                            pangoLineage: 'JN.1*',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_week3,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_week4',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2024-01-22',
+                            dateTo: '2024-01-28',
+                            fields: [],
+                            pangoLineage: 'JN.1*',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_week4,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_week5',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2024-01-29',
+                            dateTo: '2024-02-04',
+                            fields: [],
+                            pangoLineage: 'JN.1*',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_week5,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_week6',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            dateFrom: '2024-02-05',
+                            dateTo: '2024-02-11',
+                            fields: [],
+                            pangoLineage: 'JN.1*',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_week6,
+                    },
+                },
+                {
+                    matcher: {
                         name: 'nucleotideMutation_overall',
                         url: NUCLEOTIDE_MUTATIONS_ENDPOINT,
                         body: {
@@ -391,6 +585,83 @@ export const AminoAcidMutationsByDay: StoryObj<Required<MutationsOverTimeProps>>
                     response: {
                         status: 200,
                         body: aggregated_byDay,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_20_01_2024',
+                        url: AGGREGATED_ENDPOINT,
+                        body: { pangoLineage: 'JN.1*', dateFrom: '2024-01-20', dateTo: '2024-01-20', fields: [] },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_20_01_2024,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_21_01_2024',
+                        url: AGGREGATED_ENDPOINT,
+                        body: { pangoLineage: 'JN.1*', dateFrom: '2024-01-21', dateTo: '2024-01-21', fields: [] },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_21_01_2024,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_22_01_2024',
+                        url: AGGREGATED_ENDPOINT,
+                        body: { pangoLineage: 'JN.1*', dateFrom: '2024-01-22', dateTo: '2024-01-22', fields: [] },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_22_01_2024,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_23_01_2024',
+                        url: AGGREGATED_ENDPOINT,
+                        body: { pangoLineage: 'JN.1*', dateFrom: '2024-01-23', dateTo: '2024-01-23', fields: [] },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_23_01_2024,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_24_01_2024',
+                        url: AGGREGATED_ENDPOINT,
+                        body: { pangoLineage: 'JN.1*', dateFrom: '2024-01-24', dateTo: '2024-01-24', fields: [] },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_24_01_2024,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_25_01_2024',
+                        url: AGGREGATED_ENDPOINT,
+                        body: { pangoLineage: 'JN.1*', dateFrom: '2024-01-25', dateTo: '2024-01-25', fields: [] },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_25_01_2024,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregated_26_01_2024',
+                        url: AGGREGATED_ENDPOINT,
+                        body: { pangoLineage: 'JN.1*', dateFrom: '2024-01-26', dateTo: '2024-01-26', fields: [] },
+                    },
+                    response: {
+                        status: 200,
+                        body: aggregated_26_01_2024,
                     },
                 },
                 {


### PR DESCRIPTION
closes #386

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
* query aggregated without `fields` for every date range to get the total count
* display the total count in the tooltip

I wasn't sure how to display the tooltip exactly. I put it in the same line with the count, because an extra line uses even more space for the tooltip, which makes positioning harder.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![grafik](https://github.com/user-attachments/assets/d25530aa-738e-47cd-8291-4e902cce9271)

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
