### PR TITLE
fix(components): hide proportion on width of cell

### DIFF
--- a/components/src/preact/mutationsOverTime/mutations-over-time-grid.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time-grid.tsx
@@ -43,7 +43,6 @@ const MutationsOverTimeGrid: FunctionComponent<MutationsOverTimeGridProps> = ({ 
                     gridTemplateRows: `repeat(${shownMutations.length}, 24px)`,
                     gridTemplateColumns: `${MUTATION_CELL_WIDTH_REM}rem repeat(${dates.length}, minmax(0.05rem, 1fr))`,
                 }}
-                className='@container'
             >
                 {shownMutations.map((mutation, rowIndex) => {
                     return (
@@ -122,9 +121,9 @@ const ProportionCell: FunctionComponent<{
                         backgroundColor: getColorWithingScale(value.proportion, colorScale),
                         color: getTextColorForScale(value.proportion, colorScale),
                     }}
-                    className={`w-full h-full text-center hover:font-bold text-xs group`}
+                    className={`w-full h-full text-center hover:font-bold text-xs group @container`}
                 >
-                    <span className='invisible @[30rem]:visible'>{formatProportion(value.proportion, 0)}</span>
+                    <span className='invisible @[2rem]:visible'>{formatProportion(value.proportion, 0)}</span>
                 </div>
             </Tooltip>
         </div>


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #538

This is a draft, since we need to decide at which width should the numbers be hidden. Currently, I tried to use roughly the width of the entry '100%' .

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Hides the numbers on the proportion cells in the mutation over time component, when the cell is too small to show the number. 

This is a fix. Right now it hides the numbers dependent on the width of the full table. This does not work, since there can be a variable number of columns.



### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

This is the smallest width, where the numbers are still showing:
![grafik](https://github.com/user-attachments/assets/ae931ef1-4bdd-47b8-b9b0-b26708468489)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
