### PR TITLE
feat(components): gs-date-range-selector: replace `customSelectOptions` by `dateRangeOptions`

### DIFF
--- a/components/.gitignore
+++ b/components/.gitignore
@@ -1,5 +1,6 @@
 /lib/
 /dist/
+/standalone-bundle/
 /test/
 /build/
 custom-elements.json

--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -21,7 +21,6 @@
                 "flatpickr": "^4.6.13",
                 "gridjs": "^6.2.0",
                 "lit": "^3.1.3",
-                "object-hash": "^3.0.0",
                 "preact": "^10.20.1",
                 "zod": "^3.23.0"
             },
@@ -44,7 +43,6 @@
                 "@storybook/web-components": "^8.0.9",
                 "@storybook/web-components-vite": "^8.0.9",
                 "@types/node": "^22.0.0",
-                "@types/object-hash": "^3.0.6",
                 "@typescript-eslint/eslint-plugin": "^8.2.0",
                 "@typescript-eslint/parser": "^8.2.0",
                 "autoprefixer": "^10.4.19",
@@ -3472,12 +3470,6 @@
             "dependencies": {
                 "undici-types": "~6.19.8"
             }
-        },
-        "node_modules/@types/object-hash": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-3.0.6.tgz",
-            "integrity": "sha512-fOBV8C1FIu2ELinoILQ+ApxcUKz4ngq+IWUYrxSGjXzzjUALijilampwkMgEtJ+h2njAW3pi853QpzNVCHB73w==",
-            "dev": true
         },
         "node_modules/@types/parse-json": {
             "version": "4.0.2",
@@ -11920,6 +11912,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
             "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+            "dev": true,
             "engines": {
                 "node": ">= 6"
             }

--- a/components/package.json
+++ b/components/package.json
@@ -80,7 +80,6 @@
         "flatpickr": "^4.6.13",
         "gridjs": "^6.2.0",
         "lit": "^3.1.3",
-        "object-hash": "^3.0.0",
         "preact": "^10.20.1",
         "zod": "^3.23.0"
     },
@@ -103,7 +102,6 @@
         "@storybook/web-components": "^8.0.9",
         "@storybook/web-components-vite": "^8.0.9",
         "@types/node": "^22.0.0",
-        "@types/object-hash": "^3.0.6",
         "@typescript-eslint/eslint-plugin": "^8.2.0",
         "@typescript-eslint/parser": "^8.2.0",
         "autoprefixer": "^10.4.19",

--- a/components/src/index.ts
+++ b/components/src/index.ts
@@ -1,6 +1,7 @@
 export * from './web-components';
 
 export { type ErrorEvent, UserFacingError } from './preact/components/error-display';
+export { type DateRangeOption, dateRangeOptionPresets } from './preact/dateRangeSelector/dateRangeOption';
 
 declare global {
     interface HTMLElementEventMap {

--- a/components/src/preact/dateRangeSelector/computeInitialValues.spec.ts
+++ b/components/src/preact/dateRangeSelector/computeInitialValues.spec.ts
@@ -1,48 +1,75 @@
 import { describe, expect, it } from 'vitest';
 
 import { computeInitialValues } from './computeInitialValues';
-import { PRESET_VALUE_CUSTOM, PRESET_VALUE_LAST_3_MONTHS, PRESET_VALUE_LAST_6_MONTHS } from './selectableOptions';
 
 const today = new Date();
 const earliestDate = '1900-01-01';
 
+const fromOption = 'fromOption';
+const toOption = 'toOption';
+const fromToOption = 'fromToOption';
+const dateFromOptionValue = '2010-06-30';
+const dateToOptionValue = '2020-01-01';
+
+const dateRangeOptions = [
+    { label: fromOption, dateFrom: dateFromOptionValue },
+    { label: toOption, dateTo: dateToOptionValue },
+    { label: fromToOption, dateFrom: dateFromOptionValue, dateTo: dateToOptionValue },
+];
+
 describe('computeInitialValues', () => {
     it('should compute for initial value if initial "from" and "to" are unset', () => {
-        const result = computeInitialValues(PRESET_VALUE_LAST_3_MONTHS, undefined, undefined, earliestDate, []);
+        const result = computeInitialValues(fromToOption, undefined, undefined, earliestDate, dateRangeOptions);
 
-        const expectedFrom = new Date();
-        expectedFrom.setMonth(today.getMonth() - 3);
+        expect(result.initialSelectedDateRange).toEqual(fromToOption);
+        expectDateMatches(result.initialSelectedDateFrom, new Date(dateFromOptionValue));
+        expectDateMatches(result.initialSelectedDateTo, new Date(dateToOptionValue));
+    });
 
-        expect(result.initialSelectedDateRange).toEqual(PRESET_VALUE_LAST_3_MONTHS);
-        expectDateMatches(result.initialSelectedDateFrom, expectedFrom);
+    it('should use today as "dateTo" if it is unset in selected option', () => {
+        const result = computeInitialValues(fromOption, undefined, undefined, earliestDate, dateRangeOptions);
+
+        expect(result.initialSelectedDateRange).toEqual(fromOption);
+        expectDateMatches(result.initialSelectedDateFrom, new Date(dateFromOptionValue));
+        expectDateMatches(result.initialSelectedDateTo, today);
+    });
+
+    it('should use earliest date as "dateFrom" if it is unset in selected option', () => {
+        const result = computeInitialValues(toOption, undefined, undefined, earliestDate, dateRangeOptions);
+
+        expect(result.initialSelectedDateRange).toEqual(toOption);
+        expectDateMatches(result.initialSelectedDateFrom, new Date(earliestDate));
+        expectDateMatches(result.initialSelectedDateTo, new Date(dateToOptionValue));
+    });
+
+    it('should fall back to full range if initial value is not set', () => {
+        const result = computeInitialValues(undefined, undefined, undefined, earliestDate, dateRangeOptions);
+
+        expect(result.initialSelectedDateRange).toBeUndefined();
+        expectDateMatches(result.initialSelectedDateFrom, new Date(earliestDate));
         expectDateMatches(result.initialSelectedDateTo, today);
     });
 
     it('should fall back to default when initial value is unknown', () => {
-        const result = computeInitialValues('not a known value', undefined, undefined, earliestDate, []);
-
-        const expectedFrom = new Date();
-        expectedFrom.setMonth(today.getMonth() - 6);
-
-        expect(result.initialSelectedDateRange).toEqual(PRESET_VALUE_LAST_6_MONTHS);
-        expectDateMatches(result.initialSelectedDateFrom, expectedFrom);
-        expectDateMatches(result.initialSelectedDateTo, today);
+        expect(() => computeInitialValues('not a known value', undefined, undefined, earliestDate, [])).toThrowError(
+            /Invalid initialValue "not a known value", It must be one of/,
+        );
     });
 
     it('should overwrite initial value if initial "from" is set', () => {
         const initialDateFrom = '2020-01-01';
-        const result = computeInitialValues(PRESET_VALUE_LAST_3_MONTHS, initialDateFrom, undefined, earliestDate, []);
+        const result = computeInitialValues(fromOption, initialDateFrom, undefined, earliestDate, dateRangeOptions);
 
-        expect(result.initialSelectedDateRange).toEqual(PRESET_VALUE_CUSTOM);
+        expect(result.initialSelectedDateRange).toBeUndefined();
         expectDateMatches(result.initialSelectedDateFrom, new Date(initialDateFrom));
         expectDateMatches(result.initialSelectedDateTo, today);
     });
 
     it('should overwrite initial value if initial "to" is set', () => {
         const initialDateTo = '2020-01-01';
-        const result = computeInitialValues(PRESET_VALUE_LAST_3_MONTHS, undefined, initialDateTo, earliestDate, []);
+        const result = computeInitialValues(fromOption, undefined, initialDateTo, earliestDate, dateRangeOptions);
 
-        expect(result.initialSelectedDateRange).toEqual(PRESET_VALUE_CUSTOM);
+        expect(result.initialSelectedDateRange).toBeUndefined();
         expectDateMatches(result.initialSelectedDateFrom, new Date(earliestDate));
         expectDateMatches(result.initialSelectedDateTo, new Date(initialDateTo));
     });
@@ -50,15 +77,9 @@ describe('computeInitialValues', () => {
     it('should overwrite initial value if initial "to" and "from" are set', () => {
         const initialDateFrom = '2020-01-01';
         const initialDateTo = '2022-01-01';
-        const result = computeInitialValues(
-            PRESET_VALUE_LAST_3_MONTHS,
-            initialDateFrom,
-            initialDateTo,
-            earliestDate,
-            [],
-        );
+        const result = computeInitialValues(fromOption, initialDateFrom, initialDateTo, earliestDate, dateRangeOptions);
 
-        expect(result.initialSelectedDateRange).toEqual(PRESET_VALUE_CUSTOM);
+        expect(result.initialSelectedDateRange).toBeUndefined();
         expectDateMatches(result.initialSelectedDateFrom, new Date(initialDateFrom));
         expectDateMatches(result.initialSelectedDateTo, new Date(initialDateTo));
     });
@@ -66,29 +87,23 @@ describe('computeInitialValues', () => {
     it('should set initial "to" to "from" if "from" is after "to"', () => {
         const initialDateFrom = '2020-01-01';
         const initialDateTo = '1900-01-01';
-        const result = computeInitialValues(
-            PRESET_VALUE_LAST_3_MONTHS,
-            initialDateFrom,
-            initialDateTo,
-            earliestDate,
-            [],
-        );
+        const result = computeInitialValues(undefined, initialDateFrom, initialDateTo, earliestDate, dateRangeOptions);
 
-        expect(result.initialSelectedDateRange).toEqual(PRESET_VALUE_CUSTOM);
+        expect(result.initialSelectedDateRange).toBeUndefined();
         expectDateMatches(result.initialSelectedDateFrom, new Date(initialDateFrom));
         expectDateMatches(result.initialSelectedDateTo, new Date(initialDateFrom));
     });
 
     it('should throw if initial "from" is not a valid date', () => {
-        expect(() =>
-            computeInitialValues(PRESET_VALUE_LAST_3_MONTHS, 'not a date', undefined, earliestDate, []),
-        ).toThrowError('Invalid initialDateFrom');
+        expect(() => computeInitialValues(undefined, 'not a date', undefined, earliestDate, [])).toThrowError(
+            'Invalid initialDateFrom',
+        );
     });
 
     it('should throw if initial "to" is not a valid date', () => {
-        expect(() =>
-            computeInitialValues(PRESET_VALUE_LAST_3_MONTHS, undefined, 'not a date', earliestDate, []),
-        ).toThrowError('Invalid initialDateTo');
+        expect(() => computeInitialValues(undefined, undefined, 'not a date', earliestDate, [])).toThrowError(
+            'Invalid initialDateTo',
+        );
     });
 
     function expectDateMatches(actual: Date, expected: Date) {

--- a/components/src/preact/dateRangeSelector/computeInitialValues.ts
+++ b/components/src/preact/dateRangeSelector/computeInitialValues.ts
@@ -1,36 +1,30 @@
-import {
-    type CustomSelectOption,
-    getDatesForSelectorValue,
-    getSelectableOptions,
-    PRESET_VALUE_CUSTOM,
-    PRESET_VALUE_LAST_6_MONTHS,
-    type PresetOptionValues,
-} from './selectableOptions';
+import { type DateRangeOption } from './dateRangeOption';
+import { getDatesForSelectorValue, getSelectableOptions } from './selectableOptions';
 import { UserFacingError } from '../components/error-display';
 
-export function computeInitialValues<CustomLabel extends string>(
-    initialValue: PresetOptionValues | CustomLabel | undefined,
+export function computeInitialValues(
+    initialValue: string | undefined,
     initialDateFrom: string | undefined,
     initialDateTo: string | undefined,
     earliestDate: string,
-    customSelectOptions: CustomSelectOption<CustomLabel>[],
+    dateRangeOptions: DateRangeOption[],
 ): {
-    initialSelectedDateRange: CustomLabel | PresetOptionValues;
+    initialSelectedDateRange: string | undefined;
     initialSelectedDateFrom: Date;
     initialSelectedDateTo: Date;
 } {
     if (isUndefinedOrEmpty(initialDateFrom) && isUndefinedOrEmpty(initialDateTo)) {
-        const selectableOptions = getSelectableOptions(customSelectOptions);
-        const initialSelectedDateRange =
-            initialValue !== undefined && selectableOptions.some((option) => option.value === initialValue)
-                ? initialValue
-                : PRESET_VALUE_LAST_6_MONTHS;
+        const selectableOptions = getSelectableOptions(dateRangeOptions);
+        const initialSelectedDateRange = selectableOptions.find((option) => option.value === initialValue)?.value;
 
-        const { dateFrom, dateTo } = getDatesForSelectorValue(
-            initialSelectedDateRange,
-            customSelectOptions,
-            earliestDate,
-        );
+        if (initialValue !== undefined && initialSelectedDateRange === undefined) {
+            throw new UserFacingError(
+                'Invalid initialValue',
+                `Invalid initialValue "${initialValue}", It must be one of ${selectableOptions.map((option) => `'${option.value}'`).join(', ')}`,
+            );
+        }
+
+        const { dateFrom, dateTo } = getDatesForSelectorValue(initialSelectedDateRange, dateRangeOptions, earliestDate);
 
         return {
             initialSelectedDateRange,
@@ -62,7 +56,7 @@ export function computeInitialValues<CustomLabel extends string>(
     }
 
     return {
-        initialSelectedDateRange: PRESET_VALUE_CUSTOM,
+        initialSelectedDateRange: undefined,
         initialSelectedDateFrom,
         initialSelectedDateTo,
     };

--- a/components/src/preact/dateRangeSelector/dateRangeOption.ts
+++ b/components/src/preact/dateRangeSelector/dateRangeOption.ts
@@ -1,0 +1,65 @@
+import { toYYYYMMDD } from './dateConversion';
+
+/**
+ * A date range option that can be used in the `gs-date-range-selector` component.
+ */
+export type DateRangeOption = {
+    /** The label of the date range option that will be shown to the user */
+    label: string;
+    /**
+     * The start date of the date range in the format `YYYY-MM-DD`.
+     * If not set, the date range selector will default to the `earliestDate` property.
+     */
+    dateFrom?: string;
+    /**
+     * The end date of the date range in the format `YYYY-MM-DD`.
+     * If not set, the date range selector will default to the current date.
+     */
+    dateTo?: string;
+};
+
+const today = new Date();
+
+const twoWeeksAgo = new Date();
+twoWeeksAgo.setDate(today.getDate() - 14);
+
+const lastMonth = new Date(today);
+lastMonth.setMonth(today.getMonth() - 1);
+
+const last2Months = new Date(today);
+last2Months.setMonth(today.getMonth() - 2);
+
+const last3Months = new Date(today);
+last3Months.setMonth(today.getMonth() - 3);
+
+const last6Months = new Date(today);
+last6Months.setMonth(today.getMonth() - 6);
+
+/**
+ * Presets for the `gs-date-range-selector` component that can be used as `dateRangeOptions`.
+ */
+export const dateRangeOptionPresets = {
+    last2Weeks: {
+        label: 'Last 2 weeks',
+        dateFrom: toYYYYMMDD(twoWeeksAgo),
+    },
+    lastMonth: {
+        label: 'Last month',
+        dateFrom: toYYYYMMDD(lastMonth),
+    },
+    last2Months: {
+        label: 'Last 2 months',
+        dateFrom: toYYYYMMDD(last2Months),
+    },
+    last3Months: {
+        label: 'Last 3 months',
+        dateFrom: toYYYYMMDD(last3Months),
+    },
+    last6Months: {
+        label: 'Last 6 months',
+        dateFrom: toYYYYMMDD(last6Months),
+    },
+    allTimes: {
+        label: 'All times',
+    },
+} satisfies Record<string, DateRangeOption>;

--- a/components/src/preact/dateRangeSelector/selectableOptions.ts
+++ b/components/src/preact/dateRangeSelector/selectableOptions.ts
@@ -1,79 +1,30 @@
-export const PRESET_VALUE_CUSTOM = 'custom';
-export const PRESET_VALUE_ALL_TIMES = 'allTimes';
-export const PRESET_VALUE_LAST_2_WEEKS = 'last2Weeks';
-export const PRESET_VALUE_LAST_MONTH = 'lastMonth';
-export const PRESET_VALUE_LAST_2_MONTHS = 'last2Months';
-export const PRESET_VALUE_LAST_3_MONTHS = 'last3Months';
-export const PRESET_VALUE_LAST_6_MONTHS = 'last6Months';
+import { type DateRangeOption } from './dateRangeOption';
 
-export const presets = {
-    [PRESET_VALUE_CUSTOM]: { label: 'Custom' },
-    [PRESET_VALUE_ALL_TIMES]: { label: 'All times' },
-    [PRESET_VALUE_LAST_2_WEEKS]: { label: 'Last 2 weeks' },
-    [PRESET_VALUE_LAST_MONTH]: { label: 'Last month' },
-    [PRESET_VALUE_LAST_2_MONTHS]: { label: 'Last 2 months' },
-    [PRESET_VALUE_LAST_3_MONTHS]: { label: 'Last 3 months' },
-    [PRESET_VALUE_LAST_6_MONTHS]: { label: 'Last 6 months' },
-};
-
-export type PresetOptionValues = keyof typeof presets;
-
-export type CustomSelectOption<CustomLabel extends string> = { label: CustomLabel; dateFrom: string; dateTo: string };
-
-export const getSelectableOptions = <Label extends string>(customSelectOptions: CustomSelectOption<Label>[]) => {
-    const presetOptions = Object.entries(presets).map(([key, value]) => {
-        return { label: value.label, value: key };
-    });
-
-    const customOptions = customSelectOptions.map((customSelectOption) => {
+export const getSelectableOptions = (dateRangeOptions: DateRangeOption[]) => {
+    return dateRangeOptions.map((customSelectOption) => {
         return { label: customSelectOption.label, value: customSelectOption.label };
     });
-
-    return [...presetOptions, ...customOptions];
 };
 
-export const getDatesForSelectorValue = <Label extends string>(
-    selectorValue: string,
-    customSelectOptions: CustomSelectOption<Label>[],
+export const getDatesForSelectorValue = (
+    initialSelectedDateRange: string | undefined,
+    dateRangeOptions: DateRangeOption[],
     earliestDate: string,
 ) => {
     const today = new Date();
+    const defaultDates = { dateFrom: new Date(earliestDate), dateTo: today };
 
-    const customSelectOption = customSelectOptions.find((option) => option.label === selectorValue);
-    if (customSelectOption) {
-        return { dateFrom: new Date(customSelectOption.dateFrom), dateTo: new Date(customSelectOption.dateTo) };
+    if (initialSelectedDateRange === undefined) {
+        return defaultDates;
     }
 
-    switch (selectorValue) {
-        case PRESET_VALUE_LAST_2_WEEKS: {
-            const twoWeeksAgo = new Date(today);
-            twoWeeksAgo.setDate(today.getDate() - 14);
-            return { dateFrom: twoWeeksAgo, dateTo: today };
-        }
-        case PRESET_VALUE_LAST_MONTH: {
-            const lastMonth = new Date(today);
-            lastMonth.setMonth(today.getMonth() - 1);
-            return { dateFrom: lastMonth, dateTo: today };
-        }
-        case PRESET_VALUE_LAST_2_MONTHS: {
-            const twoMonthsAgo = new Date(today);
-            twoMonthsAgo.setMonth(today.getMonth() - 2);
-            return { dateFrom: twoMonthsAgo, dateTo: today };
-        }
-        case PRESET_VALUE_LAST_3_MONTHS: {
-            const threeMonthsAgo = new Date(today);
-            threeMonthsAgo.setMonth(today.getMonth() - 3);
-            return { dateFrom: threeMonthsAgo, dateTo: today };
-        }
-        case PRESET_VALUE_LAST_6_MONTHS: {
-            const sixMonthsAgo = new Date(today);
-            sixMonthsAgo.setMonth(today.getMonth() - 6);
-            return { dateFrom: sixMonthsAgo, dateTo: today };
-        }
-        case PRESET_VALUE_ALL_TIMES: {
-            return { dateFrom: new Date(earliestDate), dateTo: today };
-        }
-        default:
-            return { dateFrom: today, dateTo: today };
+    const dateRangeOption = dateRangeOptions.find((option) => option.label === initialSelectedDateRange);
+    if (dateRangeOption) {
+        return {
+            dateFrom: new Date(dateRangeOption.dateFrom ?? earliestDate),
+            dateTo: new Date(dateRangeOption.dateTo ?? today),
+        };
     }
+
+    return defaultDates;
 };

--- a/components/src/preact/mutationsOverTime/MutationOverTimeData.ts
+++ b/components/src/preact/mutationsOverTime/MutationOverTimeData.ts
@@ -1,0 +1,20 @@
+import {
+    type MutationOverTimeMutationValue,
+    serializeSubstitutionOrDeletion,
+    serializeTemporal,
+} from '../../query/queryMutationsOverTime';
+import { type Map2d, Map2dBase, type Map2DContents } from '../../utils/map2d';
+import type { Deletion, Substitution } from '../../utils/mutations';
+import type { Temporal } from '../../utils/temporalClass';
+
+export type MutationOverTimeDataMap = Map2d<Substitution | Deletion, Temporal, MutationOverTimeMutationValue>;
+
+export class BaseMutationOverTimeDataMap extends Map2dBase<
+    Substitution | Deletion,
+    Temporal,
+    MutationOverTimeMutationValue
+> {
+    constructor(initialContent?: Map2DContents<Substitution | Deletion, Temporal, MutationOverTimeMutationValue>) {
+        super(serializeSubstitutionOrDeletion, serializeTemporal, initialContent);
+    }
+}

--- a/components/src/preact/mutationsOverTime/getFilteredMutationsOverTime.spec.ts
+++ b/components/src/preact/mutationsOverTime/getFilteredMutationsOverTime.spec.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
+import { BaseMutationOverTimeDataMap } from './MutationOverTimeData';
 import { getFilteredMutationOverTimeData } from './getFilteredMutationsOverTimeData';
-import { type MutationOverTimeMutationValue } from '../../query/queryMutationsOverTime';
 import { type DeletionEntry, type SubstitutionEntry } from '../../types';
-import { Map2dBase } from '../../utils/map2d';
 import { type Deletion, type Substitution } from '../../utils/mutations';
 import { type TemporalClass } from '../../utils/temporalClass';
 import { yearMonthDay } from '../../utils/temporalTestHelpers';
@@ -194,7 +193,7 @@ describe('getFilteredMutationOverTimeData', () => {
         mutationEntries: (SubstitutionEntry<Substitution> | DeletionEntry<Deletion>)[],
         temporals: TemporalClass[] = [someTemporal, anotherTemporal],
     ) {
-        const data = new Map2dBase<Substitution | Deletion, TemporalClass, MutationOverTimeMutationValue>();
+        const data = new BaseMutationOverTimeDataMap();
 
         temporals.forEach((temporal) => {
             mutationEntries.forEach((entry) => {

--- a/components/src/preact/mutationsOverTime/getFilteredMutationsOverTimeData.ts
+++ b/components/src/preact/mutationsOverTime/getFilteredMutationsOverTimeData.ts
@@ -1,4 +1,4 @@
-import { type MutationOverTimeData } from './mutations-over-time';
+import { type MutationOverTimeDataMap } from './MutationOverTimeData';
 import { type SubstitutionOrDeletionEntry } from '../../types';
 import { Map2dView } from '../../utils/map2d';
 import type { Deletion, Substitution } from '../../utils/mutations';
@@ -6,7 +6,7 @@ import type { DisplayedMutationType } from '../components/mutation-type-selector
 import type { DisplayedSegment } from '../components/segment-selector';
 
 export function getFilteredMutationOverTimeData(
-    data: MutationOverTimeData,
+    data: MutationOverTimeDataMap,
     overallMutationData: SubstitutionOrDeletionEntry<Substitution, Deletion>[],
     displayedSegments: DisplayedSegment[],
     displayedMutationTypes: DisplayedMutationType[],

--- a/components/src/preact/mutationsOverTime/mutations-over-time-grid.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time-grid.tsx
@@ -1,16 +1,16 @@
 import { Fragment, type FunctionComponent, type RefObject } from 'preact';
 import { useEffect, useRef, useState } from 'preact/hooks';
 
-import { type MutationOverTimeData } from './mutations-over-time';
+import { type MutationOverTimeDataMap } from './MutationOverTimeData';
 import { type MutationOverTimeMutationValue } from '../../query/queryMutationsOverTime';
 import { type Deletion, type Substitution } from '../../utils/mutations';
-import { toTemporalClass, type Temporal, type TemporalClass, YearMonthDayClass } from '../../utils/temporalClass';
+import { type Temporal, type TemporalClass, toTemporalClass, YearMonthDayClass } from '../../utils/temporalClass';
 import { type ColorScale, getColorWithingScale, getTextColorForScale } from '../components/color-scale-selector';
 import Tooltip, { type TooltipPosition } from '../components/tooltip';
 import { formatProportion } from '../shared/table/formatProportion';
 
 export interface MutationsOverTimeGridProps {
-    data: MutationOverTimeData;
+    data: MutationOverTimeDataMap;
     colorScale: ColorScale;
 }
 

--- a/components/src/preact/mutationsOverTime/mutations-over-time.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.tsx
@@ -3,24 +3,19 @@ import { type Dispatch, type StateUpdater, useContext, useMemo, useState } from 
 
 // @ts-expect-error -- uses subpath imports and vite worker import
 import MutationOverTimeWorker from '#mutationOverTime?worker&inline';
+import { BaseMutationOverTimeDataMap, type MutationOverTimeDataMap } from './MutationOverTimeData';
 import { getFilteredMutationOverTimeData } from './getFilteredMutationsOverTimeData';
 import { type MutationOverTimeWorkerResponse } from './mutationOverTimeWorker';
 import MutationsOverTimeGrid from './mutations-over-time-grid';
-import {
-    type MutationOverTimeMutationValue,
-    type MutationOverTimeQuery,
-    serializeSubstitutionOrDeletion,
-    serializeTemporal,
-} from '../../query/queryMutationsOverTime';
+import { type MutationOverTimeQuery } from '../../query/queryMutationsOverTime';
 import {
     type LapisFilter,
     type SequenceType,
     type SubstitutionOrDeletionEntry,
     type TemporalGranularity,
 } from '../../types';
-import { type Map2d, Map2dBase } from '../../utils/map2d';
 import { type Deletion, type Substitution } from '../../utils/mutations';
-import { type Temporal, toTemporalClass } from '../../utils/temporalClass';
+import { toTemporalClass } from '../../utils/temporalClass';
 import { LapisUrlContext } from '../LapisUrlContext';
 import { type ColorScale } from '../components/color-scale-selector';
 import { ColorScaleSelectorDropdown } from '../components/color-scale-selector-dropdown';
@@ -99,11 +94,7 @@ export const MutationsOverTimeInner: FunctionComponent<MutationsOverTimeInnerPro
     }
 
     const { overallMutationData, mutationOverTimeSerialized } = data;
-    const mutationOverTimeData = new Map2dBase(
-        serializeSubstitutionOrDeletion,
-        serializeTemporal,
-        mutationOverTimeSerialized,
-    );
+    const mutationOverTimeData = new BaseMutationOverTimeDataMap(mutationOverTimeSerialized);
     return (
         <MutationsOverTimeTabs
             overallMutationData={overallMutationData}
@@ -114,10 +105,8 @@ export const MutationsOverTimeInner: FunctionComponent<MutationsOverTimeInnerPro
     );
 };
 
-export type MutationOverTimeData = Map2d<Substitution | Deletion, Temporal, MutationOverTimeMutationValue>;
-
 type MutationOverTimeTabsProps = {
-    mutationOverTimeData: MutationOverTimeData;
+    mutationOverTimeData: BaseMutationOverTimeDataMap;
     sequenceType: SequenceType;
     views: View[];
     overallMutationData: SubstitutionOrDeletionEntry<Substitution, Deletion>[];
@@ -192,7 +181,7 @@ type ToolbarProps = {
     setDisplayedMutationTypes: (types: DisplayedMutationType[]) => void;
     proportionInterval: ProportionInterval;
     setProportionInterval: Dispatch<StateUpdater<ProportionInterval>>;
-    filteredData: MutationOverTimeData;
+    filteredData: MutationOverTimeDataMap;
     colorScale: ColorScale;
     setColorScale: Dispatch<StateUpdater<ColorScale>>;
 };
@@ -236,7 +225,7 @@ const Toolbar: FunctionComponent<ToolbarProps> = ({
     );
 };
 
-function getDownloadData(filteredData: MutationOverTimeData) {
+function getDownloadData(filteredData: MutationOverTimeDataMap) {
     const dates = filteredData.getSecondAxisKeys().map((date) => toTemporalClass(date));
 
     return filteredData.getFirstAxisKeys().map((mutation) => {

--- a/components/src/query/queryMutationsOverTime.ts
+++ b/components/src/query/queryMutationsOverTime.ts
@@ -6,6 +6,7 @@ import { MapOperator } from '../operator/MapOperator';
 import { RenameFieldOperator } from '../operator/RenameFieldOperator';
 import { SortOperator } from '../operator/SortOperator';
 import { UserFacingError } from '../preact/components/error-display';
+import { BaseMutationOverTimeDataMap } from '../preact/mutationsOverTime/MutationOverTimeData';
 import { sortSubstitutionsAndDeletions } from '../preact/shared/sort/sortSubstitutionsAndDeletions';
 import {
     type DeletionEntry,
@@ -15,7 +16,7 @@ import {
     type SubstitutionOrDeletionEntry,
     type TemporalGranularity,
 } from '../types';
-import { type Map2d, Map2dBase } from '../utils/map2d';
+import { type Map2d } from '../utils/map2d';
 import {
     type Deletion,
     type DeletionClass,
@@ -218,10 +219,7 @@ export function groupByMutation(
     data: MutationOverTimeData[],
     overallMutationData: (SubstitutionEntry | DeletionEntry)[],
 ) {
-    const dataArray = new Map2dBase<Substitution | Deletion, Temporal, MutationOverTimeMutationValue>(
-        serializeSubstitutionOrDeletion,
-        serializeTemporal,
-    );
+    const dataArray = new BaseMutationOverTimeDataMap();
 
     const allDates = data.map((mutationData) => mutationData.date);
 

--- a/components/src/utils/map2d.spec.ts
+++ b/components/src/utils/map2d.spec.ts
@@ -4,20 +4,29 @@ import { Map2dBase, Map2dView } from './map2d';
 
 describe('Map2dBase', () => {
     it('should add a value and return it', () => {
-        const map2d = new Map2dBase<string, string, number>();
+        const map2d = new Map2dBase<string, string, number>(
+            (value) => value,
+            (value) => value,
+        );
         map2d.set('a', 'b', 2);
         expect(map2d.get('a', 'b')).toBe(2);
     });
 
     it('should update a value', () => {
-        const map2d = new Map2dBase<string, string, number>();
+        const map2d = new Map2dBase<string, string, number>(
+            (value) => value,
+            (value) => value,
+        );
         map2d.set('a', 'b', 2);
         map2d.set('a', 'b', 3);
         expect(map2d.get('a', 'b')).toBe(3);
     });
 
     it('should return the data as an array', () => {
-        const map2d = new Map2dBase<string, string, number>();
+        const map2d = new Map2dBase<string, string, number>(
+            (value) => value,
+            (value) => value,
+        );
         map2d.set('a', 'b', 1);
         map2d.set('a', 'd', 2);
         map2d.set('c', 'b', 3);
@@ -30,7 +39,10 @@ describe('Map2dBase', () => {
     });
 
     it('should fill empty values with the given value', () => {
-        const map2d = new Map2dBase<string, string, number>();
+        const map2d = new Map2dBase<string, string, number>(
+            (value) => value,
+            (value) => value,
+        );
         map2d.set('a', 'b', 2);
         map2d.set('c', 'd', 4);
         expect(map2d.getAsArray(0)).toEqual([
@@ -40,7 +52,10 @@ describe('Map2dBase', () => {
     });
 
     it('should return the keys from the first axis', () => {
-        const map2d = new Map2dBase<string, string, number>();
+        const map2d = new Map2dBase<string, string, number>(
+            (value) => value,
+            (value) => value,
+        );
         map2d.set('a', 'b', 2);
         map2d.set('c', 'd', 4);
 
@@ -48,7 +63,10 @@ describe('Map2dBase', () => {
     });
 
     it('should return the keys from the second axis', () => {
-        const map2d = new Map2dBase<string, string, number>();
+        const map2d = new Map2dBase<string, string, number>(
+            (value) => value,
+            (value) => value,
+        );
         map2d.set('a', 'b', 2);
         map2d.set('c', 'd', 4);
 
@@ -56,7 +74,10 @@ describe('Map2dBase', () => {
     });
 
     it('should work with objects as keys', () => {
-        const map2d = new Map2dBase<{ a: string }, { b: string }, number>();
+        const map2d = new Map2dBase<{ a: string }, { b: string }, number>(
+            ({ a }) => a,
+            ({ b }) => b,
+        );
         map2d.set({ a: 'a' }, { b: 'b' }, 2);
         map2d.set({ a: 'second' }, { b: 'second' }, 3);
 
@@ -65,14 +86,20 @@ describe('Map2dBase', () => {
     });
 
     it('should update a value with objects as keys', () => {
-        const map2d = new Map2dBase<{ a: string }, { b: string }, number>();
+        const map2d = new Map2dBase<{ a: string }, { b: string }, number>(
+            ({ a }) => a,
+            ({ b }) => b,
+        );
         map2d.set({ a: 'a' }, { b: 'b' }, 2);
         map2d.set({ a: 'a' }, { b: 'b' }, 3);
         expect(map2d.get({ a: 'a' }, { b: 'b' })).toBe(3);
     });
 
     it('should return a row by key', () => {
-        const map2d = new Map2dBase<string, string, number>();
+        const map2d = new Map2dBase<string, string, number>(
+            (value) => value,
+            (value) => value,
+        );
         map2d.set('a', 'b', 2);
         map2d.set('c', 'd', 4);
 
@@ -81,14 +108,20 @@ describe('Map2dBase', () => {
     });
 
     it('should return an empty array when the row does not exist', () => {
-        const map2d = new Map2dBase<string, string, number>();
+        const map2d = new Map2dBase<string, string, number>(
+            (value) => value,
+            (value) => value,
+        );
         map2d.set('a', 'b', 2);
 
         expect(map2d.getRow('c', 0)).toEqual([]);
     });
 
     it('should return content as object', () => {
-        const map2d = new Map2dBase<string, string, number>();
+        const map2d = new Map2dBase<string, string, number>(
+            (value) => value,
+            (value) => value,
+        );
         map2d.set('a', 'b', 2);
         map2d.set('c', 'd', 4);
 
@@ -99,7 +132,10 @@ describe('Map2dBase', () => {
     });
 
     it('should use initial data', () => {
-        const map2d = new Map2dBase<string, string, number>();
+        const map2d = new Map2dBase<string, string, number>(
+            (value) => value,
+            (value) => value,
+        );
         map2d.set('a', 'b', 2);
         map2d.set('c', 'd', 4);
 
@@ -174,7 +210,10 @@ describe('Map2dView', () => {
     });
 
     function createBaseContainer() {
-        const container = new Map2dBase<string, string, number>();
+        const container = new Map2dBase<string, string, number>(
+            (value) => value,
+            (value) => value,
+        );
         container.set('a', 'b', 1);
         container.set('c', 'b', 3);
         container.set('c', 'd', 4);

--- a/components/src/utils/map2d.ts
+++ b/components/src/utils/map2d.ts
@@ -1,5 +1,3 @@
-import hash from 'object-hash';
-
 export interface Map2d<Key1, Key2, Value> {
     get(keyFirstAxis: Key1, keySecondAxis: Key2): Value | undefined;
 
@@ -16,6 +14,7 @@ export interface Map2d<Key1, Key2, Value> {
     getAsArray(fillEmptyWith: Value): Value[][];
 
     serializeFirstAxis(key: Key1): string;
+
     serializeSecondAxis(key: Key2): string;
 
     readonly keysFirstAxis: Map<string, Key1>;
@@ -36,8 +35,8 @@ export class Map2dBase<Key1 extends object | string, Key2 extends object | strin
     readonly keysSecondAxis = new Map<string, Key2>();
 
     constructor(
-        readonly serializeFirstAxis: (key: Key1) => string = (key) => (typeof key === 'string' ? key : hash(key)),
-        readonly serializeSecondAxis: (key: Key2) => string = (key) => (typeof key === 'string' ? key : hash(key)),
+        readonly serializeFirstAxis: (key: Key1) => string,
+        readonly serializeSecondAxis: (key: Key2) => string,
         initialContent?: Map2DContents<Key1, Key2, Value>,
     ) {
         if (initialContent) {

--- a/components/src/web-components/input/gs-date-range-selector.stories.ts
+++ b/components/src/web-components/input/gs-date-range-selector.stories.ts
@@ -9,29 +9,21 @@ import { type DateRangeSelectorProps } from '../../preact/dateRangeSelector/date
 import './gs-date-range-selector';
 import '../app';
 import { toYYYYMMDD } from '../../preact/dateRangeSelector/dateConversion';
-import {
-    PRESET_VALUE_ALL_TIMES,
-    PRESET_VALUE_CUSTOM,
-    PRESET_VALUE_LAST_2_MONTHS,
-    PRESET_VALUE_LAST_2_WEEKS,
-    PRESET_VALUE_LAST_3_MONTHS,
-    PRESET_VALUE_LAST_6_MONTHS,
-    PRESET_VALUE_LAST_MONTH,
-} from '../../preact/dateRangeSelector/selectableOptions';
+import { dateRangeOptionPresets } from '../../preact/dateRangeSelector/dateRangeOption';
 import { withinShadowRoot } from '../withinShadowRoot.story';
 
 const codeExample = String.raw`
 <gs-date-range-selector
-    customSelectOptions='[{ "label": "Year 2021", "dateFrom": "2021-01-01", "dateTo": "2021-12-31" }]'
+    dateRangeOptions='[{ "label": "Year 2021", "dateFrom": "2021-01-01", "dateTo": "2021-12-31" }]'
     earliestDate="1970-01-01"
-    initialValue="${PRESET_VALUE_LAST_6_MONTHS}"
+    initialValue="Year 2021"
     initialDateFrom="2020-01-01"
     initialDateTo="2021-01-01"
     width="100%"
     dateColumn="myDateColumn"
 ></gs-date-range-selector>`;
 
-const meta: Meta<Required<DateRangeSelectorProps<'CustomDateRange'>>> = {
+const meta: Meta<Required<DateRangeSelectorProps>> = {
     title: 'Input/DateRangeSelector',
     component: 'gs-date-range-selector',
     parameters: withComponentDocs({
@@ -50,19 +42,10 @@ const meta: Meta<Required<DateRangeSelectorProps<'CustomDateRange'>>> = {
             control: {
                 type: 'select',
             },
-            options: [
-                PRESET_VALUE_CUSTOM,
-                PRESET_VALUE_ALL_TIMES,
-                PRESET_VALUE_LAST_2_WEEKS,
-                PRESET_VALUE_LAST_MONTH,
-                PRESET_VALUE_LAST_2_MONTHS,
-                PRESET_VALUE_LAST_3_MONTHS,
-                PRESET_VALUE_LAST_6_MONTHS,
-                'CustomDateRange',
-            ],
+            options: [dateRangeOptionPresets.lastMonth.label, dateRangeOptionPresets.allTimes.label, 'CustomDateRange'],
         },
         dateColumn: { control: { type: 'text' } },
-        customSelectOptions: {
+        dateRangeOptions: {
             control: {
                 type: 'object',
             },
@@ -79,9 +62,14 @@ const meta: Meta<Required<DateRangeSelectorProps<'CustomDateRange'>>> = {
         },
     },
     args: {
-        customSelectOptions: [{ label: 'CustomDateRange', dateFrom: '2021-01-01', dateTo: '2021-12-31' }],
+        dateRangeOptions: [
+            dateRangeOptionPresets.lastMonth,
+            dateRangeOptionPresets.last3Months,
+            dateRangeOptionPresets.allTimes,
+            { label: 'CustomDateRange', dateFrom: '2021-01-01', dateTo: '2021-12-31' },
+        ],
         earliestDate: '1970-01-01',
-        initialValue: PRESET_VALUE_LAST_6_MONTHS,
+        initialValue: dateRangeOptionPresets.lastMonth.label,
         dateColumn: 'aDateColumn',
         width: '100%',
         initialDateFrom: '',
@@ -92,12 +80,12 @@ const meta: Meta<Required<DateRangeSelectorProps<'CustomDateRange'>>> = {
 
 export default meta;
 
-export const DateRangeSelectorStory: StoryObj<Required<DateRangeSelectorProps<'CustomDateRange'>>> = {
+export const DateRangeSelectorStory: StoryObj<Required<DateRangeSelectorProps>> = {
     render: (args) =>
         html` <gs-app lapis="${LAPIS_URL}">
             <div class="max-w-screen-lg">
                 <gs-date-range-selector
-                    .customSelectOptions=${args.customSelectOptions}
+                    .dateRangeOptions=${args.dateRangeOptions}
                     .earliestDate=${args.earliestDate}
                     .initialValue=${args.initialValue}
                     .initialDateFrom=${args.initialDateFrom}
@@ -112,7 +100,7 @@ export const DateRangeSelectorStory: StoryObj<Required<DateRangeSelectorProps<'C
         const dateTo = () => canvas.getByPlaceholderText('Date to');
 
         await step('Expect last 6 months to be selected', async () => {
-            await expect(canvas.getByRole('combobox')).toHaveValue('last6Months');
+            await expect(canvas.getByRole('combobox')).toHaveValue('Last month');
             await waitFor(() => {
                 expect(dateTo()).toHaveValue(toYYYYMMDD(new Date()));
             });

--- a/components/src/web-components/input/gs-date-range-selector.tsx
+++ b/components/src/web-components/input/gs-date-range-selector.tsx
@@ -37,13 +37,14 @@ import { PreactLitAdapter } from '../PreactLitAdapter';
 @customElement('gs-date-range-selector')
 export class DateRangeSelectorComponent extends PreactLitAdapter {
     /**
-     * An array of custom options that the select field should provide,
-     * in addition to the predefined options.
+     * An array of date range options that the select field should provide.
      * The `label` will be shown to the user, and it will be available as `initialValue`.
      * The dates must be in the format `YYYY-MM-DD`.
+     *
+     * If dateFrom or dateTo is not set, the component will default to the `earliestDate` or the current date.
      */
     @property({ type: Array })
-    customSelectOptions: { label: string; dateFrom: string; dateTo: string }[] = [];
+    dateRangeOptions: { label: string; dateFrom?: string; dateTo?: string }[] = [];
 
     /**
      * The `dateFrom` value to use in the `allTimes` preset in the format `YYYY-MM-DD`.
@@ -51,26 +52,18 @@ export class DateRangeSelectorComponent extends PreactLitAdapter {
     @property({ type: String })
     earliestDate: string = '1900-01-01';
 
-    // prettier-ignore
-    // The multiline union type must not start with `| 'custom'` - Storybook will list "" as the first type which is wrong
     /**
      * The initial value to use for this date range selector.
-     * Must be a valid label from the preset labels or a `label` given in the `customSelectOptions`.
+     * Must be a valid label from the `dateRangeOptions`.
      *
-     * If the value is invalid, the component will default to `'last6Months'`.
+     * If the value is not set, the component will default to the range `earliestDate` until today.
      *
      * It will be overwritten if `initialDateFrom` or `initialDateTo` is set.
+     *
+     * We provide some options in `dateRangeOptionPresets` for convenience.
      */
     @property()
-    initialValue:
-        'custom'
-        | 'allTimes'
-        | 'last2Weeks'
-        | 'lastMonth'
-        | 'last2Months'
-        | 'last3Months'
-        | 'last6Months'
-        | string = 'last6Months';
+    initialValue: string | undefined = undefined;
 
     /**
      * A date string in the format `YYYY-MM-DD`.
@@ -105,7 +98,7 @@ export class DateRangeSelectorComponent extends PreactLitAdapter {
     override render() {
         return (
             <DateRangeSelector
-                customSelectOptions={this.customSelectOptions}
+                dateRangeOptions={this.dateRangeOptions}
                 earliestDate={this.earliestDate}
                 initialValue={this.initialValue}
                 initialDateFrom={this.initialDateFrom}
@@ -138,30 +131,22 @@ declare global {
 
 /* eslint-disable @typescript-eslint/no-unused-vars, no-unused-vars */
 type CustomSelectOptionsMatches = Expect<
-    Equals<
-        typeof DateRangeSelectorComponent.prototype.customSelectOptions,
-        DateRangeSelectorProps<string>['customSelectOptions']
-    >
+    Equals<typeof DateRangeSelectorComponent.prototype.dateRangeOptions, DateRangeSelectorProps['dateRangeOptions']>
 >;
 type EarliestDateMatches = Expect<
-    Equals<typeof DateRangeSelectorComponent.prototype.earliestDate, DateRangeSelectorProps<string>['earliestDate']>
+    Equals<typeof DateRangeSelectorComponent.prototype.earliestDate, DateRangeSelectorProps['earliestDate']>
 >;
 type InitialValueMatches = Expect<
-    Equals<typeof DateRangeSelectorComponent.prototype.initialValue, DateRangeSelectorProps<string>['initialValue']>
+    Equals<typeof DateRangeSelectorComponent.prototype.initialValue, DateRangeSelectorProps['initialValue']>
 >;
 type InitialDateFromMatches = Expect<
-    Equals<
-        typeof DateRangeSelectorComponent.prototype.initialDateFrom,
-        DateRangeSelectorProps<string>['initialDateFrom']
-    >
+    Equals<typeof DateRangeSelectorComponent.prototype.initialDateFrom, DateRangeSelectorProps['initialDateFrom']>
 >;
 type InitialDateToMatches = Expect<
-    Equals<typeof DateRangeSelectorComponent.prototype.initialDateTo, DateRangeSelectorProps<string>['initialDateTo']>
+    Equals<typeof DateRangeSelectorComponent.prototype.initialDateTo, DateRangeSelectorProps['initialDateTo']>
 >;
-type WidthMatches = Expect<
-    Equals<typeof DateRangeSelectorComponent.prototype.width, DateRangeSelectorProps<string>['width']>
->;
+type WidthMatches = Expect<Equals<typeof DateRangeSelectorComponent.prototype.width, DateRangeSelectorProps['width']>>;
 type DateColumnMatches = Expect<
-    Equals<typeof DateRangeSelectorComponent.prototype.dateColumn, DateRangeSelectorProps<string>['dateColumn']>
+    Equals<typeof DateRangeSelectorComponent.prototype.dateColumn, DateRangeSelectorProps['dateColumn']>
 >;
 /* eslint-enable @typescript-eslint/no-unused-vars, no-unused-vars */

--- a/components/tests/dateRangeSelector.spec.ts
+++ b/components/tests/dateRangeSelector.spec.ts
@@ -32,7 +32,7 @@ test('date selector should switch to custom and back', async ({ page }) => {
     await dateFrom.fill(someDateInThePast);
     await dateFrom.press('Enter');
 
-    expect(await selectBox.inputValue()).toBe('custom');
+    expect(await selectBox.inputValue()).toBe('Custom');
     expect(await dateFrom.inputValue()).toBe(someDateInThePast);
 
     const today = new Date();
@@ -41,14 +41,14 @@ test('date selector should switch to custom and back', async ({ page }) => {
     expect(firstEvent.aDateColumnTo).toBe(toYYYYMMDD(today));
 
     const secondEventPromise = getEventPromiseInsideTestBrowser(page);
-    await selectBox.selectOption('last3Months');
+    await selectBox.selectOption('Last 3 months');
 
     const threeMonthAgo = new Date();
     threeMonthAgo.setMonth(threeMonthAgo.getMonth() - 3);
 
     expect(await dateFrom.inputValue()).toBe(toYYYYMMDD(threeMonthAgo));
     expect(await dateTo.inputValue()).toBe(toYYYYMMDD(today));
-    expect(await selectBox.inputValue()).toBe('last3Months');
+    expect(await selectBox.inputValue()).toBe('Last 3 months');
     const secondEvent = await secondEventPromise;
     expect(secondEvent.aDateColumnFrom).toBe(toYYYYMMDD(threeMonthAgo));
     expect(secondEvent.aDateColumnTo).toBe(toYYYYMMDD(today));

--- a/examples/React/src/App.tsx
+++ b/examples/React/src/App.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import {useEffect, useState} from 'react';
+import {DateRangeOption, dateRangeOptionPresets} from '@genspectrum/dashboard-components';
 import '@genspectrum/dashboard-components';
 import '@genspectrum/dashboard-components/style.css';
 
@@ -54,14 +55,26 @@ function App() {
         },
     };
 
+    const dataRangeOptions = [
+        dateRangeOptionPresets.allTimes,
+        dateRangeOptionPresets.last6Months,
+        dateRangeOptionPresets.lastMonth,
+        { label: '2020', dateFrom: '2020-01-01', dateTo: '2020-12-31' },
+        { label: '2021', dateFrom: '2021-01-01', dateTo: '2021-12-31' },
+        { label: '2022', dateFrom: '2022-01-01', dateTo: '2022-12-31' },
+    ] satisfies DateRangeOption[];
+
     return (
         <gs-app lapis='https://lapis.cov-spectrum.org/open/v2/'>
             <gs-location-filter
                 initialValue='Europe / Switzerland'
                 fields='["region", "country", "division", "location"]'
             ></gs-location-filter>
-            <gs-date-range-selector initialValue='last6Months'></gs-date-range-selector>
-            <div style={{ display: 'flex', flexDirection: 'row' }}>
+            <gs-date-range-selector
+                dateRangeOptions={JSON.stringify(dataRangeOptions)}
+                initialValue={dateRangeOptionPresets.last6Months.label}
+            ></gs-date-range-selector>
+            <div style={{display: 'flex', flexDirection: 'row'}}>
                 <div>
                     <h1 className='text-xl bold'>Prevalence over time</h1>
                     <gs-prevalence-over-time
@@ -74,7 +87,7 @@ function App() {
                         height='300px'
                     ></gs-prevalence-over-time>
                 </div>
-                <div style={{ height: '300px', width: '1000px' }}>
+                <div style={{height: '300px', width: '1000px'}}>
                     <h1 className='text-xl bold'>Prevalence over time</h1>
                     <gs-prevalence-over-time
                         numeratorFilter={JSON.stringify(numerator)}

--- a/examples/plainJavascript/index.html
+++ b/examples/plainJavascript/index.html
@@ -20,7 +20,8 @@
                 fields='["region", "country", "division", "location"]'
             ></gs-location-filter>
             <gs-date-range-selector
-                initialValue="last6Months"
+                dateRangeOptions='[{"label":"2020","dateFrom":"2020-01-01","dateTo":"2020-12-31"},{"label":"2021","dateFrom":"2021-01-01","dateTo":"2021-12-31"},{"label":"2022","dateFrom":"2022-01-01","dateTo":"2022-12-31"}]'
+                initialValue="2021"
             ></gs-date-range-selector>
             <gs-prevalence-over-time
                 numeratorFilter='{"displayName": "My variant","lapisFilter":{"country":"Switzerland", "pangoLineage":"B.1.1.7", "dateTo":"2022-01-01", "dateFrom":"2021-01-01"}}'


### PR DESCRIPTION
resolves #473

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

The date range selector doesn't come with predefined date ranges anymore. Users of the component need to supply themselves.
We provide the old options as constants for convenient use.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
