### PR TITLE
fix(components): mutation over time worker runs on message change

### DIFF
--- a/components/src/preact/mutationsOverTime/mutations-over-time.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.tsx
@@ -63,15 +63,21 @@ export const MutationsOverTimeInner: FunctionComponent<MutationsOverTimeProps> =
     const lapis = useContext(LapisUrlContext);
     const { lapisFilter, sequenceType, granularity, lapisDateField } = componentProps;
 
-    const { data, error, isLoading } = useWebWorker<MutationOverTimeQuery, MutationOverTimeWorkerResponse>(
-        {
+    const messageToWorker = useMemo(() => {
+        return {
             lapisFilter,
             sequenceType,
             granularity,
             lapisDateField,
             lapis,
-        },
-        new MutationOverTimeWorker() as Worker,
+        };
+    }, [granularity, lapis, lapisDateField, lapisFilter, sequenceType]);
+
+    const worker = useMemo(() => new MutationOverTimeWorker(), []);
+
+    const { data, error, isLoading } = useWebWorker<MutationOverTimeQuery, MutationOverTimeWorkerResponse>(
+        messageToWorker,
+        worker,
     );
 
     if (isLoading) {

--- a/components/src/preact/webWorkers/useWebWorker.ts
+++ b/components/src/preact/webWorkers/useWebWorker.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 
 export function useWebWorker<Request, Response>(messageToWorker: Request, worker: Worker) {
     const [data, setData] = useState<Response | undefined>(undefined);
@@ -37,15 +37,11 @@ export function useWebWorker<Request, Response>(messageToWorker: Request, worker
             setError(new Error(`Worker received a message that it cannot deserialize: ${event.data}`));
             setIsLoading(false);
         };
+    }, [worker]);
 
-        return () => {
-            worker.terminate();
-        };
-    }, []);
-
-    useMemo(() => {
+    useEffect(() => {
         worker.postMessage(messageToWorker);
-    }, [messageToWorker]);
+    }, [messageToWorker, worker]);
 
     return { data, error, isLoading };
 }


### PR DESCRIPTION
Resolves #509

### Summary
Fixes the bug, that the mutation over time component in storybook does not update on controls change

<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
