### PR TITLE
fix(components): show no data indicator on mutation over time instead of error

### DIFF
--- a/components/src/preact/mutationsOverTime/__mockData__/noDataWhenNoMutationsAreInFilter.ts
+++ b/components/src/preact/mutationsOverTime/__mockData__/noDataWhenNoMutationsAreInFilter.ts
@@ -1,0 +1,22 @@
+import type { MutationOverTimeMockData } from './mockConversion';
+
+export const noDataWhenNoMutationsAreInFilter: MutationOverTimeMockData = {
+    query: {
+        lapisFilter: {
+            dateFrom: '1800-01-01',
+            dateTo: '1800-01-02',
+        },
+        sequenceType: 'nucleotide',
+        granularity: 'year',
+        lapisDateField: 'date',
+        lapis: 'https://lapis.cov-spectrum.org/open/v2',
+    },
+    response: {
+        overallMutationData: [],
+        mutationOverTimeSerializedAsArray: {
+            keysFirstAxis: [],
+            keysSecondAxis: [],
+            data: [],
+        },
+    },
+};

--- a/components/src/preact/mutationsOverTime/__mockData__/noDataWhenThereAreNoDatesInFilter.ts
+++ b/components/src/preact/mutationsOverTime/__mockData__/noDataWhenThereAreNoDatesInFilter.ts
@@ -1,0 +1,22 @@
+import type { MutationOverTimeMockData } from './mockConversion';
+
+export const noDataWhenNoMutationsAreInFilter: MutationOverTimeMockData = {
+    query: {
+        lapisFilter: {
+            dateFrom: '2345-01-01',
+            dateTo: '2020-01-02',
+        },
+        sequenceType: 'nucleotide',
+        granularity: 'year',
+        lapisDateField: 'date',
+        lapis: 'https://lapis.cov-spectrum.org/open/v2',
+    },
+    response: {
+        overallMutationData: [],
+        mutationOverTimeSerializedAsArray: {
+            keysFirstAxis: [],
+            keysSecondAxis: [],
+            data: [],
+        },
+    },
+};

--- a/components/src/preact/mutationsOverTime/mutationOverTimeWorker.mock.ts
+++ b/components/src/preact/mutationsOverTime/mutationOverTimeWorker.mock.ts
@@ -5,6 +5,7 @@ import { workerFunction } from '../webWorkers/workerFunction';
 import { byWeek } from './__mockData__/byWeek';
 import { defaultMockData } from './__mockData__/defaultMockData';
 import { getMutationOverTimeMock } from './__mockData__/mockConversion';
+import { noDataWhenNoMutationsAreInFilter } from './__mockData__/noDataWhenNoMutationsAreInFilter';
 import { showsMessageWhenTooManyMutations } from './__mockData__/showsMessageWhenTooManyMutations';
 
 const mockQueries: { query: MutationOverTimeQuery; response: MutationOverTimeWorkerResponse }[] = [
@@ -12,6 +13,7 @@ const mockQueries: { query: MutationOverTimeQuery; response: MutationOverTimeWor
     getMutationOverTimeMock(showsMessageWhenTooManyMutations),
     getMutationOverTimeMock(byWeek),
     getMutationOverTimeMock(aminoAcidMutationsByDay),
+    getMutationOverTimeMock(noDataWhenNoMutationsAreInFilter),
 ];
 
 self.onmessage = async function (event: MessageEvent<MutationOverTimeQuery>) {

--- a/components/src/preact/mutationsOverTime/mutations-over-time-grid.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time-grid.tsx
@@ -35,6 +35,9 @@ const MutationsOverTimeGrid: FunctionComponent<MutationsOverTimeGridProps> = ({ 
                     reduce the number of mutations.
                 </div>
             )}
+            {allMutations.length === 0 && (
+                <div className={'flex justify-center'}>No data available for your filters.</div>
+            )}
             <div
                 ref={gridRef}
                 style={{

--- a/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
@@ -85,3 +85,73 @@ export const ShowsMessageWhenTooManyMutations: StoryObj<MutationsOverTimeProps> 
         });
     },
 };
+
+export const ShowsNoDataWhenNoMutationsAreInFilter: StoryObj<MutationsOverTimeProps> = {
+    ...Template,
+    args: {
+        lapisFilter: { dateFrom: '1800-01-01', dateTo: '1800-01-02' },
+        sequenceType: 'nucleotide',
+        views: ['grid'],
+        width: '100%',
+        height: '700px',
+        granularity: 'year',
+        lapisDateField: 'date',
+    },
+    play: async ({ canvas }) => {
+        await waitFor(() => expect(canvas.getByText('No data available.', { exact: false })).toBeVisible(), {
+            timeout: 10000,
+        });
+    },
+};
+
+export const ShowsNoDataMessageWhenThereAreNoDatesInFilter: StoryObj<MutationsOverTimeProps> = {
+    ...Template,
+    args: {
+        lapisFilter: { dateFrom: '2345-01-01', dateTo: '2020-01-02' },
+        sequenceType: 'nucleotide',
+        views: ['grid'],
+        width: '100%',
+        height: '700px',
+        granularity: 'year',
+        lapisDateField: 'date',
+    },
+    play: async ({ canvas }) => {
+        await waitFor(() => expect(canvas.getByText('No data available.', { exact: false })).toBeVisible(), {
+            timeout: 10000,
+        });
+    },
+};
+
+export const ShowsNoDataMessageForStrictFilters: StoryObj<MutationsOverTimeProps> = {
+    ...Template,
+    args: {
+        lapisFilter: { pangoLineage: 'JN.1*', dateFrom: '2024-01-15', dateTo: '2024-07-10' },
+        sequenceType: 'nucleotide',
+        views: ['grid'],
+        width: '100%',
+        height: '700px',
+        granularity: 'month',
+        lapisDateField: 'date',
+    },
+    play: async ({ canvas }) => {
+        await waitFor(() => expect(canvas.getByText('Grid')).toBeVisible(), { timeout: 10000 });
+
+        const button = canvas.getByRole('button', { name: 'Mean proportion 5.0% - 90.0%' });
+        await userEvent.click(button);
+
+        const minInput = canvas.getAllByLabelText('%')[0];
+        await userEvent.clear(minInput);
+        await userEvent.type(minInput, '40');
+
+        const maxInput = canvas.getAllByLabelText('%')[1];
+        await userEvent.clear(maxInput);
+        await userEvent.type(maxInput, '41');
+
+        await waitFor(
+            () => expect(canvas.getByText('No data available for your filters.', { exact: false })).toBeVisible(),
+            {
+                timeout: 10000,
+            },
+        );
+    },
+};

--- a/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
@@ -1,5 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/preact';
-import { expect, waitFor } from '@storybook/test';
+import { expect, userEvent, waitFor } from '@storybook/test';
 
 import { MutationsOverTime, type MutationsOverTimeProps } from './mutations-over-time';
 import { LAPIS_URL } from '../../constants';

--- a/components/src/preact/mutationsOverTime/mutations-over-time.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.tsx
@@ -88,7 +88,7 @@ export const MutationsOverTimeInner: FunctionComponent<MutationsOverTimeProps> =
         return <ErrorDisplay error={error} />;
     }
 
-    if (data === null || data === undefined) {
+    if (data === null || data === undefined || data.overallMutationData.length === 0) {
         return <NoDataDisplay />;
     }
 

--- a/components/src/query/queryMutationsOverTime.spec.ts
+++ b/components/src/query/queryMutationsOverTime.spec.ts
@@ -719,6 +719,36 @@ describe('queryMutationsOverTime', () => {
         expect(dates[1].dateString).toBe('2023-02');
     });
 
+    it('should return empty data when there are no dates in filter', async () => {
+        const lapisFilter = { field1: 'value1', field2: 'value2' };
+        const dateField = 'dateField';
+
+        lapisRequestMocks.multipleAggregated([
+            {
+                body: { ...lapisFilter, fields: [dateField] },
+                response: {
+                    data: [],
+                },
+            },
+        ]);
+
+        const { mutationOverTimeData } = await queryMutationsOverTimeData({
+            lapisFilter,
+            sequenceType: 'nucleotide',
+            lapis: DUMMY_LAPIS_URL,
+            lapisDateField: dateField,
+            granularity: 'month',
+        });
+
+        expect(mutationOverTimeData.getAsArray({ count: 0, proportion: 0, totalCount: 0 })).to.deep.equal([]);
+
+        const sequences = mutationOverTimeData.getFirstAxisKeys();
+        expect(sequences.length).toBe(0);
+
+        const dates = mutationOverTimeData.getSecondAxisKeys();
+        expect(dates.length).toBe(0);
+    });
+
     function getSomeTestMutation(proportion: number, count: number) {
         return {
             mutation: 'sequenceName:A123T',

--- a/components/src/query/queryMutationsOverTime.ts
+++ b/components/src/query/queryMutationsOverTime.ts
@@ -66,6 +66,13 @@ export async function queryOverallMutationData({
     signal?: AbortSignal;
 }) {
     const allDates = await getDatesInDataset(lapisFilter, lapis, granularity, lapisDateField, signal);
+
+    if (allDates.length === 0) {
+        return {
+            content: [],
+        };
+    }
+
     const filter = {
         ...lapisFilter,
         [`${lapisDateField}From`]: allDates[0].firstDay.toString(),


### PR DESCRIPTION
Resolves: #501
Resolves: #487

### Summary
Shows a "No data available" indication, when there is no data for the lapis filters. Also adds a no data message, for the filters the user can select in the component itself.

<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot

When the user selects a too narrow filter in the component
![grafik](https://github.com/user-attachments/assets/012ee1a2-7b72-4594-ad1d-ba53e10cce2c)


<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
