### PR TITLE
fix(components): don't use Leaflet default export

### DIFF
--- a/components/src/preact/map/sequences-by-location-map.tsx
+++ b/components/src/preact/map/sequences-by-location-map.tsx
@@ -1,5 +1,5 @@
 import type { Feature, Geometry, GeometryObject } from 'geojson';
-import Leaflet, { type Layer, type LayerGroup } from 'leaflet';
+import { geoJson, type Layer, type LayerGroup, map } from 'leaflet';
 import type { FunctionComponent } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 
@@ -42,7 +42,7 @@ export const SequencesByLocationMap: FunctionComponent<SequencesByLocationMapPro
             return;
         }
 
-        const leafletMap = Leaflet.map(ref.current, {
+        const leafletMap = map(ref.current, {
             scrollWheelZoom: enableMapNavigation,
             zoomControl: enableMapNavigation,
             keyboard: enableMapNavigation,
@@ -52,7 +52,7 @@ export const SequencesByLocationMap: FunctionComponent<SequencesByLocationMapPro
             center: [offsetY, offsetX],
         });
 
-        Leaflet.geoJson(locations, {
+        geoJson(locations, {
             style: (feature: Feature<GeometryObject, EnhancedGeoJsonFeatureProperties> | undefined) => ({
                 fillColor: getColor(feature?.properties.data?.proportion),
                 fillOpacity: 1,

--- a/examples/plainJavascript/index.html
+++ b/examples/plainJavascript/index.html
@@ -16,7 +16,7 @@
     <body>
         <gs-app lapis="https://lapis.cov-spectrum.org/open/v2/">
             <gs-location-filter
-                value='{"region": "Europe" "country": "Switzerland"}'
+                value='{"region": "Europe", "country": "Switzerland"}'
                 fields='["region", "country", "division", "location"]'
                 placeholderText='Enter a location'
             ></gs-location-filter>


### PR DESCRIPTION



### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
because it broke the plain JS example - for some reason the browser complained that Leaflet doesn't export a "default" export.
### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
