### PR TITLE
feat(components): gs-relative-growth-advantage: show better errors when fit fails

### DIFF
--- a/components/src/preact/components/no-data-display.tsx
+++ b/components/src/preact/components/no-data-display.tsx
@@ -1,9 +1,9 @@
 import { type FunctionComponent } from 'preact';
 
-export const NoDataDisplay: FunctionComponent = () => {
+export const NoDataDisplay: FunctionComponent<{ message?: string }> = ({ message = 'No data available.' }) => {
     return (
         <div className='h-full w-full rounded-md border-2 border-gray-100 p-2 flex items-center justify-center'>
-            <div>No data available.</div>
+            <div>{message}</div>
         </div>
     );
 };

--- a/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
+++ b/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
@@ -3,6 +3,7 @@ import { useContext, useState } from 'preact/hooks';
 
 import RelativeGrowthAdvantageChart from './relative-growth-advantage-chart';
 import {
+    NotEnoughDataToComputeFitError,
     queryRelativeGrowthAdvantage,
     type RelativeGrowthAdvantageData,
 } from '../../query/queryRelativeGrowthAdvantage';
@@ -62,6 +63,11 @@ export const RelativeGrowthAdvantageInner: FunctionComponent<RelativeGrowthAdvan
     }
 
     if (error !== null) {
+        if (error instanceof NotEnoughDataToComputeFitError) {
+            return (
+                <NoDataDisplay message='It was not possible to estimate the relative growth advantage due to insufficient data in the specified filter.' />
+            );
+        }
         throw error;
     }
 


### PR DESCRIPTION



resolves #506


### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->




### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

* show a nice error when we can't connect to the cov spectrum server
![grafik](https://github.com/user-attachments/assets/17391ca2-35e4-4d29-b2b7-694b5191d08e)

* when the cov spectrum server errors, we assume that it didn't have enough data to compute a fit
 
![grafik](https://github.com/user-attachments/assets/90f7bd0c-2f65-4a82-8ef3-7809448936f8)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
