### PR TITLE
fix(components): show no data message for prevalence over time

### DIFF
--- a/components/src/operator/SlidingOperator.ts
+++ b/components/src/operator/SlidingOperator.ts
@@ -14,6 +14,9 @@ export class SlidingOperator<Data, AggregationResult> implements Operator<Aggreg
     async evaluate(lapis: string, signal?: AbortSignal) {
         const childEvaluated = await this.child.evaluate(lapis, signal);
         const content = new Array<AggregationResult>();
+        if (childEvaluated.content.length === 0) {
+            return { content };
+        }
         const numberOfWindows = Math.max(childEvaluated.content.length - this.windowSize, 0) + 1;
         for (let i = 0; i < numberOfWindows; i++) {
             content.push(this.aggregate(childEvaluated.content.slice(i, i + this.windowSize)));

--- a/components/src/preact/prevalenceOverTime/__mockData__/numeratorFilterNoData.json
+++ b/components/src/preact/prevalenceOverTime/__mockData__/numeratorFilterNoData.json
@@ -1,0 +1,11 @@
+{
+    "errors": [],
+    "info": {
+        "apiVersion": 1,
+        "dataVersion": 1709685650,
+        "deprecationDate": null,
+        "deprecationInfo": null,
+        "acknowledgement": null
+    },
+    "data": []
+}

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time-bar-chart.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time-bar-chart.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../query/queryPrevalenceOverTime';
 import { sortNullToBeginningThenByDate } from '../../utils/sort';
 import GsChart from '../components/chart';
+import { NoDataDisplay } from '../components/no-data-display';
 import { LogitScale } from '../shared/charts/LogitScale';
 import { singleGraphColorRGBAById } from '../shared/charts/colors';
 import { type ConfidenceIntervalMethod, wilson95PercentConfidenceInterval } from '../shared/charts/confideceInterval';
@@ -30,12 +31,18 @@ const PrevalenceOverTimeBarChart = ({
     confidenceIntervalMethod,
     yAxisMaxConfig,
 }: PrevalenceOverTimeBarChartProps) => {
-    const nullFirstData = data.map((variantData) => {
-        return {
-            content: variantData.content.sort(sortNullToBeginningThenByDate),
-            displayName: variantData.displayName,
-        };
-    });
+    const nullFirstData = data
+        .filter((prevalenceOverTimeData) => prevalenceOverTimeData.content.length > 0)
+        .map((variantData) => {
+            return {
+                content: variantData.content.sort(sortNullToBeginningThenByDate),
+                displayName: variantData.displayName,
+            };
+        });
+
+    if (nullFirstData.length === 0) {
+        return <NoDataDisplay />;
+    }
 
     const datasets = nullFirstData.map((graphData, index) => getDataset(graphData, index, confidenceIntervalMethod));
 

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time-bubble-chart.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time-bubble-chart.tsx
@@ -5,6 +5,7 @@ import { type PrevalenceOverTimeData } from '../../query/queryPrevalenceOverTime
 import { addUnit, minusTemporal } from '../../utils/temporalClass';
 import { getMinMaxNumber } from '../../utils/utils';
 import GsChart from '../components/chart';
+import { NoDataDisplay } from '../components/no-data-display';
 import { LogitScale } from '../shared/charts/LogitScale';
 import { singleGraphColorRGBAById } from '../shared/charts/colors';
 import { getYAxisMax, type YAxisMaxConfig } from '../shared/charts/getYAxisMax';
@@ -23,12 +24,18 @@ const PrevalenceOverTimeBubbleChart = ({
     yAxisScaleType,
     yAxisMaxConfig,
 }: PrevalenceOverTimeBubbleChartProps) => {
-    const nonNullDateRangeData = data.map((variantData) => {
-        return {
-            content: variantData.content.filter((dataPoint) => dataPoint.dateRange !== null),
-            displayName: variantData.displayName,
-        };
-    });
+    const nonNullDateRangeData = data
+        .filter((prevalenceOverTimeData) => prevalenceOverTimeData.content.length > 0)
+        .map((variantData) => {
+            return {
+                content: variantData.content.filter((dataPoint) => dataPoint.dateRange !== null),
+                displayName: variantData.displayName,
+            };
+        });
+
+    if (nonNullDateRangeData.length === 0) {
+        return <NoDataDisplay />;
+    }
 
     const firstDate = nonNullDateRangeData[0].content[0].dateRange!;
     const total = nonNullDateRangeData.map((graphData) => graphData.content.map((dataPoint) => dataPoint.total)).flat();

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time-line-chart.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time-line-chart.tsx
@@ -4,6 +4,7 @@ import { type TooltipItem } from 'chart.js/dist/types';
 import { maxInData } from './prevalence-over-time';
 import { type PrevalenceOverTimeData, type PrevalenceOverTimeVariantData } from '../../query/queryPrevalenceOverTime';
 import GsChart from '../components/chart';
+import { NoDataDisplay } from '../components/no-data-display';
 import { LogitScale } from '../shared/charts/LogitScale';
 import { singleGraphColorRGBAById } from '../shared/charts/colors';
 import {
@@ -29,12 +30,18 @@ const PrevalenceOverTimeLineChart = ({
     confidenceIntervalMethod,
     yAxisMaxConfig,
 }: PrevalenceOverTimeLineChartProps) => {
-    const nonNullDateRangeData = data.map((variantData) => {
-        return {
-            content: variantData.content.filter((dataPoint) => dataPoint.dateRange !== null),
-            displayName: variantData.displayName,
-        };
-    });
+    const nonNullDateRangeData = data
+        .filter((prevalenceOverTimeData) => prevalenceOverTimeData.content.length > 0)
+        .map((variantData) => {
+            return {
+                content: variantData.content.filter((dataPoint) => dataPoint.dateRange !== null),
+                displayName: variantData.displayName,
+            };
+        });
+
+    if (nonNullDateRangeData.length === 0) {
+        return <NoDataDisplay />;
+    }
 
     const datasets = nonNullDateRangeData
         .map((graphData, index) => getDataset(graphData, index, confidenceIntervalMethod))

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.stories.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.stories.tsx
@@ -1,11 +1,15 @@
+import type { StoryObj } from '@storybook/preact';
+import { expect, waitFor } from '@storybook/test';
+
+import { LapisUrlContext } from '../LapisUrlContext';
 import denominatorFilter from './__mockData__/denominatorFilter.json';
 import denominatorOneDataset from './__mockData__/denominatorFilterOneDataset.json';
 import numeratorFilterEG from './__mockData__/numeratorFilterEG.json';
 import numeratorFilterJN1 from './__mockData__/numeratorFilterJN1.json';
+import numeratorFilterNoData from './__mockData__/numeratorFilterNoData.json';
 import numeratorOneDataset from './__mockData__/numeratorFilterOneDataset.json';
 import { PrevalenceOverTime, type PrevalenceOverTimeProps } from './prevalence-over-time';
 import { AGGREGATED_ENDPOINT, LAPIS_URL } from '../../constants';
-import { LapisUrlContext } from '../LapisUrlContext';
 
 export default {
     title: 'Visualization/PrevalenceOverTime',
@@ -58,7 +62,7 @@ const Template = {
     ),
 };
 
-export const TwoVariants = {
+export const TwoVariants: StoryObj<PrevalenceOverTimeProps> = {
     ...Template,
     args: {
         numeratorFilter: [
@@ -74,10 +78,8 @@ export const TwoVariants = {
         height: '700px',
         lapisDateField: 'date',
         pageSize: 10,
-        yAxisMaxConfig: {
-            linear: 1,
-            logarithmic: 1,
-        },
+        yAxisMaxLinear: 1,
+        yAxisMaxLogarithmic: 1,
     },
     parameters: {
         fetchMock: {
@@ -134,7 +136,7 @@ export const TwoVariants = {
     },
 };
 
-export const OneVariant = {
+export const OneVariant: StoryObj<PrevalenceOverTimeProps> = {
     ...Template,
     args: {
         numeratorFilter: {
@@ -150,10 +152,8 @@ export const OneVariant = {
         height: '700px',
         lapisDateField: 'date',
         pageSize: 10,
-        yAxisMaxConfig: {
-            linear: 1,
-            logarithmic: 1,
-        },
+        yAxisMaxLinear: 1,
+        yAxisMaxLogarithmic: 1,
     },
     parameters: {
         fetchMock: {
@@ -191,5 +191,68 @@ export const OneVariant = {
                 },
             ],
         },
+    },
+};
+
+export const ShowsNoDataBanner: StoryObj<PrevalenceOverTimeProps> = {
+    ...Template,
+    args: {
+        numeratorFilter: {
+            displayName: 'EG',
+            lapisFilter: { country: 'USA', pangoLineage: 'BA.2.86*', dateFrom: '2023-10-01' },
+        },
+        denominatorFilter: { country: 'USA', dateFrom: '2023-10-01' },
+        granularity: 'day',
+        smoothingWindow: 7,
+        views: ['bar', 'line', 'bubble', 'table'],
+        confidenceIntervalMethods: ['wilson'],
+        width: '100%',
+        height: '700px',
+        lapisDateField: 'date',
+        pageSize: 10,
+        yAxisMaxLinear: 1,
+        yAxisMaxLogarithmic: 1,
+    },
+    parameters: {
+        fetchMock: {
+            mocks: [
+                {
+                    matcher: {
+                        name: 'numeratorOneVariant',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            country: 'USA',
+                            pangoLineage: 'BA.2.86*',
+                            dateFrom: '2023-10-01',
+                            fields: ['date'],
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: numeratorFilterNoData,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'denominatorOneVariant',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            country: 'USA',
+                            dateFrom: '2023-10-01',
+                            fields: ['date'],
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: numeratorFilterNoData,
+                    },
+                },
+            ],
+        },
+    },
+    play: async ({ canvas }) => {
+        await waitFor(() => expect(canvas.getByText('No data available.', { exact: false })).toBeVisible(), {
+            timeout: 10000,
+        });
     },
 };

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
@@ -80,7 +80,7 @@ export const PrevalenceOverTimeInner: FunctionComponent<PrevalenceOverTimeProps>
         return <ErrorDisplay error={error} />;
     }
 
-    if (data === null) {
+    if (data === null || data.every((variant) => variant.content.length === 0)) {
         return <NoDataDisplay />;
     }
 


### PR DESCRIPTION
Resolves #502

### Summary
Adds a guard against missing data. It then shows "No data available". Also fixes the error, that when no data is returned the sliding window still works.

Moreover, a general guard was introduced to each of the charts (bar, line, bubble), so they don't throw an error, when they get no data.

<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
