### PR TITLE
fix(components): fix `lastDay` of `YearWeekClass`

### DIFF
--- a/components/src/utils/temporal.spec.ts
+++ b/components/src/utils/temporal.spec.ts
@@ -68,15 +68,69 @@ describe('YearMonthDay', () => {
 });
 
 describe('YearWeek', () => {
-    it('should parse from string', () => {
-        const underTest = YearWeekClass.parse('2020-W02', cache);
+    const examples = [
+        {
+            string: '2020-W01',
+            expectedYear: 2020,
+            expectedWeek: 1,
+            expectedFirstDay: '2019-12-30',
+            expectedLastDay: '2020-01-05',
+            expectedText: '2020-W01',
+        },
+        {
+            string: '2020-W53',
+            expectedYear: 2020,
+            expectedWeek: 53,
+            expectedFirstDay: '2020-12-28',
+            expectedLastDay: '2021-01-03',
+            expectedText: '2020-W53',
+        },
+        {
+            string: '2021-W01',
+            expectedYear: 2021,
+            expectedWeek: 1,
+            expectedFirstDay: '2021-01-04',
+            expectedLastDay: '2021-01-10',
+            expectedText: '2021-W01',
+        },
+        {
+            string: '2021-W53',
+            expectedYear: 2021,
+            expectedWeek: 53,
+            expectedFirstDay: '2022-01-03',
+            expectedLastDay: '2022-01-09',
+            expectedText: '2022-W01',
+        },
+        {
+            string: '2022-W01',
+            expectedYear: 2022,
+            expectedWeek: 1,
+            expectedFirstDay: '2022-01-03',
+            expectedLastDay: '2022-01-09',
+            expectedText: '2022-W01',
+        },
+        {
+            string: '2024-W01',
+            expectedYear: 2024,
+            expectedWeek: 1,
+            expectedFirstDay: '2024-01-01',
+            expectedLastDay: '2024-01-07',
+            expectedText: '2024-W01',
+        },
+    ];
 
-        expect(underTest.isoYearNumber).equal(2020);
-        expect(underTest.isoWeekNumber).equal(2);
-        expect(underTest.firstDay.text).equal('2020-01-06');
-        expect(underTest.text).equal('2020-W02');
-        expect(underTest.lastDay.text).equal('2020-01-12');
-    });
+    for (const example of examples) {
+        const { string, expectedYear, expectedWeek, expectedFirstDay, expectedLastDay, expectedText } = example;
+        it(`should parse ${string} from string`, () => {
+            const underTest = YearWeekClass.parse(string, cache);
+
+            expect(underTest.isoYearNumber).equal(expectedYear);
+            expect(underTest.isoWeekNumber).equal(expectedWeek);
+            expect(underTest.firstDay.text).equal(expectedFirstDay);
+            expect(underTest.text).equal(expectedText);
+            expect(underTest.lastDay.text).equal(expectedLastDay);
+        });
+    }
 });
 
 describe('YearMonth', () => {

--- a/components/src/utils/temporalClass.ts
+++ b/components/src/utils/temporalClass.ts
@@ -171,14 +171,7 @@ export class YearWeekClass implements YearWeek {
     }
 
     get lastDay(): YearMonthDayClass {
-        const firstDay = dayjs()
-            .year(this.isoYearNumber)
-            .startOf('year')
-            .add((this.isoWeekNumber - 1) * 7, 'day')
-            .startOf('week')
-            .add(1, 'day');
-        const lastDay = firstDay.add(6, 'day');
-
+        const lastDay = this.firstDay.dayjs.add(6, 'days');
         return this.cache.getYearMonthDay(lastDay.format('YYYY-MM-DD'));
     }
 


### PR DESCRIPTION


<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
targets #635 case 1

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
The `lastDay`s in 2021 and 2022 were off by 7 days. "2022-W01" would show "first day 2022-01-03" and "last day "2022-01-02". Thus, the mutation over time cells would be empty.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
