### PR TITLE
feat(components): export utils as extra entrypoint

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -13,7 +13,7 @@ Usage with a bundler in HTML:
 ```html
 <body>
     <script>
-        import '@genspectrum/dashboard-components';
+        import '@genspectrum/dashboard-components/components';
         import '@genspectrum/dashboard-components/style.css';
     </script>
     <gs-app lapis="https://your.lapis.url"></gs-app>
@@ -41,6 +41,13 @@ We also provide a standalone version of the components that can be used without 
 
 Internally, the components use [Preact](https://preactjs.com/).
 We use [Lit](https://lit.dev/) to create web components.
+
+We have split the package into two parts:
+
+-   The components, which are web components that can be used in the browser.
+    -   They can be imported with `import '@genspectrum/dashboard-components/components';`
+-   utility functions, which can also be used in a node environment.
+    -   They can be imported with `import '@genspectrum/dashboard-components/util';`
 
 We primarily provide two kinds of components:
 
@@ -130,4 +137,9 @@ We follow this testing concept:
 
 #### Mocking
 
-All our tests use mock data. In general, we use `storybook-addon-fetch-mock` for all outgoing requests. This strategy cannot be used for components that use web workers, like gs-mutations-over-time. Therefore, we created custom mock workers that return mocked data. The mock workers are enabled in the package.json using Node.js [subpath imports](https://nodejs.org/api/packages.html#subpath-imports), following the guide from [storybook](https://storybook.js.org/docs/writing-stories/mocking-data-and-modules/mocking-modules). This ensures that when importing the worker in the component, the mock worker is used inside Storybook instead of the real worker.
+All our tests use mock data. In general, we use `storybook-addon-fetch-mock` for all outgoing requests. This strategy
+cannot be used for components that use web workers, like gs-mutations-over-time. Therefore, we created custom mock
+workers that return mocked data. The mock workers are enabled in the package.json using
+Node.js [subpath imports](https://nodejs.org/api/packages.html#subpath-imports), following the guide
+from [storybook](https://storybook.js.org/docs/writing-stories/mocking-data-and-modules/mocking-modules). This ensures
+that when importing the worker in the component, the mock worker is used inside Storybook instead of the real worker.

--- a/components/package.json
+++ b/components/package.json
@@ -27,10 +27,15 @@
         ]
     },
     "exports": {
-        ".": {
-            "import": "./dist/dashboard-components.js",
-            "require": "./dist/dashboard-components.js",
-            "types": "./dist/genspectrum-components.d.ts"
+        "./components": {
+            "import": "./dist/components.js",
+            "require": "./dist/components.js",
+            "types": "./dist/components.d.ts"
+        },
+        "./util": {
+            "import": "./dist/util.js",
+            "require": "./dist/util.js",
+            "types": "./dist/util.d.ts"
         },
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/components/src/componentsEntrypoint.ts
+++ b/components/src/componentsEntrypoint.ts
@@ -1,7 +1,6 @@
 export * from './web-components';
 
 export { type ErrorEvent, UserFacingError } from './preact/components/error-display';
-export { type DateRangeOption, dateRangeOptionPresets } from './preact/dateRangeSelector/dateRangeOption';
 
 declare global {
     interface HTMLElementEventMap {

--- a/components/src/standaloneEntrypoint.ts
+++ b/components/src/standaloneEntrypoint.ts
@@ -1,0 +1,2 @@
+export * from './utilEntrypoint';
+export * from './componentsEntrypoint';

--- a/components/src/utilEntrypoint.ts
+++ b/components/src/utilEntrypoint.ts
@@ -1,0 +1,1 @@
+export { type DateRangeOption, dateRangeOptionPresets } from './preact/dateRangeSelector/dateRangeOption';

--- a/components/vite.release-standalone.config.ts
+++ b/components/vite.release-standalone.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
         lib: {
             formats: ['es'],
             entry: {
-                'dashboard-components': 'dist/dashboard-components.js',
+                'dashboard-components': 'src/standaloneEntrypoint.ts',
             },
         },
         sourcemap: true,

--- a/components/vite.release.config.ts
+++ b/components/vite.release.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
         lib: {
             formats: ['es'],
             entry: {
-                'dashboard-components': 'src/index.ts',
+                components: 'src/componentsEntrypoint.ts',
+                util: 'src/utilEntrypoint.ts',
             },
         },
         sourcemap: true,

--- a/examples/React/src/App.tsx
+++ b/examples/React/src/App.tsx
@@ -1,6 +1,6 @@
 import {useEffect, useState} from 'react';
-import {DateRangeOption, dateRangeOptionPresets} from '@genspectrum/dashboard-components';
-import '@genspectrum/dashboard-components';
+import {DateRangeOption, dateRangeOptionPresets} from '@genspectrum/dashboard-components/util';
+import '@genspectrum/dashboard-components/components';
 import '@genspectrum/dashboard-components/style.css';
 
 function App() {
@@ -10,7 +10,7 @@ function App() {
     });
     const [dateRange, setDateRange] = useState({
         dateFrom: '2021-01-01',
-        dateTo: '2022-01-01',
+        dateTo: '2021-12-31',
     });
 
     useEffect(() => {
@@ -72,7 +72,7 @@ function App() {
             ></gs-location-filter>
             <gs-date-range-selector
                 dateRangeOptions={JSON.stringify(dataRangeOptions)}
-                initialValue={dateRangeOptionPresets.last6Months.label}
+                initialValue={'2021'}
             ></gs-date-range-selector>
             <div style={{display: 'flex', flexDirection: 'row'}}>
                 <div>

--- a/examples/plainJavascript/index.html
+++ b/examples/plainJavascript/index.html
@@ -6,7 +6,7 @@
         <title>Components Demo</title>
         <script
             type="module"
-            src="node_modules/@genspectrum/dashboard-components/dist/dashboard-components.js"
+            src="node_modules/@genspectrum/dashboard-components/dist/components.js"
         ></script>
         <link
             rel="stylesheet"


### PR DESCRIPTION
BREAKING CHANGE: DateRangeOption and dateRangeOptionPresets now in own sub package

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
When importing our components utility functions (like dateRangeOptionPresets) in a node environment or on the server side of an astro application we get an error, that "HTMLElement not defined". This message occurs, because the lit element class extends HTMLElement. 
To provide users of our package also access to our utility functions, we put them into an own sub-package. They can now be imported through e.g.: `import { dateRangeOptionPresets } from '@genspectrum/dashboard-components/util';`

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
~~- [ ] The implemented feature is covered by an appropriate test.~~
