### PR TITLE
fix(components): gs-mutation-filter: allow for reference genome with no genes

### DIFF
--- a/components/src/preact/mutationFilter/ExampleMutation.tsx
+++ b/components/src/preact/mutationFilter/ExampleMutation.tsx
@@ -1,0 +1,68 @@
+import { useContext } from 'preact/hooks';
+import type { FC } from 'react';
+
+import { type ReferenceGenome } from '../../lapisApi/ReferenceGenome';
+import type { SequenceType } from '../../types';
+import { ReferenceGenomeContext } from '../ReferenceGenomeContext';
+
+type ExampleMutationProps = {
+    sequenceType: SequenceType;
+    mutationType: 'substitution' | 'insertion';
+};
+
+export const ExampleMutation: FC<ExampleMutationProps> = ({ sequenceType, mutationType }) => {
+    const referenceGenome = useContext(ReferenceGenomeContext);
+
+    return <b>{getExampleMutation(referenceGenome, sequenceType, mutationType)}</b>;
+};
+
+export function getExampleMutation(
+    referenceGenome: ReferenceGenome,
+    sequenceType: SequenceType,
+    mutationType: 'substitution' | 'insertion',
+) {
+    switch (sequenceType) {
+        case 'amino acid': {
+            if (referenceGenome.genes.length === 0) {
+                return '';
+            }
+
+            const firstGene = referenceGenome.genes[0].name;
+
+            switch (mutationType) {
+                case 'substitution':
+                    return `${firstGene}:57Q`;
+                case 'insertion':
+                    return `ins_${firstGene}:31:N`;
+            }
+        }
+        // Issue of linter https://github.com/typescript-eslint/typescript-eslint/issues/3455
+        // eslint-disable-next-line no-fallthrough
+        case 'nucleotide': {
+            switch (referenceGenome.nucleotideSequences.length) {
+                case 0: {
+                    return '';
+                }
+                case 1: {
+                    switch (mutationType) {
+                        case 'substitution':
+                            return '23T';
+                        case 'insertion':
+                            return 'ins_1046:A';
+                    }
+                }
+                // Issue of linter https://github.com/typescript-eslint/typescript-eslint/issues/3455
+                // eslint-disable-next-line no-fallthrough
+                default: {
+                    const firstSegment = referenceGenome.nucleotideSequences[0].name;
+                    switch (mutationType) {
+                        case 'substitution':
+                            return `${firstSegment}:23T`;
+                        case 'insertion':
+                            return `ins_${firstSegment}:10462:A`;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/components/src/preact/mutationFilter/mutation-filter-info.tsx
+++ b/components/src/preact/mutationFilter/mutation-filter-info.tsx
@@ -1,130 +1,112 @@
 import { useContext } from 'preact/hooks';
-import { type FC } from 'react';
 
-import { isSingleSegmented } from '../../lapisApi/ReferenceGenome';
-import { type SequenceType } from '../../types';
+import { isSingleSegmented, type ReferenceGenome } from '../../lapisApi/ReferenceGenome';
 import { ReferenceGenomeContext } from '../ReferenceGenomeContext';
+import { ExampleMutation } from './ExampleMutation';
 import Info, { InfoHeadline1, InfoHeadline2, InfoParagraph } from '../components/info';
 
 export const MutationFilterInfo = () => {
-    const referenceGenome = useContext(ReferenceGenomeContext);
-
-    const firstGene = referenceGenome.genes[0].name;
     return (
         <Info>
             <InfoHeadline1> Mutation Filter</InfoHeadline1>
             <InfoParagraph>This component allows you to filter for mutations at specific positions.</InfoParagraph>
 
-            <InfoHeadline2>Quickstart</InfoHeadline2>
-            <InfoParagraph>
-                <ul className='list-disc list-inside'>
-                    <li>
-                        Filter for nucleotide mutations:{' '}
-                        <ExampleMutation mutationType='substitution' sequenceType='nucleotide' />
-                    </li>
-                    <li>
-                        Filter for amino acid mutations:{' '}
-                        <ExampleMutation mutationType='insertion' sequenceType='nucleotide' />
-                    </li>
-                    <li>
-                        Filter for nucleotide insertions:{' '}
-                        <ExampleMutation mutationType='substitution' sequenceType='amino acid' />
-                    </li>
-                    <li>
-                        Filter for amino acid insertions:{' '}
-                        <ExampleMutation mutationType='insertion' sequenceType='amino acid' />
-                    </li>
-                </ul>
-            </InfoParagraph>
-            {!isSingleSegmented(referenceGenome) && (
-                <InfoParagraph>
-                    This organism has the following segments:{' '}
-                    {referenceGenome.nucleotideSequences.map((gene) => gene.name).join(', ')}.
-                </InfoParagraph>
-            )}
-            <InfoParagraph>
-                This organism has the following genes: {referenceGenome.genes.map((gene) => gene.name).join(', ')}.
-            </InfoParagraph>
-
-            <InfoHeadline2>Nucleotide Mutations and Insertions</InfoHeadline2>
-            {isSingleSegmented(referenceGenome) ? (
-                <SingleSegmentedNucleotideMutationsInfo />
-            ) : (
-                <MultiSegmentedNucleotideMutationsInfo />
-            )}
-
-            <InfoHeadline2>Amino Acid Mutations and Insertions</InfoHeadline2>
-            <InfoParagraph>
-                An amino acid mutation has the format <b>&lt;gene&gt;:&lt;position&gt;&lt;base&gt;</b> or
-                <b>&lt;gene&gt;:&lt;base_ref&gt;&lt;position&gt;&lt;base&gt;</b>. A <b>&lt;base&gt;</b> can be one of
-                the 20 amino acid codes. It can also be <b>-</b> for deletion and <b>X</b> for unknown. Example:{' '}
-                <ExampleMutation mutationType='substitution' sequenceType='amino acid' />.
-            </InfoParagraph>
-            <InfoParagraph>
-                Insertions can be searched for in the same manner, they just need to have <b>ins_</b> appended to the
-                start of the mutation. Example: <b>ins_{firstGene}:31:N</b> would filter for sequences with an insertion
-                of N between positions 31 and 32 in the gene {firstGene}.
-            </InfoParagraph>
-
-            <InfoHeadline2>Insertion Wildcards</InfoHeadline2>
-            <InfoParagraph>
-                This component supports insertion queries that contain wildcards <b>?</b>. For example{' '}
-                <b>ins_{firstGene}:214:?EP?</b> will match all cases where segment <b>{firstGene}</b> has an insertion
-                of <b>EP</b> between the positions <b>214</b> and <b>215</b> but also an insertion of other amino acids
-                which include the <b>EP</b>, e.g. the insertion <b>EPE</b> will be matched.
-            </InfoParagraph>
-            <InfoParagraph>
-                You can also use wildcards to match any insertion at a given position. For example{' '}
-                <b>ins_{firstGene}:214:?</b> match any (but at least one) insertion between the positions 214 and 215.
-            </InfoParagraph>
-
-            <InfoHeadline2>Multiple Mutations</InfoHeadline2>
-            <InfoParagraph>
-                Multiple mutation filters can be provided by adding one mutation after the other.
-            </InfoParagraph>
-
-            <InfoHeadline2>Any Mutation</InfoHeadline2>
-            <InfoParagraph>
-                To filter for any mutation at a given position you can omit the <b>&lt;base&gt;</b>. Example:{' '}
-                <b>{firstGene}:20</b>.
-            </InfoParagraph>
-
-            <InfoHeadline2>No Mutation</InfoHeadline2>
-            <InfoParagraph>
-                You can write a <b>.</b> for the <b>&lt;base&gt;</b> to filter for sequences for which it is confirmed
-                that no mutation occurred, i.e. has the same base as the reference genome at the specified position.
-            </InfoParagraph>
+            <QuickStart />
+            <NucleotideMutationsInfo />
+            <AminoAcidMutationsInfo />
+            <InsertionWildcards />
+            <MultipleMutations />
+            <AnyMutation />
+            <NoMutation />
         </Info>
     );
 };
 
-const SingleSegmentedNucleotideMutationsInfo = () => {
+const QuickStart = () => {
+    const referenceGenome = useContext(ReferenceGenomeContext);
     return (
         <>
+            <InfoHeadline2>Quickstart</InfoHeadline2>
             <InfoParagraph>
-                This organism is single-segmented. Thus, nucleotide mutations have the format{' '}
-                <b>&lt;position&gt;&lt;base&gt;</b> or <b>&lt;base_ref&gt;&lt;position&gt;&lt;base&gt;</b>. The{' '}
-                <b>&lt;base_ref&gt;</b> is the reference base at the position. It is optional. A <b>&lt;base&gt;</b> can
-                be one of the four nucleotides <b>A</b>, <b>T</b>, <b>C</b>, and <b>G</b>. It can also be <b>-</b> for
-                deletion and <b>N</b> for unknown. For example if the reference sequence is <b>A</b> at position{' '}
-                <b>23</b> both: <b>23T</b> and <b>A23T</b> will yield the same results.
+                <ul className='list-disc list-inside'>
+                    {referenceGenome.nucleotideSequences.length > 0 && (
+                        <li>
+                            Filter for nucleotide mutations:{' '}
+                            <ExampleMutation mutationType='substitution' sequenceType='nucleotide' />
+                        </li>
+                    )}
+                    {referenceGenome.genes.length > 0 && (
+                        <li>
+                            Filter for amino acid mutations:{' '}
+                            <ExampleMutation mutationType='substitution' sequenceType='amino acid' />
+                        </li>
+                    )}
+                    {referenceGenome.nucleotideSequences.length > 0 && (
+                        <li>
+                            Filter for nucleotide insertions:{' '}
+                            <ExampleMutation mutationType='insertion' sequenceType='nucleotide' />
+                        </li>
+                    )}
+                    {referenceGenome.genes.length > 0 && (
+                        <li>
+                            Filter for amino acid insertions:{' '}
+                            <ExampleMutation mutationType='insertion' sequenceType='amino acid' />
+                        </li>
+                    )}
+                </ul>
             </InfoParagraph>
-            <InfoParagraph>
-                Insertions can be searched for in the same manner, they just need to have <b>ins_</b> appended to the
-                start of the mutation. Example: <b>ins_1046:A</b> would filter for sequences with an insertion of A
-                between the positions 1046 and 1047 in the nucleotide sequence.
-            </InfoParagraph>
+
+            {referenceGenome.nucleotideSequences.length > 1 ? (
+                <InfoParagraph>
+                    This organism has the following segments:{' '}
+                    {referenceGenome.nucleotideSequences.map((gene) => gene.name).join(', ')}.
+                </InfoParagraph>
+            ) : (
+                <InfoParagraph>This organism doesn't support nucleotide sequences.</InfoParagraph>
+            )}
+            {referenceGenome.genes.length !== 0 ? (
+                <InfoParagraph>
+                    This organism has the following genes: {referenceGenome.genes.map((gene) => gene.name).join(', ')}.
+                </InfoParagraph>
+            ) : (
+                <InfoParagraph>This organism doesn't support amino acid sequences.</InfoParagraph>
+            )}
         </>
     );
 };
 
-const MultiSegmentedNucleotideMutationsInfo = () => {
+const NucleotideMutationsInfo = () => {
     const referenceGenome = useContext(ReferenceGenomeContext);
 
-    const firstSegment = referenceGenome.nucleotideSequences[0].name;
+    if (referenceGenome.nucleotideSequences.length === 0) {
+        return null;
+    }
 
+    if (isSingleSegmented(referenceGenome)) {
+        return (
+            <>
+                <InfoHeadline2>Nucleotide Mutations and Insertions</InfoHeadline2>
+                <InfoParagraph>
+                    This organism is single-segmented. Thus, nucleotide mutations have the format{' '}
+                    <b>&lt;position&gt;&lt;base&gt;</b> or <b>&lt;base_ref&gt;&lt;position&gt;&lt;base&gt;</b>. The{' '}
+                    <b>&lt;base_ref&gt;</b> is the reference base at the position. It is optional. A <b>&lt;base&gt;</b>{' '}
+                    can be one of the four nucleotides <b>A</b>, <b>T</b>, <b>C</b>, and <b>G</b>. It can also be{' '}
+                    <b>-</b> for deletion and <b>N</b> for unknown. For example if the reference sequence is <b>A</b> at
+                    position <b>23</b> both: <b>23T</b> and <b>A23T</b> will yield the same results.
+                </InfoParagraph>
+                <InfoParagraph>
+                    Insertions can be searched for in the same manner, they just need to have <b>ins_</b> appended to
+                    the start of the mutation. Example: <b>ins_1046:A</b> would filter for sequences with an insertion
+                    of A between the positions 1046 and 1047 in the nucleotide sequence.
+                </InfoParagraph>
+            </>
+        );
+    }
+
+    const firstSegment = referenceGenome.nucleotideSequences[0].name;
     return (
         <>
+            <InfoHeadline2>Nucleotide Mutations and Insertions</InfoHeadline2>
             <InfoParagraph>
                 This organism is multi-segmented. Thus, nucleotide mutations have the format{' '}
                 <b>&lt;segment&gt;:&lt;position&gt;&lt;base&gt;</b> or{' '}
@@ -142,39 +124,124 @@ const MultiSegmentedNucleotideMutationsInfo = () => {
     );
 };
 
-type ExampleMutationProps = {
-    sequenceType: SequenceType;
-    mutationType: 'substitution' | 'insertion';
-};
-
-const ExampleMutation: FC<ExampleMutationProps> = ({ sequenceType, mutationType }) => {
+const AminoAcidMutationsInfo = () => {
     const referenceGenome = useContext(ReferenceGenomeContext);
 
-    const firstSegment = referenceGenome.nucleotideSequences[0].name;
+    if (referenceGenome.genes.length === 0) {
+        return null;
+    }
+
     const firstGene = referenceGenome.genes[0].name;
 
-    if (sequenceType === 'amino acid') {
-        switch (mutationType) {
-            case 'substitution':
-                return <b>{firstGene}:57Q</b>;
-            case 'insertion':
-                return <b>ins_{firstGene}:31:N</b>;
-        }
+    return (
+        <>
+            <InfoHeadline2>Amino Acid Mutations and Insertions</InfoHeadline2>
+            <InfoParagraph>
+                An amino acid mutation has the format <b>&lt;gene&gt;:&lt;position&gt;&lt;base&gt;</b> or
+                <b>&lt;gene&gt;:&lt;base_ref&gt;&lt;position&gt;&lt;base&gt;</b>. A <b>&lt;base&gt;</b> can be one of
+                the 20 amino acid codes. It can also be <b>-</b> for deletion and <b>X</b> for unknown. Example:{' '}
+                <ExampleMutation mutationType='substitution' sequenceType='amino acid' />.
+            </InfoParagraph>
+            <InfoParagraph>
+                Insertions can be searched for in the same manner, they just need to have <b>ins_</b> appended to the
+                start of the mutation. Example: <b>ins_{firstGene}:31:N</b> would filter for sequences with an insertion
+                of N between positions 31 and 32 in the gene {firstGene}.
+            </InfoParagraph>
+        </>
+    );
+};
+
+const InsertionWildcards = () => {
+    const referenceGenome = useContext(ReferenceGenomeContext);
+
+    if (referenceGenome.nucleotideSequences.length === 0 && referenceGenome.genes.length === 0) {
+        return null;
     }
 
-    if (isSingleSegmented(referenceGenome)) {
-        switch (mutationType) {
-            case 'substitution':
-                return <b>23T</b>;
-            case 'insertion':
-                return <b>ins_1046:A</b>;
-        }
-    }
+    return (
+        <>
+            <InfoHeadline2>Insertion Wildcards</InfoHeadline2>
+            <InfoParagraph>
+                This component supports nucleotide and amino acid insertion queries that contain wildcards <b>?</b>. For
+                example{' '}
+                <b>
+                    ins_{exampleSegmentString(referenceGenome)}214:?{exampleWildcardInsertion(referenceGenome)}?
+                </b>{' '}
+                will match all cases where segment <b>{exampleSegment(referenceGenome)}</b> has an insertion of{' '}
+                <b>{exampleWildcardInsertion(referenceGenome)}</b> between the positions <b>214</b> and <b>215</b> but
+                also an insertion of other amino acids which include the <b>EP</b>, e.g. the insertion{' '}
+                <b>{exampleWildcardInsertion(referenceGenome)}T</b> will be matched.
+            </InfoParagraph>
+            <InfoParagraph>
+                You can also use wildcards to match any insertion at a given position. For example{' '}
+                <b>ins_{exampleSegmentString(referenceGenome)}214:?</b> match any (but at least one) insertion between
+                the positions 214 and 215.
+            </InfoParagraph>
+        </>
+    );
+};
 
-    switch (mutationType) {
-        case 'substitution':
-            return <b>{firstSegment}:23T</b>;
-        case 'insertion':
-            return <b>ins_{firstSegment}:10462:A</b>;
+const exampleSegmentString = (referenceGenome: ReferenceGenome) => {
+    const segment = exampleSegment(referenceGenome);
+    if (segment === '') {
+        return '';
     }
+    return `${segment}:`;
+};
+
+const exampleSegment = (referenceGenome: ReferenceGenome) => {
+    if (referenceGenome.genes.length > 0) {
+        return `${referenceGenome.genes[0].name}`;
+    }
+    if (referenceGenome.nucleotideSequences.length > 1) {
+        return `${referenceGenome.nucleotideSequences[0].name}`;
+    }
+    return '';
+};
+
+const exampleWildcardInsertion = (referenceGenome: ReferenceGenome) => {
+    if (referenceGenome.genes.length > 0) {
+        return 'EP';
+    }
+    if (referenceGenome.nucleotideSequences.length > 0) {
+        return 'CG';
+    }
+    return '';
+};
+
+const MultipleMutations = () => {
+    return (
+        <>
+            <InfoHeadline2>Multiple Mutations</InfoHeadline2>
+            <InfoParagraph>
+                Multiple mutation filters can be provided by adding one mutation after the other.
+            </InfoParagraph>
+        </>
+    );
+};
+
+const AnyMutation = () => {
+    const referenceGenome = useContext(ReferenceGenomeContext);
+
+    return (
+        <>
+            <InfoHeadline2>Any Mutation</InfoHeadline2>
+            <InfoParagraph>
+                To filter for any mutation at a given position you can omit the <b>&lt;base&gt;</b>. Example:{' '}
+                <b>{exampleSegmentString(referenceGenome)}20</b>.
+            </InfoParagraph>
+        </>
+    );
+};
+
+const NoMutation = () => {
+    return (
+        <>
+            <InfoHeadline2>No Mutation</InfoHeadline2>
+            <InfoParagraph>
+                You can write a <b>.</b> for the <b>&lt;base&gt;</b> to filter for sequences for which it is confirmed
+                that no mutation occurred, i.e. has the same base as the reference genome at the specified position.
+            </InfoParagraph>
+        </>
+    );
 };

--- a/components/src/preact/mutationFilter/mutation-filter.tsx
+++ b/components/src/preact/mutationFilter/mutation-filter.tsx
@@ -2,6 +2,7 @@ import { type FunctionComponent } from 'preact';
 import { useContext, useRef, useState } from 'preact/hooks';
 import z from 'zod';
 
+import { getExampleMutation } from './ExampleMutation';
 import { MutationFilterInfo } from './mutation-filter-info';
 import { parseAndValidateMutation, type ParsedMutationFilter } from './parseAndValidateMutation';
 import { type ReferenceGenome } from '../../lapisApi/ReferenceGenome';
@@ -208,7 +209,6 @@ const MutationFilterSelector: FunctionComponent<{
     };
 
     const handleBlur = (event: FocusEvent) => {
-        // Check if click was inside the selector
         if (!selectorRef.current?.contains(event.relatedTarget as Node)) {
             setOption(null);
         }
@@ -242,11 +242,16 @@ const MutationFilterSelector: FunctionComponent<{
 };
 
 function getPlaceholder(referenceGenome: ReferenceGenome) {
-    const segmentPrefix =
-        referenceGenome.nucleotideSequences.length > 1 ? `${referenceGenome.nucleotideSequences[0].name}:` : '';
-    const firstGene = referenceGenome.genes[0].name;
+    const nucleotideSubstitution = getExampleMutation(referenceGenome, 'nucleotide', 'substitution');
+    const nucleotideInsertion = getExampleMutation(referenceGenome, 'nucleotide', 'insertion');
+    const aminoAcidSubstitution = getExampleMutation(referenceGenome, 'amino acid', 'substitution');
+    const aminoAcidInsertion = getExampleMutation(referenceGenome, 'amino acid', 'insertion');
 
-    return `Enter a mutation (e.g. ${segmentPrefix}A123T, ins_${segmentPrefix}123:AT, ${firstGene}:M123E, ins_${firstGene}:123:ME)`;
+    const exampleMutations = [nucleotideSubstitution, nucleotideInsertion, aminoAcidSubstitution, aminoAcidInsertion]
+        .filter((example) => example !== '')
+        .join(', ');
+
+    return `Enter a mutation (e.g. ${exampleMutations})`;
 }
 
 const backgroundColor: { [key in keyof SelectedFilters]: string } = {

--- a/components/src/web-components/input/gs-mutation-filter.stories.ts
+++ b/components/src/web-components/input/gs-mutation-filter.stories.ts
@@ -158,7 +158,7 @@ export const MultiSegmentedReferenceGenomes: StoryObj<MutationFilterProps> = {
             const placeholderText = inputField().getAttribute('placeholder');
 
             expect(placeholderText).toEqual(
-                'Enter a mutation (e.g. seg1:A123T, ins_seg1:123:AT, gene1:M123E, ins_gene1:123:ME)',
+                'Enter a mutation (e.g. seg1:23T, ins_seg1:10462:A, gene1:57Q, ins_gene1:31:N)',
             );
         });
 


### PR DESCRIPTION


### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Fixes the error on the gs-mutation-filter component, when a reference genome is provided with no genes.
Its mostly a refactoring.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
