### PR TITLE
feat(components): Filter suggestion dropdown to only include values that exist with the current filters and add show the number of options

### DIFF
--- a/components/src/preact/lineageFilter/fetchLineageAutocompleteList.spec.ts
+++ b/components/src/preact/lineageFilter/fetchLineageAutocompleteList.spec.ts
@@ -7,7 +7,7 @@ describe('fetchLineageAutocompleteList', () => {
     test('should add sublineage values', async () => {
         lapisRequestMocks.aggregated({ fields: ['lineageField'] }, { data: [{ lineageField: 'B.1.1.7', count: 1 }] });
 
-        const result = await fetchLineageAutocompleteList(DUMMY_LAPIS_URL, 'lineageField');
+        const result = await fetchLineageAutocompleteList({}, DUMMY_LAPIS_URL, 'lineageField');
 
         expect(result).to.deep.equal([
             {

--- a/components/src/preact/lineageFilter/fetchLineageAutocompleteList.spec.ts
+++ b/components/src/preact/lineageFilter/fetchLineageAutocompleteList.spec.ts
@@ -9,6 +9,27 @@ describe('fetchLineageAutocompleteList', () => {
 
         const result = await fetchLineageAutocompleteList(DUMMY_LAPIS_URL, 'lineageField');
 
-        expect(result).to.deep.equal(['B.1.1.7', 'B.1.1.7*']);
+        expect(result).to.deep.equal([
+            {
+                count: 1,
+                lineageField: 'B.1.1.7',
+            },
+            {
+                count: 1,
+                lineageField: 'B.1.1.7*',
+            },
+            {
+                count: 1,
+                lineageField: 'B.1.1*',
+            },
+            {
+                count: 1,
+                lineageField: 'B.1*',
+            },
+            {
+                count: 1,
+                lineageField: 'B*',
+            },
+        ]);
     });
 });

--- a/components/src/preact/lineageFilter/fetchLineageAutocompleteList.ts
+++ b/components/src/preact/lineageFilter/fetchLineageAutocompleteList.ts
@@ -1,9 +1,57 @@
 import { FetchAggregatedOperator } from '../../operator/FetchAggregatedOperator';
 
+type GroupType = Record<string, string> & { count: number };
+
 export async function fetchLineageAutocompleteList(lapis: string, field: string, signal?: AbortSignal) {
     const fetchAggregatedOperator = new FetchAggregatedOperator<Record<string, string>>({}, [field]);
 
     const data = (await fetchAggregatedOperator.evaluate(lapis, signal)).content;
 
-    return data.flatMap((item) => [item[field], `${item[field]}*`]).sort();
+    const output: (Record<string, string> & {
+        count: number;
+    })[] = [];
+
+    const findOrCreateGroup = (pattern: string) => {
+        let group = output.find((item) => item[field] === pattern) as GroupType | undefined;
+        if (!group) {
+            group = { count: 0, [field]: pattern } as GroupType;
+            output.push(group);
+        }
+        return group;
+    };
+
+    data.forEach((item) => {
+        if (!item[field]) {
+            return;
+        }
+        const parts = item[field].split('.');
+        for (let step = 0; step < parts.length; step++) {
+            const section = `${parts.slice(0, step + 1).join('.')}*`;
+            const group = findOrCreateGroup(section);
+            group.count += item.count;
+        }
+        const group = findOrCreateGroup(item[field]);
+        group.count += item.count;
+    });
+
+    return sortDataByField(output, field);
 }
+
+const sortDataByField = (data: (Record<string, string> & { count: number })[], field: string) => {
+    return data.sort((a, b) => {
+        const aValue = a[field];
+        const bValue = b[field];
+
+        if (aValue === undefined && bValue !== undefined) {
+            return 1;
+        }
+        if (bValue === undefined && aValue !== undefined) {
+            return -1;
+        }
+        if (aValue === undefined && bValue === undefined) {
+            return 0;
+        }
+
+        return aValue.localeCompare(bValue);
+    });
+};

--- a/components/src/preact/lineageFilter/fetchLineageAutocompleteList.ts
+++ b/components/src/preact/lineageFilter/fetchLineageAutocompleteList.ts
@@ -1,9 +1,15 @@
 import { FetchAggregatedOperator } from '../../operator/FetchAggregatedOperator';
+import { type LapisFilter } from '../../types';
 
 type GroupType = Record<string, string> & { count: number };
 
-export async function fetchLineageAutocompleteList(lapis: string, field: string, signal?: AbortSignal) {
-    const fetchAggregatedOperator = new FetchAggregatedOperator<Record<string, string>>({}, [field]);
+export async function fetchLineageAutocompleteList(
+    lapisFilter: LapisFilter,
+    lapis: string,
+    field: string,
+    signal?: AbortSignal,
+) {
+    const fetchAggregatedOperator = new FetchAggregatedOperator<Record<string, string>>(lapisFilter, [field]);
 
     const data = (await fetchAggregatedOperator.evaluate(lapis, signal)).content;
 

--- a/components/src/preact/lineageFilter/lineage-filter.stories.tsx
+++ b/components/src/preact/lineageFilter/lineage-filter.stories.tsx
@@ -35,6 +35,7 @@ const meta: Meta = {
     },
     args: {
         lapisField: 'pangoLineage',
+        lapisFilter: {},
         placeholderText: 'Enter lineage',
         initialValue: '',
         width: '100%',
@@ -48,6 +49,7 @@ export const Default: StoryObj<LineageFilterProps> = {
         <LapisUrlContext.Provider value={LAPIS_URL}>
             <LineageFilter
                 lapisField={args.lapisField}
+                lapisFilter={args.lapisFilter}
                 placeholderText={args.placeholderText}
                 initialValue={args.initialValue}
                 width={args.width}

--- a/components/src/preact/lineageFilter/lineage-filter.tsx
+++ b/components/src/preact/lineageFilter/lineage-filter.tsx
@@ -3,6 +3,7 @@ import { useContext, useRef, useState } from 'preact/hooks';
 import z from 'zod';
 
 import { fetchLineageAutocompleteList } from './fetchLineageAutocompleteList';
+import { lapisFilterSchema } from '../../types';
 import { LapisUrlContext } from '../LapisUrlContext';
 import { ErrorBoundary } from '../components/error-boundary';
 import { LoadingDisplay } from '../components/loading-display';
@@ -12,6 +13,7 @@ import { useQuery } from '../useQuery';
 
 const lineageFilterInnerPropsSchema = z.object({
     lapisField: z.string().min(1),
+    lapisFilter: lapisFilterSchema,
     placeholderText: z.string().optional(),
     initialValue: z.string(),
 });
@@ -38,6 +40,7 @@ export const LineageFilter: FunctionComponent<LineageFilterProps> = (props) => {
 
 const LineageFilterInner: FunctionComponent<LineageFilterInnerProps> = ({
     lapisField,
+    lapisFilter,
     placeholderText,
     initialValue,
 }) => {
@@ -49,8 +52,8 @@ const LineageFilterInner: FunctionComponent<LineageFilterInnerProps> = ({
     const [inputValue, setInputValue] = useState(initialValue || '');
 
     const { data, error, isLoading } = useQuery(
-        () => fetchLineageAutocompleteList(lapis, lapisField),
-        [lapisField, lapis],
+        () => fetchLineageAutocompleteList(lapisFilter, lapis, lapisField),
+        [lapisFilter, lapisField, lapis],
     );
 
     if (isLoading) {

--- a/components/src/preact/lineageFilter/lineage-filter.tsx
+++ b/components/src/preact/lineageFilter/lineage-filter.tsx
@@ -85,7 +85,7 @@ const LineageFilterInner: FunctionComponent<LineageFilterInnerProps> = ({
         if (value === undefined) {
             return true;
         }
-        return data.includes(value);
+        return data.map((item) => item[lapisField]).includes(value);
     };
 
     return (
@@ -118,7 +118,10 @@ const LineageFilterInner: FunctionComponent<LineageFilterInnerProps> = ({
             </div>
             <datalist id={lapisField}>
                 {data.map((item) => (
-                    <option value={item} key={item} />
+                    <option
+                        value={item[lapisField]}
+                        key={item[lapisField]}
+                    >{`${item[lapisField]} (${item['count']})`}</option>
                 ))}
             </datalist>
         </>

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
@@ -229,7 +229,7 @@ const PrevalenceOverTimeInfo: FunctionComponent<PrevalenceOverTimeProps> = (comp
     const lapis = useContext(LapisUrlContext);
     return (
         <Info>
-            <InfoHeadline1>Prevalence over time</InfoHeadline1>
+            <InfoHeadline1>Info for Prevalence over time</InfoHeadline1>
             <InfoParagraph>
                 This presents the proportion of one or more variants per <b>{granularity}</b>
                 {smoothingWindow > 0 && `, smoothed using a ${smoothingWindow}-${granularity} sliding window`}. The

--- a/components/src/preact/textInput/fetchAutocompleteList.ts
+++ b/components/src/preact/textInput/fetchAutocompleteList.ts
@@ -1,9 +1,35 @@
 import { FetchAggregatedOperator } from '../../operator/FetchAggregatedOperator';
+import { type LapisFilter } from '../../types';
 
-export async function fetchAutocompleteList(lapis: string, field: string, signal?: AbortSignal) {
-    const fetchAggregatedOperator = new FetchAggregatedOperator<Record<string, string>>({}, [field]);
+export async function fetchAutocompleteList(
+    lapisFilter: LapisFilter,
+    lapis: string,
+    field: string,
+    signal?: AbortSignal,
+) {
+    const fetchAggregatedOperator = new FetchAggregatedOperator<Record<string, string>>(lapisFilter, [field]);
 
     const data = (await fetchAggregatedOperator.evaluate(lapis, signal)).content;
 
-    return data.map((item) => item[field]).sort();
+    return sortDataByField(data, field);
 }
+
+const sortDataByField = (data: (Record<string, string | null> & { count: number })[], field: string) => {
+    return data.sort((a, b) => {
+        const aValue = a[field];
+        const bValue = b[field];
+
+        if ((aValue === undefined || aValue === null) && bValue !== undefined && bValue !== null) {
+            return 1;
+        }
+        if ((bValue === undefined || bValue === null) && aValue !== undefined && aValue !== null) {
+            return -1;
+        }
+        if ((aValue === undefined || aValue === null) && (bValue === undefined || bValue === null)) {
+            return 0;
+        }
+
+        // Compare values when both are non-null and defined
+        return aValue!.localeCompare(bValue!);
+    });
+};

--- a/components/src/preact/textInput/fetchAutocompleteList.ts
+++ b/components/src/preact/textInput/fetchAutocompleteList.ts
@@ -11,25 +11,26 @@ export async function fetchAutocompleteList(
 
     const data = (await fetchAggregatedOperator.evaluate(lapis, signal)).content;
 
-    return sortDataByField(data, field);
+    const filteredData = data.filter((record) => record[field] !== null);
+
+    return sortDataByField(filteredData, field);
 }
 
-const sortDataByField = (data: (Record<string, string | null> & { count: number })[], field: string) => {
+const sortDataByField = (data: (Record<string, string> & { count: number })[], field: string) => {
     return data.sort((a, b) => {
         const aValue = a[field];
         const bValue = b[field];
 
-        if ((aValue === undefined || aValue === null) && bValue !== undefined && bValue !== null) {
+        if (aValue === undefined && bValue !== undefined) {
             return 1;
         }
-        if ((bValue === undefined || bValue === null) && aValue !== undefined && aValue !== null) {
+        if (bValue === undefined && aValue !== undefined) {
             return -1;
         }
-        if ((aValue === undefined || aValue === null) && (bValue === undefined || bValue === null)) {
+        if (aValue === undefined && bValue === undefined) {
             return 0;
         }
 
-        // Compare values when both are non-null and defined
-        return aValue!.localeCompare(bValue!);
+        return aValue.localeCompare(bValue);
     });
 };

--- a/components/src/preact/textInput/text-input.stories.tsx
+++ b/components/src/preact/textInput/text-input.stories.tsx
@@ -64,6 +64,7 @@ export const Default: StoryObj<TextInputProps> = {
     render: (args) => (
         <LapisUrlContext.Provider value={LAPIS_URL}>
             <TextInput
+                lapisFilter={args.lapisFilter}
                 lapisField={args.lapisField}
                 placeholderText={args.placeholderText}
                 initialValue={args.initialValue}
@@ -72,6 +73,7 @@ export const Default: StoryObj<TextInputProps> = {
         </LapisUrlContext.Provider>
     ),
     args: {
+        lapisFilter: {},
         lapisField: 'host',
         placeholderText: 'Enter a host name',
         initialValue: '',

--- a/components/src/preact/textInput/text-input.tsx
+++ b/components/src/preact/textInput/text-input.tsx
@@ -3,6 +3,7 @@ import { useContext, useRef, useState } from 'preact/hooks';
 import z from 'zod';
 
 import { fetchAutocompleteList } from './fetchAutocompleteList';
+import { lapisFilterSchema } from '../../types';
 import { LapisUrlContext } from '../LapisUrlContext';
 import { ErrorBoundary } from '../components/error-boundary';
 import { LoadingDisplay } from '../components/loading-display';
@@ -11,6 +12,7 @@ import { ResizeContainer } from '../components/resize-container';
 import { useQuery } from '../useQuery';
 
 const textInputInnerPropsSchema = z.object({
+    lapisFilter: lapisFilterSchema,
     lapisField: z.string().min(1),
     placeholderText: z.string().optional(),
     initialValue: z.string().optional(),
@@ -36,7 +38,12 @@ export const TextInput: FunctionComponent<TextInputProps> = (props) => {
     );
 };
 
-const TextInputInner: FunctionComponent<TextInputInnerProps> = ({ lapisField, placeholderText, initialValue }) => {
+const TextInputInner: FunctionComponent<TextInputInnerProps> = ({
+    lapisFilter,
+    lapisField,
+    placeholderText,
+    initialValue,
+}) => {
     const lapis = useContext(LapisUrlContext);
 
     const inputRef = useRef<HTMLInputElement>(null);
@@ -44,7 +51,10 @@ const TextInputInner: FunctionComponent<TextInputInnerProps> = ({ lapisField, pl
     const [hasInput, setHasInput] = useState<boolean>(!!initialValue);
     const [inputValue, setInputValue] = useState(initialValue || '');
 
-    const { data, error, isLoading } = useQuery(() => fetchAutocompleteList(lapis, lapisField), [lapisField, lapis]);
+    const { data, error, isLoading } = useQuery(
+        () => fetchAutocompleteList(lapisFilter, lapis, lapisField),
+        [lapisFilter, lapis, lapisField],
+    );
 
     if (isLoading) {
         return <LoadingDisplay />;

--- a/components/src/preact/textInput/text-input.tsx
+++ b/components/src/preact/textInput/text-input.tsx
@@ -78,7 +78,7 @@ const TextInputInner: FunctionComponent<TextInputInnerProps> = ({ lapisField, pl
         if (value === undefined) {
             return true;
         }
-        return data.includes(value);
+        return data.map((item) => item[lapisField]).includes(value);
     };
 
     return (
@@ -111,7 +111,11 @@ const TextInputInner: FunctionComponent<TextInputInnerProps> = ({ lapisField, pl
             </div>
             <datalist id={lapisField}>
                 {data.map((item) => (
-                    <option value={item} key={item} />
+                    <option
+                        value={item[lapisField]}
+                        key={item[lapisField]}
+                        style='white-space: nowrap;'
+                    >{`${item[lapisField]} (${item['count']})`}</option>
                 ))}
             </datalist>
         </>

--- a/components/src/web-components/input/gs-lineage-filter.stories.ts
+++ b/components/src/web-components/input/gs-lineage-filter.stories.ts
@@ -14,6 +14,7 @@ import { withinShadowRoot } from '../withinShadowRoot.story';
 const codeExample = String.raw`
 <gs-lineage-filter 
     lapisField="pangoLineage"
+    lapisFilter={{}}
     placeholderText="Enter lineage"
     initialValue="B.1.1.7"
     width="50%">
@@ -60,6 +61,7 @@ export const Default: StoryObj<Required<LineageFilterProps>> = {
             <div class="max-w-screen-lg">
                 <gs-lineage-filter
                     .lapisField=${args.lapisField}
+                    .lapisFilter=${args.lapisFilter}
                     .placeholderText=${args.placeholderText}
                     .initialValue=${args.initialValue}
                     .width=${args.width}
@@ -69,6 +71,7 @@ export const Default: StoryObj<Required<LineageFilterProps>> = {
     },
     args: {
         lapisField: 'pangoLineage',
+        lapisFilter: {},
         placeholderText: 'Enter lineage',
         initialValue: 'B.1.1.7',
         width: '100%',

--- a/components/src/web-components/input/gs-lineage-filter.tsx
+++ b/components/src/web-components/input/gs-lineage-filter.tsx
@@ -36,6 +36,20 @@ export class LineageFilterComponent extends PreactLitAdapter {
     initialValue: string = '';
 
     /**
+     * A LAPIS filter to fetch the number of sequences for.
+     *
+     * The `lapisFilter` will be sent as is to LAPIS to select the data.
+     * It must be a valid LAPIS filter object.
+     */
+    @property({ type: Object })
+    lapisFilter: Record<string, string | string[] | number | null | boolean | undefined> & {
+        nucleotideMutations?: string[];
+        aminoAcidMutations?: string[];
+        nucleotideInsertions?: string[];
+        aminoAcidInsertions?: string[];
+    } = {};
+
+    /**
      * Required.
      *
      * The LAPIS field name to use for this lineage filter.
@@ -62,6 +76,7 @@ export class LineageFilterComponent extends PreactLitAdapter {
         return (
             <LineageFilter
                 lapisField={this.lapisField}
+                lapisFilter={this.lapisFilter}
                 placeholderText={this.placeholderText}
                 initialValue={this.initialValue}
                 width={this.width}
@@ -90,6 +105,9 @@ declare global {
 }
 
 /* eslint-disable @typescript-eslint/no-unused-vars, no-unused-vars */
+type LapisFilterMatches = Expect<
+    Equals<typeof LineageFilterComponent.prototype.lapisFilter, LineageFilterProps['lapisFilter']>
+>;
 type InitialValueMatches = Expect<
     Equals<typeof LineageFilterComponent.prototype.initialValue, LineageFilterProps['initialValue']>
 >;

--- a/components/src/web-components/input/gs-text-input.stories.ts
+++ b/components/src/web-components/input/gs-text-input.stories.ts
@@ -14,6 +14,7 @@ import { withinShadowRoot } from '../withinShadowRoot.story';
 const codeExample = String.raw`
 <gs-text-input 
     lapisField="host"
+    lapisFilter={{}}
     placeholderText="Enter host name"
     initialValue="Homo sapiens"
     width="50%">
@@ -82,6 +83,7 @@ export const Default: StoryObj<Required<TextInputProps>> = {
             <div class="max-w-screen-lg">
                 <gs-text-input
                     .lapisField=${args.lapisField}
+                    .lapisFilter=${args.lapisFilter}
                     .placeholderText=${args.placeholderText}
                     .initialValue=${args.initialValue}
                     .width=${args.width}
@@ -91,6 +93,7 @@ export const Default: StoryObj<Required<TextInputProps>> = {
     },
     args: {
         lapisField: 'host',
+        lapisFilter: {},
         placeholderText: 'Enter host name',
         initialValue: 'Homo sapiens',
         width: '100%',

--- a/components/src/web-components/input/gs-text-input.tsx
+++ b/components/src/web-components/input/gs-text-input.tsx
@@ -30,6 +30,20 @@ export class TextInputComponent extends PreactLitAdapter {
     initialValue: string | undefined = undefined;
 
     /**
+     * A LAPIS filter to fetch the number of sequences for.
+     *
+     * The `lapisFilter` will be sent as is to LAPIS to select the data.
+     * It must be a valid LAPIS filter object.
+     */
+    @property({ type: Object })
+    lapisFilter: Record<string, string | string[] | number | null | boolean | undefined> & {
+        nucleotideMutations?: string[];
+        aminoAcidMutations?: string[];
+        nucleotideInsertions?: string[];
+        aminoAcidInsertions?: string[];
+    } = {};
+
+    /**
      * Required.
      *
      * The LAPIS field name to use for this text input.
@@ -55,6 +69,7 @@ export class TextInputComponent extends PreactLitAdapter {
     override render() {
         return (
             <TextInput
+                lapisFilter={this.lapisFilter}
                 lapisField={this.lapisField}
                 placeholderText={this.placeholderText}
                 initialValue={this.initialValue}
@@ -84,6 +99,9 @@ declare global {
 }
 
 /* eslint-disable @typescript-eslint/no-unused-vars, no-unused-vars */
+type LapisFilterMatches = Expect<
+    Equals<typeof TextInputComponent.prototype.lapisFilter, TextInputProps['lapisFilter']>
+>;
 type InitialValueMatches = Expect<
     Equals<typeof TextInputComponent.prototype.initialValue, TextInputProps['initialValue']>
 >;


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves https://github.com/GenSpectrum/dashboard-components/issues/609

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
This shows the number of values for each option in the dropdown and filters the list of option to options that are available with current filters. 


Sadly it is not possible to style the options component so that the number of the options is next to the value and not below, we will need to create a custom component for this. Loculus does this by using `'@headlessui/react'`'s `Combobox` class -- however sadly this requires react and thus cannot be used in our webcomponents (?) I have not been able to find a good solution for this without react. 

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![image](https://github.com/user-attachments/assets/0b958409-559d-4d5d-bc6f-68f235f89fd1)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
