### PR TITLE
fix(components): gs-text-input: validate attributes

### DIFF
--- a/components/src/preact/textInput/text-input.stories.tsx
+++ b/components/src/preact/textInput/text-input.stories.tsx
@@ -6,6 +6,7 @@ import { TextInput, type TextInputProps } from './text-input';
 import { previewHandles } from '../../../.storybook/preview';
 import { AGGREGATED_ENDPOINT, LAPIS_URL } from '../../constants';
 import { LapisUrlContext } from '../LapisUrlContext';
+import { expectInvalidAttributesErrorMessage } from '../shared/stories/expectInvalidAttributesErrorMessage';
 
 const meta: Meta<TextInputProps> = {
     title: 'Input/TextInput',
@@ -90,6 +91,19 @@ export const WithInitialValue: StoryObj<TextInputProps> = {
         await waitFor(() => {
             const input = canvas.getByPlaceholderText('Enter a host name', { exact: false });
             expect(input).toHaveValue('Homo sapiens');
+        });
+    },
+};
+
+export const WithNoLapisField: StoryObj<TextInputProps> = {
+    ...Default,
+    args: {
+        ...Default.args,
+        lapisField: '',
+    },
+    play: async ({ canvasElement, step }) => {
+        step('expect error message', async () => {
+            await expectInvalidAttributesErrorMessage(canvasElement, 'String must contain at least 1 character(s)');
         });
     },
 };

--- a/components/src/preact/textInput/text-input.tsx
+++ b/components/src/preact/textInput/text-input.tsx
@@ -1,5 +1,6 @@
 import { type FunctionComponent } from 'preact';
 import { useContext, useRef } from 'preact/hooks';
+import z from 'zod';
 
 import { fetchAutocompleteList } from './fetchAutocompleteList';
 import { LapisUrlContext } from '../LapisUrlContext';
@@ -9,21 +10,25 @@ import { NoDataDisplay } from '../components/no-data-display';
 import { ResizeContainer } from '../components/resize-container';
 import { useQuery } from '../useQuery';
 
-export interface TextInputInnerProps {
-    lapisField: string;
-    placeholderText: string;
-    initialValue: string;
-}
+const textInputInnerPropsSchema = z.object({
+    lapisField: z.string().min(1),
+    placeholderText: z.string().optional(),
+    initialValue: z.string().optional(),
+});
 
-export interface TextInputProps extends TextInputInnerProps {
-    width: string;
-}
+const textInputPropsSchema = textInputInnerPropsSchema.extend({
+    width: z.string(),
+});
 
-export const TextInput: FunctionComponent<TextInputProps> = ({ width, ...innerProps }) => {
+export type TextInputInnerProps = z.infer<typeof textInputInnerPropsSchema>;
+export type TextInputProps = z.infer<typeof textInputPropsSchema>;
+
+export const TextInput: FunctionComponent<TextInputProps> = (props) => {
+    const { width, ...innerProps } = props;
     const size = { width, height: '3rem' };
 
     return (
-        <ErrorBoundary size={size} layout='horizontal'>
+        <ErrorBoundary size={size} layout='horizontal' componentProps={props} schema={textInputPropsSchema}>
             <ResizeContainer size={size}>
                 <TextInputInner {...innerProps} />
             </ResizeContainer>
@@ -76,7 +81,7 @@ const TextInputInner: FunctionComponent<TextInputInnerProps> = ({ lapisField, pl
             <input
                 type='text'
                 class='input input-bordered w-full'
-                placeholder={placeholderText !== undefined ? placeholderText : lapisField}
+                placeholder={placeholderText ?? lapisField}
                 onInput={onInput}
                 ref={inputRef}
                 list={lapisField}

--- a/components/src/web-components/input/gs-text-input.tsx
+++ b/components/src/web-components/input/gs-text-input.tsx
@@ -27,7 +27,7 @@ export class TextInputComponent extends PreactLitAdapter {
      * The initial value to use for this text input.
      */
     @property()
-    initialValue: string = '';
+    initialValue: string | undefined = undefined;
 
     /**
      * Required.
@@ -42,7 +42,7 @@ export class TextInputComponent extends PreactLitAdapter {
      * The placeholder text to display in the input field.
      */
     @property()
-    placeholderText: string = '';
+    placeholderText: string | undefined = undefined;
 
     /**
      * The width of the component.


### PR DESCRIPTION
Resolves: #571

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

Validates the input of gs-text-input and changes the default value of "initialValue" and "placeholderText" to undefined.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
