### PR TITLE
fix(components): show mutation over time tooltip below value on first six rows

### DIFF
--- a/components/src/preact/mutationsOverTime/mutations-over-time-grid.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time-grid.tsx
@@ -85,7 +85,7 @@ const MutationsOverTimeGrid: FunctionComponent<MutationsOverTimeGridProps> = ({ 
 };
 
 function getTooltipPosition(rowIndex: number, rows: number, columnIndex: number, columns: number) {
-    const tooltipX = rowIndex < rows / 2 ? 'bottom' : 'top';
+    const tooltipX = rowIndex < rows / 2 || rowIndex < 6 ? 'bottom' : 'top';
     const tooltipY = columnIndex < columns / 2 ? 'start' : 'end';
     return `${tooltipX}-${tooltipY}` as const;
 }


### PR DESCRIPTION

Resolves: #634

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

This change was necessary, so the tooltip does not reach out of the containing tab window, if there are only few entries. 

This is a quick fix of the bug. It does not work a component with a small height (below 250px). There the tooltip height of the tooltip is larger than the box. Thus the user can not hover on the elment and read the tooltip at the same time. But since this is no usefull component height, it is left out of the considerations.


### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

![grafik](https://github.com/user-attachments/assets/2f019df3-4e43-40c7-b5e9-8a9cbb401513)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
