### PR TITLE
feat(components): gs-mutation-comparison: add info text

### DIFF
--- a/components/src/preact/components/mutation-info.tsx
+++ b/components/src/preact/components/mutation-info.tsx
@@ -1,0 +1,36 @@
+import { InfoHeadline2, InfoLink, InfoParagraph } from './info';
+
+export const SubstitutionsLink = () => (
+    <InfoLink href='https://www.genome.gov/genetics-glossary/Substitution'>substitutions</InfoLink>
+);
+
+export const InsertionsLink = () => (
+    <InfoLink href='https://www.genome.gov/genetics-glossary/Insertion'>insertions</InfoLink>
+);
+
+export const DeletionsLink = () => (
+    <InfoLink href='https://www.genome.gov/genetics-glossary/Deletion'>deletions</InfoLink>
+);
+
+export const ProportionExplanation = () => (
+    <>
+        <InfoHeadline2>Proportion calculation</InfoHeadline2>
+        <InfoParagraph>
+            The proportion of a mutation is calculated by dividing the number of sequences with the mutation by the
+            total number of sequences with a non-ambiguous symbol at the position.
+        </InfoParagraph>
+        <InfoParagraph>
+            <b>Example:</b> Assume we look at nucleotide mutations at position 5 where the reference has a T and assume
+            there are 10 sequences in total:
+            <ul className='list-disc list-inside ml-2'>
+                <li>3 sequences have a C,</li>
+                <li>2 sequences have a T,</li>
+                <li>1 sequence has a G,</li>
+                <li>3 sequences have an N,</li>
+                <li>1 sequence has a Y (which means T or C),</li>
+            </ul>
+            then the proportion of the T5C mutation is 50%. The 4 sequences that have an N or Y are excluded from the
+            calculation.
+        </InfoParagraph>
+    </>
+);

--- a/components/src/preact/mutationComparison/mutation-comparison.tsx
+++ b/components/src/preact/mutationComparison/mutation-comparison.tsx
@@ -11,8 +11,9 @@ import { LapisUrlContext } from '../LapisUrlContext';
 import { CsvDownloadButton } from '../components/csv-download-button';
 import { ErrorBoundary } from '../components/error-boundary';
 import { Fullscreen } from '../components/fullscreen';
-import Info, { InfoComponentCode, InfoHeadline1, InfoParagraph } from '../components/info';
+import Info, { InfoComponentCode, InfoHeadline1, InfoHeadline2, InfoParagraph } from '../components/info';
 import { LoadingDisplay } from '../components/loading-display';
+import { DeletionsLink, ProportionExplanation, SubstitutionsLink } from '../components/mutation-info';
 import { type DisplayedMutationType, MutationTypeSelector } from '../components/mutation-type-selector';
 import { NoDataDisplay } from '../components/no-data-display';
 import { type ProportionInterval } from '../components/proportion-selector';
@@ -190,7 +191,30 @@ const MutationComparisonInfo: FunctionComponent<MutationComparisonInfoProps> = (
     return (
         <Info>
             <InfoHeadline1>Info for mutation comparison</InfoHeadline1>
-            <InfoParagraph>TODO: https://github.com/GenSpectrum/dashboard-components/issues/465</InfoParagraph>
+            <InfoParagraph>
+                This displays <SubstitutionsLink /> and <DeletionsLink /> of several variants. It shows mutations where
+                the proportion for any given variant falls within the range you can select in the component's toolbar.
+            </InfoParagraph>
+            <ProportionExplanation />
+            {originalComponentProps.views.includes(views.table) && (
+                <>
+                    <InfoHeadline2>Table View</InfoHeadline2>
+                    <InfoParagraph>
+                        The table view displays the proportion of mutations that appear in any of the variants.
+                    </InfoParagraph>
+                </>
+            )}
+            {originalComponentProps.views.includes(views.venn) && (
+                <>
+                    <InfoHeadline2>Venn Diagram View</InfoHeadline2>
+                    <InfoParagraph>
+                        The Venn diagram view illustrates which mutations overlap between the variants and which are
+                        exclusive to specific variants. Mutations overlap if their proportion falls within the selected
+                        range for two variants. If the proportion of a mutation is within the selected range for one
+                        variant but not for the other, the mutation is considered exclusive to that variant.
+                    </InfoParagraph>
+                </>
+            )}
             <InfoComponentCode componentName='mutation-comparison' params={originalComponentProps} lapisUrl={lapis} />
         </Info>
     );

--- a/components/src/preact/mutations/mutations.tsx
+++ b/components/src/preact/mutations/mutations.tsx
@@ -19,8 +19,9 @@ import { LapisUrlContext } from '../LapisUrlContext';
 import { CsvDownloadButton } from '../components/csv-download-button';
 import { ErrorBoundary } from '../components/error-boundary';
 import { Fullscreen } from '../components/fullscreen';
-import Info, { InfoComponentCode, InfoHeadline1, InfoHeadline2, InfoLink, InfoParagraph } from '../components/info';
+import Info, { InfoComponentCode, InfoHeadline1, InfoParagraph } from '../components/info';
 import { LoadingDisplay } from '../components/loading-display';
+import { DeletionsLink, InsertionsLink, ProportionExplanation, SubstitutionsLink } from '../components/mutation-info';
 import { type DisplayedMutationType, MutationTypeSelector } from '../components/mutation-type-selector';
 import { NoDataDisplay } from '../components/no-data-display';
 import type { ProportionInterval } from '../components/proportion-selector';
@@ -242,29 +243,10 @@ const MutationsInfo: FunctionComponent<MutationsInfoProps> = ({ originalComponen
         <Info>
             <InfoHeadline1>Mutations</InfoHeadline1>
             <InfoParagraph>
-                This shows mutations of a variant. There are three types of mutations:{' '}
-                <InfoLink href='https://www.genome.gov/genetics-glossary/Substitution'>substitutions</InfoLink>,{' '}
-                <InfoLink href='https://www.genome.gov/genetics-glossary/Deletion'>deletions</InfoLink> and{' '}
-                <InfoLink href='https://www.genome.gov/genetics-glossary/Insertion'>insertions</InfoLink>.
+                This shows mutations of a variant. There are three types of mutations: <SubstitutionsLink />,{' '}
+                <DeletionsLink /> and <InsertionsLink />.
             </InfoParagraph>
-            <InfoHeadline2>Proportion calculation</InfoHeadline2>
-            <InfoParagraph>
-                The proportion of a mutation is calculated by dividing the number of sequences with the mutation by the
-                total number of sequences with a non-ambiguous symbol at the position.
-            </InfoParagraph>
-            <InfoParagraph>
-                <b>Example:</b> Assume we look at nucleotide mutations at position 5 where the reference has a T and
-                assume there are 10 sequences in total:
-                <ul className='list-disc list-inside ml-2'>
-                    <li>3 sequences have a C,</li>
-                    <li>2 sequences have a T,</li>
-                    <li>1 sequence has a G,</li>
-                    <li>3 sequences have an N,</li>
-                    <li>1 sequence has a Y (which means T or C),</li>
-                </ul>
-                then the proportion of the T5C mutation is 50%. The 4 sequences that have an N or Y are excluded from
-                the calculation.
-            </InfoParagraph>
+            <ProportionExplanation />
             <InfoComponentCode componentName='mutations' params={originalComponentProps} lapisUrl={lapis} />
         </Info>
     );


### PR DESCRIPTION
resolves #465


### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
I reused parts of the `gs-mutations` info text.
### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![image](https://github.com/user-attachments/assets/c7cdd433-df7c-400b-b6ed-81badc94def0)

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
~~- [ ] The implemented feature is covered by an appropriate test.~~
