### PR TITLE
fix(components): gs-wastewater-mutations-over-time: throw proper error when there is an invalid mutation

### DIFF
--- a/components/src/query/queryWastewaterMutationsOverTime.spec.ts
+++ b/components/src/query/queryWastewaterMutationsOverTime.spec.ts
@@ -88,7 +88,35 @@ describe('queryWastewaterMutationsOverTime', () => {
         );
 
         await expect(queryWastewaterMutationsOverTime(DUMMY_LAPIS_URL, lapisFilter)).rejects.toThrowError(
-            /^Failed to parse mutation frequency/,
+            /Failed to parse mutation frequency/,
+        );
+    });
+
+    it('should error on invalid mutation', async () => {
+        const lapisFilter = { country: 'Germany' };
+
+        lapisRequestMocks.details(
+            {
+                country: 'Germany',
+                fields: ['date', 'location', 'nucleotideMutationFrequency', 'aminoAcidMutationFrequency'],
+            },
+            {
+                data: [
+                    {
+                        date: '2021-01-01',
+                        location: 'Germany',
+                        reference: 'organismA',
+                        nucleotideMutationFrequency: JSON.stringify({
+                            'not a mutation': 0.4,
+                        }),
+                        aminoAcidMutationFrequency: null,
+                    },
+                ],
+            },
+        );
+
+        await expect(queryWastewaterMutationsOverTime(DUMMY_LAPIS_URL, lapisFilter)).rejects.toThrowError(
+            /Failed to parse mutation: "not a mutation"/,
         );
     });
 });


### PR DESCRIPTION


Otherwise, there would just be a type error complaining about `null` somewhere.

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
