### PR TITLE
feat(components): remove handleOnBlur function and dispatch event from MutationFilterInner

### DIFF
--- a/components/src/preact/mutationFilter/mutation-filter.tsx
+++ b/components/src/preact/mutationFilter/mutation-filter.tsx
@@ -87,18 +87,6 @@ export const MutationFilterInner: FunctionComponent<MutationFilterInnerProps> = 
         );
     };
 
-    const handleOnBlur = () => {
-        const detail = mapToMutationFilterStrings(selectedFilters);
-
-        formRef.current?.dispatchEvent(
-            new CustomEvent<SelectedMutationFilterStrings>('gs-mutation-filter-on-blur', {
-                detail,
-                bubbles: true,
-                composed: true,
-            }),
-        );
-    };
-
     const handleInputChange = (event: Event) => {
         setInputValue((event.target as HTMLInputElement).value);
         setIsError(false);
@@ -124,7 +112,6 @@ export const MutationFilterInner: FunctionComponent<MutationFilterInnerProps> = 
                         value={inputValue}
                         onInput={handleInputChange}
                         placeholder={getPlaceholder(referenceGenome)}
-                        onBlur={handleOnBlur}
                     />
                     <button type='submit' className='btn btn-xs m-1'>
                         +

--- a/components/src/web-components/input/gs-mutation-filter.stories.ts
+++ b/components/src/web-components/input/gs-mutation-filter.stories.ts
@@ -21,7 +21,7 @@ const meta: Meta<MutationFilterProps> = {
     component: 'gs-mutation-filter',
     parameters: withComponentDocs({
         actions: {
-            handles: ['gs-mutation-filter-changed', 'gs-mutation-filter-on-blur', ...previewHandles],
+            handles: ['gs-mutation-filter-changed', ...previewHandles],
         },
         fetchMock: {},
         componentDocs: {
@@ -98,32 +98,6 @@ export const FiresFilterChangedEvent: StoryObj<MutationFilterProps> = {
                     }),
                 ),
             );
-        });
-    },
-};
-
-export const FiresFilterOnBlurEvent: StoryObj<MutationFilterProps> = {
-    ...Template,
-    play: async ({ canvasElement, step }) => {
-        const canvas = await withinShadowRoot(canvasElement, 'gs-mutation-filter');
-
-        const inputField = () => canvas.getByPlaceholderText('Enter a mutation', { exact: false });
-        const listenerMock = fn();
-        await step('Setup event listener mock', async () => {
-            canvasElement.addEventListener('gs-mutation-filter-on-blur', listenerMock);
-        });
-
-        await step('wait until data is loaded', async () => {
-            await waitFor(() => {
-                return expect(inputField()).toBeEnabled();
-            });
-        });
-
-        await step('Move outside of input', async () => {
-            await userEvent.type(inputField(), 'A123T');
-            await userEvent.tab();
-
-            await expect(listenerMock).toHaveBeenCalled();
         });
     },
 };

--- a/components/src/web-components/input/gs-mutation-filter.tsx
+++ b/components/src/web-components/input/gs-mutation-filter.tsx
@@ -53,16 +53,6 @@ import { PreactLitAdapter } from '../PreactLitAdapter';
  * Fired when:
  * - The user has submitted a valid mutation or insertion
  * - The user has removed a mutation or insertion
- *
- * @fires {CustomEvent<{
- *      nucleotideMutations: string[],
- *      aminoAcidMutations: string[],
- *      nucleotideInsertions: string[],
- *      aminoAcidInsertions: string[]
- *  }>} gs-mutation-filter-on-blur
- * Fired when:
- * - the mutation filter has lost focus
- * Contains the selected mutations in the format
  */
 @customElement('gs-mutation-filter')
 export class MutationFilterComponent extends PreactLitAdapter {
@@ -108,7 +98,6 @@ declare global {
 
     interface HTMLElementEventMap {
         'gs-mutation-filter-changed': CustomEvent<SelectedMutationFilterStrings>;
-        'gs-mutation-filter-on-blur': CustomEvent<SelectedMutationFilterStrings>;
     }
 }
 


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

In https://github.com/GenSpectrum/dashboard-components/pull/500#discussion_r1843558199 we discovered that blur dispatch events are not working as intended. (e.g. it did not fire if a user moved outside of the component if they moved outside after deleting mutations). We decided that this functionality is not needed and is tedious to implement so we will just remove it. 

The dispatch event was unused by dashboards (we use the change events dispatch event instead). 

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] Corresponding PR in dashboards will need to be merged:https://github.com/GenSpectrum/dashboards/pull/301
