### PR TITLE
fix(components): propagate UserFacingErrors through the web worker

### DIFF
--- a/components/src/preact/webWorkers/useWebWorker.ts
+++ b/components/src/preact/webWorkers/useWebWorker.ts
@@ -1,31 +1,53 @@
 import { useEffect, useState } from 'preact/hooks';
 
+import { UserFacingError } from '../components/error-display';
+
+export type LoadingWorkerStatus = {
+    status: 'loading';
+};
+export type SuccessWorkerStatus<Response> = {
+    status: 'success';
+    data: Response;
+};
+export type ErrorWorkerStatus =
+    | {
+          status: 'error';
+          userFacing: false;
+          error: Error;
+      }
+    | {
+          status: 'error';
+          userFacing: true;
+          headline: string;
+          error: Error;
+      };
+export type WorkerStatus<Response> = LoadingWorkerStatus | SuccessWorkerStatus<Response> | ErrorWorkerStatus;
+
 export function useWebWorker<Request, Response>(messageToWorker: Request, worker: Worker) {
     const [data, setData] = useState<Response | undefined>(undefined);
     const [error, setError] = useState<Error | undefined>(undefined);
     const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
-        worker.onmessage = (
-            event: MessageEvent<{
-                status: 'loading' | 'success' | 'error';
-                data?: Response;
-                error?: Error;
-            }>,
-        ) => {
-            const { status, data, error } = event.data;
+        worker.onmessage = (event: MessageEvent<WorkerStatus<Response>>) => {
+            const eventData = event.data;
+            const status = eventData.status;
 
             switch (status) {
                 case 'loading':
                     setIsLoading(true);
                     break;
                 case 'success':
-                    setData(data);
+                    setData(eventData.data);
                     setError(undefined);
                     setIsLoading(false);
                     break;
                 case 'error':
-                    setError(error);
+                    setError(
+                        eventData.userFacing
+                            ? new UserFacingError(eventData.headline, eventData.error.message)
+                            : eventData.error,
+                    );
                     setIsLoading(false);
                     break;
                 default:

--- a/components/src/preact/webWorkers/workerFunction.ts
+++ b/components/src/preact/webWorkers/workerFunction.ts
@@ -1,14 +1,30 @@
+import { type ErrorWorkerStatus, type LoadingWorkerStatus, type SuccessWorkerStatus } from './useWebWorker';
+import { UserFacingError } from '../components/error-display';
+
 export async function workerFunction<R>(queryFunction: () => R) {
     try {
-        postMessage({ status: 'loading' });
+        postMessage({ status: 'loading' } satisfies LoadingWorkerStatus);
 
         const workerResponse = await queryFunction();
 
         postMessage({
             status: 'success',
             data: workerResponse,
-        });
+        } satisfies SuccessWorkerStatus<R>);
     } catch (error) {
-        postMessage({ status: 'error', error });
+        postMessage(
+            (error instanceof UserFacingError
+                ? {
+                      status: 'error',
+                      userFacing: true,
+                      headline: error.headline,
+                      error,
+                  }
+                : {
+                      status: 'error',
+                      userFacing: false,
+                      error: error instanceof Error ? error : new Error(`${error}`),
+                  }) satisfies ErrorWorkerStatus,
+        );
     }
 }


### PR DESCRIPTION

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

Apparently, the concrete error type doesn't make it across the wire. Any error type that you send back from a web worker will be deserialized as a plain `Error`.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
