### PR TITLE
feat(components): gs-date-range-selector: make the component controllable from a surrounding JS app

### DIFF
--- a/components/.storybook-preact/preview.ts
+++ b/components/.storybook-preact/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from '@storybook/preact';
+import { clearAllMocks } from '@storybook/test';
 
 import '../src/styles/tailwind.css';
 import { withActions } from '@storybook/addon-actions/decorator';
@@ -15,6 +16,9 @@ const preview: Preview = {
         actions: { handles: [GS_ERROR_EVENT_TYPE] },
     },
     decorators: [withActions],
+    beforeEach: () => {
+        clearAllMocks();
+    },
 };
 
 export default preview;

--- a/components/src/preact/dateRangeSelector/computeInitialValues.spec.ts
+++ b/components/src/preact/dateRangeSelector/computeInitialValues.spec.ts
@@ -18,8 +18,8 @@ const dateRangeOptions = [
 ];
 
 describe('computeInitialValues', () => {
-    it('should compute for initial value if initial "from" and "to" are unset', () => {
-        const result = computeInitialValues(fromToOption, undefined, undefined, earliestDate, dateRangeOptions);
+    it('should compute initial value if value is dateRangeOption label', () => {
+        const result = computeInitialValues(fromToOption, earliestDate, dateRangeOptions);
 
         expect(result.initialSelectedDateRange).toEqual(fromToOption);
         expectDateMatches(result.initialSelectedDateFrom, new Date(dateFromOptionValue));
@@ -27,7 +27,7 @@ describe('computeInitialValues', () => {
     });
 
     it('should use today as "dateTo" if it is unset in selected option', () => {
-        const result = computeInitialValues(fromOption, undefined, undefined, earliestDate, dateRangeOptions);
+        const result = computeInitialValues(fromOption, earliestDate, dateRangeOptions);
 
         expect(result.initialSelectedDateRange).toEqual(fromOption);
         expectDateMatches(result.initialSelectedDateFrom, new Date(dateFromOptionValue));
@@ -35,7 +35,7 @@ describe('computeInitialValues', () => {
     });
 
     it('should use earliest date as "dateFrom" if it is unset in selected option', () => {
-        const result = computeInitialValues(toOption, undefined, undefined, earliestDate, dateRangeOptions);
+        const result = computeInitialValues(toOption, earliestDate, dateRangeOptions);
 
         expect(result.initialSelectedDateRange).toEqual(toOption);
         expectDateMatches(result.initialSelectedDateFrom, new Date(earliestDate));
@@ -43,7 +43,7 @@ describe('computeInitialValues', () => {
     });
 
     it('should fall back to full range if initial value is not set', () => {
-        const result = computeInitialValues(undefined, undefined, undefined, earliestDate, dateRangeOptions);
+        const result = computeInitialValues(undefined, earliestDate, dateRangeOptions);
 
         expect(result.initialSelectedDateRange).toBeUndefined();
         expectDateMatches(result.initialSelectedDateFrom, new Date(earliestDate));
@@ -51,39 +51,46 @@ describe('computeInitialValues', () => {
     });
 
     it('should throw when initial value is unknown', () => {
-        expect(() =>
-            computeInitialValues('not a known value', undefined, undefined, earliestDate, dateRangeOptions),
-        ).toThrowError(/Invalid initialValue "not a known value", It must be one of/);
+        expect(() => computeInitialValues('not a known value', earliestDate, dateRangeOptions)).toThrowError(
+            /Invalid value "not a known value", It must be one of/,
+        );
     });
 
     it('should throw when initial value is set but no options are provided', () => {
-        expect(() => computeInitialValues('not a known value', undefined, undefined, earliestDate, [])).toThrowError(
+        expect(() => computeInitialValues('not a known value', earliestDate, [])).toThrowError(
             /There are no selectable options/,
         );
     });
 
-    it('should overwrite initial value if initial "from" is set', () => {
+    it('should select from date until today if only dateFrom is given', () => {
         const initialDateFrom = '2020-01-01';
-        const result = computeInitialValues(fromOption, initialDateFrom, undefined, earliestDate, dateRangeOptions);
+        const result = computeInitialValues({ dateFrom: initialDateFrom }, earliestDate, dateRangeOptions);
 
         expect(result.initialSelectedDateRange).toBeUndefined();
         expectDateMatches(result.initialSelectedDateFrom, new Date(initialDateFrom));
         expectDateMatches(result.initialSelectedDateTo, today);
     });
 
-    it('should overwrite initial value if initial "to" is set', () => {
+    it('should select from earliest date until date if only dateTo is given', () => {
         const initialDateTo = '2020-01-01';
-        const result = computeInitialValues(fromOption, undefined, initialDateTo, earliestDate, dateRangeOptions);
+        const result = computeInitialValues({ dateTo: initialDateTo }, earliestDate, dateRangeOptions);
 
         expect(result.initialSelectedDateRange).toBeUndefined();
         expectDateMatches(result.initialSelectedDateFrom, new Date(earliestDate));
         expectDateMatches(result.initialSelectedDateTo, new Date(initialDateTo));
     });
 
-    it('should overwrite initial value if initial "to" and "from" are set', () => {
+    it('should select date range is dateFrom and dateTo are given', () => {
         const initialDateFrom = '2020-01-01';
         const initialDateTo = '2022-01-01';
-        const result = computeInitialValues(fromOption, initialDateFrom, initialDateTo, earliestDate, dateRangeOptions);
+        const result = computeInitialValues(
+            {
+                dateFrom: initialDateFrom,
+                dateTo: initialDateTo,
+            },
+            earliestDate,
+            dateRangeOptions,
+        );
 
         expect(result.initialSelectedDateRange).toBeUndefined();
         expectDateMatches(result.initialSelectedDateFrom, new Date(initialDateFrom));
@@ -93,7 +100,14 @@ describe('computeInitialValues', () => {
     it('should set initial "to" to "from" if "from" is after "to"', () => {
         const initialDateFrom = '2020-01-01';
         const initialDateTo = '1900-01-01';
-        const result = computeInitialValues(undefined, initialDateFrom, initialDateTo, earliestDate, dateRangeOptions);
+        const result = computeInitialValues(
+            {
+                dateFrom: initialDateFrom,
+                dateTo: initialDateTo,
+            },
+            earliestDate,
+            dateRangeOptions,
+        );
 
         expect(result.initialSelectedDateRange).toBeUndefined();
         expectDateMatches(result.initialSelectedDateFrom, new Date(initialDateFrom));
@@ -101,14 +115,14 @@ describe('computeInitialValues', () => {
     });
 
     it('should throw if initial "from" is not a valid date', () => {
-        expect(() => computeInitialValues(undefined, 'not a date', undefined, earliestDate, [])).toThrowError(
-            'Invalid initialDateFrom',
+        expect(() => computeInitialValues({ dateFrom: 'not a date' }, earliestDate, [])).toThrowError(
+            'Invalid value.dateFrom',
         );
     });
 
     it('should throw if initial "to" is not a valid date', () => {
-        expect(() => computeInitialValues(undefined, undefined, 'not a date', earliestDate, [])).toThrowError(
-            'Invalid initialDateTo',
+        expect(() => computeInitialValues({ dateTo: 'not a date' }, earliestDate, [])).toThrowError(
+            'Invalid value.dateTo',
         );
     });
 

--- a/components/src/preact/dateRangeSelector/computeInitialValues.ts
+++ b/components/src/preact/dateRangeSelector/computeInitialValues.ts
@@ -1,11 +1,9 @@
-import { type DateRangeOption } from './dateRangeOption';
+import { type DateRangeOption, type DateRangeValue } from './dateRangeOption';
 import { getDatesForSelectorValue, getSelectableOptions } from './selectableOptions';
 import { UserFacingError } from '../components/error-display';
 
 export function computeInitialValues(
-    initialValue: string | undefined,
-    initialDateFrom: string | undefined,
-    initialDateTo: string | undefined,
+    value: DateRangeValue | undefined,
     earliestDate: string,
     dateRangeOptions: DateRangeOption[],
 ): {
@@ -13,20 +11,26 @@ export function computeInitialValues(
     initialSelectedDateFrom: Date;
     initialSelectedDateTo: Date;
 } {
-    if (isUndefinedOrEmpty(initialDateFrom) && isUndefinedOrEmpty(initialDateTo)) {
-        const selectableOptions = getSelectableOptions(dateRangeOptions);
-        const initialSelectedDateRange = selectableOptions.find((option) => option.value === initialValue)?.value;
+    if (value === undefined) {
+        const { dateFrom, dateTo } = getDatesForSelectorValue(undefined, dateRangeOptions, earliestDate);
+        return {
+            initialSelectedDateRange: undefined,
+            initialSelectedDateFrom: dateFrom,
+            initialSelectedDateTo: dateTo,
+        };
+    }
 
-        if (initialValue !== undefined && initialSelectedDateRange === undefined) {
+    if (typeof value === 'string') {
+        const selectableOptions = getSelectableOptions(dateRangeOptions);
+        const initialSelectedDateRange = selectableOptions.find((option) => option.value === value)?.value;
+
+        if (initialSelectedDateRange === undefined) {
             if (selectableOptions.length === 0) {
-                throw new UserFacingError(
-                    'Invalid initialValue',
-                    'There are no selectable options, but initialValue is set.',
-                );
+                throw new UserFacingError('Invalid value', 'There are no selectable options, but value is set.');
             }
             throw new UserFacingError(
-                'Invalid initialValue',
-                `Invalid initialValue "${initialValue}", It must be one of ${selectableOptions.map((option) => `'${option.value}'`).join(', ')}`,
+                'Invalid value',
+                `Invalid value "${value}", It must be one of ${selectableOptions.map((option) => `'${option.value}'`).join(', ')}`,
             );
         }
 
@@ -39,21 +43,21 @@ export function computeInitialValues(
         };
     }
 
-    const initialSelectedDateFrom = isUndefinedOrEmpty(initialDateFrom)
-        ? new Date(earliestDate)
-        : new Date(initialDateFrom);
-    let initialSelectedDateTo = isUndefinedOrEmpty(initialDateTo) ? new Date() : new Date(initialDateTo);
+    const { dateFrom, dateTo } = value;
+
+    const initialSelectedDateFrom = isUndefinedOrEmpty(dateFrom) ? new Date(earliestDate) : new Date(dateFrom);
+    let initialSelectedDateTo = isUndefinedOrEmpty(dateTo) ? new Date() : new Date(dateTo);
 
     if (isNaN(initialSelectedDateFrom.getTime())) {
         throw new UserFacingError(
-            'Invalid initialDateFrom',
-            `Invalid initialDateFrom "${initialDateFrom}", It must be of the format YYYY-MM-DD`,
+            'Invalid value.dateFrom',
+            `Invalid value.dateFrom "${dateFrom}", It must be of the format YYYY-MM-DD`,
         );
     }
     if (isNaN(initialSelectedDateTo.getTime())) {
         throw new UserFacingError(
-            'Invalid initialDateTo',
-            `Invalid initialDateTo "${initialDateTo}", It must be of the format YYYY-MM-DD`,
+            'Invalid value.dateTo',
+            `Invalid value.dateTo "${dateTo}", It must be of the format YYYY-MM-DD`,
         );
     }
 

--- a/components/src/preact/dateRangeSelector/dateRangeOption.ts
+++ b/components/src/preact/dateRangeSelector/dateRangeOption.ts
@@ -22,7 +22,17 @@ export const dateRangeOptionSchema = z.object({
 
 export type DateRangeOption = z.infer<typeof dateRangeOptionSchema>;
 
-export type DateRangeSelectOption = string | { dateFrom: string; dateTo: string };
+export const dateRangeValueSchema = z.union([
+    z.string(),
+    z.object({
+        dateFrom: z.string().date().optional(),
+        dateTo: z.string().date().optional(),
+    }),
+]);
+
+export type DateRangeValue = z.infer<typeof dateRangeValueSchema>;
+
+export type DateRangeSelectOption = Required<DateRangeValue>;
 
 export class DateRangeOptionChangedEvent extends CustomEvent<DateRangeSelectOption> {
     constructor(detail: DateRangeSelectOption) {

--- a/components/src/web-components/input/gs-date-range-selector.stories.ts
+++ b/components/src/web-components/input/gs-date-range-selector.stories.ts
@@ -16,9 +16,7 @@ const codeExample = String.raw`
 <gs-date-range-selector
     dateRangeOptions='[{ "label": "Year 2021", "dateFrom": "2021-01-01", "dateTo": "2021-12-31" }]'
     earliestDate="1970-01-01"
-    initialValue="Year 2021"
-    initialDateFrom="2020-01-01"
-    initialDateTo="2021-01-01"
+    valule="Year 2021"
     width="100%"
     lapisDateField="myDateColumn"
 ></gs-date-range-selector>`;
@@ -40,11 +38,10 @@ const meta: Meta<Required<DateRangeSelectorProps>> = {
         },
     }),
     argTypes: {
-        initialValue: {
+        value: {
             control: {
-                type: 'select',
+                type: 'object',
             },
-            options: [dateRangeOptionPresets.lastMonth.label, dateRangeOptionPresets.allTimes.label, 'CustomDateRange'],
         },
         lapisDateField: { control: { type: 'text' } },
         dateRangeOptions: {
@@ -71,11 +68,9 @@ const meta: Meta<Required<DateRangeSelectorProps>> = {
             customDateRange,
         ],
         earliestDate: '1970-01-01',
-        initialValue: dateRangeOptionPresets.lastMonth.label,
+        value: dateRangeOptionPresets.lastMonth.label,
         lapisDateField: 'aDateColumn',
         width: '100%',
-        initialDateFrom: undefined,
-        initialDateTo: undefined,
     },
     tags: ['autodocs'],
 };
@@ -89,9 +84,7 @@ export const Default: StoryObj<Required<DateRangeSelectorProps>> = {
                 <gs-date-range-selector
                     .dateRangeOptions=${args.dateRangeOptions}
                     .earliestDate=${args.earliestDate}
-                    .initialValue=${args.initialValue}
-                    .initialDateFrom=${args.initialDateFrom}
-                    .initialDateTo=${args.initialDateTo}
+                    .value=${args.value}
                     .width=${args.width}
                     .lapisDateField=${args.lapisDateField}
                 ></gs-date-range-selector>

--- a/components/src/web-components/input/gs-date-range-selector.tsx
+++ b/components/src/web-components/input/gs-date-range-selector.tsx
@@ -46,15 +46,18 @@ import { PreactLitAdapter } from '../PreactLitAdapter';
  * Contains the selected dateRangeOption or when users select custom values it contains the selected dates.
  *
  * Use this event, when you want to control this component in your JS application.
+ * You can supply the `detail` of this event to the `value` attribute of this component.
  */
 @customElement('gs-date-range-selector')
 export class DateRangeSelectorComponent extends PreactLitAdapter {
     /**
      * An array of date range options that the select field should provide.
-     * The `label` will be shown to the user, and it will be available as `initialValue`.
+     * The `label` will be shown to the user, and it will be available as `value`.
      * The dates must be in the format `YYYY-MM-DD`.
      *
      * If dateFrom or dateTo is not set, the component will default to the `earliestDate` or the current date.
+     *
+     * We provide some options in `dateRangeOptionPresets` for convenience.
      */
     @property({ type: Array })
     dateRangeOptions: { label: string; dateFrom?: string; dateTo?: string }[] = [];
@@ -66,33 +69,17 @@ export class DateRangeSelectorComponent extends PreactLitAdapter {
     earliestDate: string = '1900-01-01';
 
     /**
-     * The initial value to use for this date range selector.
-     * Must be a valid label from the `dateRangeOptions`.
+     * The value to use for this date range selector.
+     * - If it is a string, then it must be a valid label from the `dateRangeOptions`.
+     * - If it is an object, then it accepts dates in the format `YYYY-MM-DD` for the keys `dateFrom` and `dateTo`.
+     *   Keys that are not set will default to the `earliestDate` or the current date respectively.
+     * - If the attribute is not set, the component will default to the range `earliestDate` until today.
      *
-     * If the value is not set, the component will default to the range `earliestDate` until today.
-     *
-     * It will be overwritten if `initialDateFrom` or `initialDateTo` is set.
-     *
-     * We provide some options in `dateRangeOptionPresets` for convenience.
+     * The `detail` of the `gs-date-range-option-changed` event can be used for this attribute,
+     * if you want to control this component in your JS application.
      */
-    @property()
-    initialValue: string | undefined = undefined;
-
-    /**
-     * A date string in the format `YYYY-MM-DD`.
-     * If set, the date range selector will be initialized with the given date (overwriting `initialValue` to `custom`).
-     * If `initialDateTo` is set, but this is unset, it will default to `earliestDate`.
-     */
-    @property()
-    initialDateFrom: string | undefined = undefined;
-
-    /**
-     * A date string in the format `YYYY-MM-DD`.
-     * If set, the date range selector will be initialized with the given date (overwriting `initialValue` to `custom`).
-     * If `initialDateFrom` is set, but this is unset, it will default to the current date.
-     */
-    @property()
-    initialDateTo: string | undefined = undefined;
+    @property({ type: Object })
+    value: string | { dateFrom?: string; dateTo?: string } | undefined = undefined;
 
     /**
      * The width of the component.
@@ -113,9 +100,7 @@ export class DateRangeSelectorComponent extends PreactLitAdapter {
             <DateRangeSelector
                 dateRangeOptions={this.dateRangeOptions}
                 earliestDate={this.earliestDate}
-                initialValue={this.initialValue}
-                initialDateFrom={this.initialDateFrom}
-                initialDateTo={this.initialDateTo}
+                value={this.value}
                 lapisDateField={this.lapisDateField}
                 width={this.width}
             />
@@ -150,15 +135,7 @@ type CustomSelectOptionsMatches = Expect<
 type EarliestDateMatches = Expect<
     Equals<typeof DateRangeSelectorComponent.prototype.earliestDate, DateRangeSelectorProps['earliestDate']>
 >;
-type InitialValueMatches = Expect<
-    Equals<typeof DateRangeSelectorComponent.prototype.initialValue, DateRangeSelectorProps['initialValue']>
->;
-type InitialDateFromMatches = Expect<
-    Equals<typeof DateRangeSelectorComponent.prototype.initialDateFrom, DateRangeSelectorProps['initialDateFrom']>
->;
-type InitialDateToMatches = Expect<
-    Equals<typeof DateRangeSelectorComponent.prototype.initialDateTo, DateRangeSelectorProps['initialDateTo']>
->;
+type ValueMatches = Expect<Equals<typeof DateRangeSelectorComponent.prototype.value, DateRangeSelectorProps['value']>>;
 type WidthMatches = Expect<Equals<typeof DateRangeSelectorComponent.prototype.width, DateRangeSelectorProps['width']>>;
 type DateColumnMatches = Expect<
     Equals<typeof DateRangeSelectorComponent.prototype.lapisDateField, DateRangeSelectorProps['lapisDateField']>

--- a/examples/React/src/App.tsx
+++ b/examples/React/src/App.tsx
@@ -76,7 +76,7 @@ function App() {
             ></gs-location-filter>
             <gs-date-range-selector
                 dateRangeOptions={JSON.stringify(dataRangeOptions)}
-                initialValue={'2021'}
+                value={JSON.stringify(dateRange)}
                 lapisDateField='date'
             ></gs-date-range-selector>
             <div style={{display: 'flex', flexDirection: 'row'}}>

--- a/examples/plainJavascript/index.html
+++ b/examples/plainJavascript/index.html
@@ -22,7 +22,7 @@
             ></gs-location-filter>
             <gs-date-range-selector
                 dateRangeOptions='[{"label":"2020","dateFrom":"2020-01-01","dateTo":"2020-12-31"},{"label":"2021","dateFrom":"2021-01-01","dateTo":"2021-12-31"},{"label":"2022","dateFrom":"2022-01-01","dateTo":"2022-12-31"}]'
-                initialValue="2021"
+                value="2021"
                 lapisDateField="date"
             ></gs-date-range-selector>
             <gs-prevalence-over-time


### PR DESCRIPTION

resolves #683


### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Now you can supply a `value` to this component. It serves as an initial value, if the attribute doesn't change. If the attribute changes, then the component will switch to use that value.

BREAKING CHANGE: gs-date-range-selector: remove `initialValue`, `initialDateFrom`, `initialDateTo`. Use `value` instead.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
