### PR TITLE
fix(components): set default of `enableMapNavigation` to false

### DIFF
--- a/components/src/web-components/visualization/gs-sequences-by-location.stories.ts
+++ b/components/src/web-components/visualization/gs-sequences-by-location.stories.ts
@@ -17,7 +17,7 @@ const codeExample = `<gs-sequences-by-location
     lapisFilter='{"dateFrom":"2022-01-01","dateTo":"2022-04-01"}'
     lapisLocationField='country'
     mapSource='{"type":"topojson","url":"https://mock.map.data/topo.json","topologyObjectsKey":"countries"}'
-    enableMapNavigation='false'
+    enableMapNavigation
     width='1100px'
     height='800px'
     views='["map"]'
@@ -25,7 +25,7 @@ const codeExample = `<gs-sequences-by-location
     offsetX='0'
     offsetY='10'
     pageSize='5'
-/>`;
+></gs-sequences-by-location>`;
 
 const meta: Meta<Required<SequencesByLocationProps>> = {
     title: 'Visualization/Sequences by location',

--- a/components/src/web-components/visualization/gs-sequences-by-location.tsx
+++ b/components/src/web-components/visualization/gs-sequences-by-location.tsx
@@ -130,7 +130,7 @@ export class SequencesByLocationComponent extends PreactLitAdapterWithGridJsStyl
      * Enable map navigation (dragging, keyboard navigation, zooming).
      */
     @property({ type: Boolean })
-    enableMapNavigation: boolean = true;
+    enableMapNavigation: boolean = false;
 
     /**
      * The width of the component.


### PR DESCRIPTION


### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes 
According to the HTML spec a boolean attribute can only bet set to `true` by setting it. Absence it considered as false which only works if also the default is false.
### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
~~- [ ] The implemented feature is covered by an appropriate test.~~
