### PR TITLE
refactor(components): memoize some chart configs

### DIFF
--- a/components/src/preact/prevalenceOverTime/prevalence-over-time-bubble-chart.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time-bubble-chart.tsx
@@ -1,4 +1,5 @@
 import { Chart, type ChartConfiguration, registerables } from 'chart.js';
+import { useMemo } from 'preact/hooks';
 
 import { maxInData } from './prevalence-over-time';
 import { type PrevalenceOverTimeData } from '../../query/queryPrevalenceOverTime';
@@ -20,94 +21,104 @@ interface PrevalenceOverTimeBubbleChartProps {
 
 Chart.register(...registerables, LogitScale);
 
+const NO_DATA = 'noData';
+
 const PrevalenceOverTimeBubbleChart = ({
     data,
     yAxisScaleType,
     yAxisMaxConfig,
     maintainAspectRatio,
 }: PrevalenceOverTimeBubbleChartProps) => {
-    const nonNullDateRangeData = data
-        .filter((prevalenceOverTimeData) => prevalenceOverTimeData.content.length > 0)
-        .map((variantData) => {
-            return {
-                content: variantData.content.filter((dataPoint) => dataPoint.dateRange !== null),
-                displayName: variantData.displayName,
-            };
-        });
+    const config = useMemo<ChartConfiguration | typeof NO_DATA>(() => {
+        const nonNullDateRangeData = data
+            .filter((prevalenceOverTimeData) => prevalenceOverTimeData.content.length > 0)
+            .map((variantData) => {
+                return {
+                    content: variantData.content.filter((dataPoint) => dataPoint.dateRange !== null),
+                    displayName: variantData.displayName,
+                };
+            });
 
-    if (nonNullDateRangeData.length === 0) {
+        if (nonNullDateRangeData.length === 0) {
+            return NO_DATA;
+        }
+
+        const firstDate = nonNullDateRangeData[0].content[0].dateRange!;
+        const total = nonNullDateRangeData
+            .map((graphData) => graphData.content.map((dataPoint) => dataPoint.total))
+            .flat();
+        const [minTotal, maxTotal] = getMinMaxNumber(total)!;
+        const scaleBubble = (value: number) => {
+            return ((value - minTotal) / (maxTotal - minTotal)) * 4.5 + 0.5;
+        };
+
+        const maxY =
+            yAxisScaleType !== 'logit'
+                ? getYAxisMax(maxInData(nonNullDateRangeData), yAxisMaxConfig?.[yAxisScaleType])
+                : undefined;
+
+        return {
+            type: 'bubble',
+            data: {
+                datasets: nonNullDateRangeData.map((graphData, index) => ({
+                    label: graphData.displayName,
+                    data: graphData.content
+                        .filter((dataPoint) => dataPoint.dateRange !== null)
+                        .map((dataPoint) => ({
+                            x: minusTemporal(dataPoint.dateRange!, firstDate),
+                            y: dataPoint.prevalence,
+                            r: scaleBubble(dataPoint.total),
+                        })),
+                    borderWidth: 1,
+                    pointRadius: 0,
+                    backgroundColor: singleGraphColorRGBAById(index, 0.3),
+                    borderColor: singleGraphColorRGBAById(index),
+                })),
+            },
+            options: {
+                animation: false,
+                maintainAspectRatio,
+                scales: {
+                    x: {
+                        ticks: {
+                            callback: (value) => addUnit(firstDate, value as number).toString(),
+                        },
+                    },
+                    y: { ...getYAxisScale(yAxisScaleType), max: maxY },
+                },
+                plugins: {
+                    legend: {
+                        display: false,
+                    },
+                    tooltip: {
+                        mode: 'index',
+                        intersect: false,
+                        callbacks: {
+                            title: (context) => {
+                                const dataset = nonNullDateRangeData[context[0].datasetIndex];
+                                const dataPoint = dataset.content[context[0].dataIndex];
+                                return dataPoint.dateRange?.toString();
+                            },
+                            label: (context) => {
+                                const dataset = nonNullDateRangeData[context.datasetIndex];
+                                const dataPoint = dataset.content[context.dataIndex];
+
+                                const percentage = (dataPoint.prevalence * 100).toFixed(2);
+                                const count = dataPoint.count.toFixed(0);
+                                const total = dataPoint.total.toFixed(0);
+
+                                return `${dataset.displayName}: ${percentage}%, ${count}/${total} samples`;
+                            },
+                        },
+                    },
+                },
+            },
+        } satisfies ChartConfiguration;
+    }, [data, maintainAspectRatio, yAxisMaxConfig, yAxisScaleType]);
+
+    if (config === NO_DATA) {
         return <NoDataDisplay />;
     }
-
-    const firstDate = nonNullDateRangeData[0].content[0].dateRange!;
-    const total = nonNullDateRangeData.map((graphData) => graphData.content.map((dataPoint) => dataPoint.total)).flat();
-    const [minTotal, maxTotal] = getMinMaxNumber(total)!;
-    const scaleBubble = (value: number) => {
-        return ((value - minTotal) / (maxTotal - minTotal)) * 4.5 + 0.5;
-    };
-
-    const maxY =
-        yAxisScaleType !== 'logit'
-            ? getYAxisMax(maxInData(nonNullDateRangeData), yAxisMaxConfig?.[yAxisScaleType])
-            : undefined;
-
-    const config: ChartConfiguration = {
-        type: 'bubble',
-        data: {
-            datasets: nonNullDateRangeData.map((graphData, index) => ({
-                label: graphData.displayName,
-                data: graphData.content
-                    .filter((dataPoint) => dataPoint.dateRange !== null)
-                    .map((dataPoint) => ({
-                        x: minusTemporal(dataPoint.dateRange!, firstDate),
-                        y: dataPoint.prevalence,
-                        r: scaleBubble(dataPoint.total),
-                    })),
-                borderWidth: 1,
-                pointRadius: 0,
-                backgroundColor: singleGraphColorRGBAById(index, 0.3),
-                borderColor: singleGraphColorRGBAById(index),
-            })),
-        },
-        options: {
-            animation: false,
-            maintainAspectRatio,
-            scales: {
-                x: {
-                    ticks: {
-                        callback: (value) => addUnit(firstDate, value as number).toString(),
-                    },
-                },
-                y: { ...getYAxisScale(yAxisScaleType), max: maxY },
-            },
-            plugins: {
-                legend: {
-                    display: false,
-                },
-                tooltip: {
-                    mode: 'index',
-                    intersect: false,
-                    callbacks: {
-                        title: (context) => {
-                            const dataset = nonNullDateRangeData[context[0].datasetIndex];
-                            const dataPoint = dataset.content[context[0].dataIndex];
-                            return dataPoint.dateRange?.toString();
-                        },
-                        label: (context) => {
-                            const dataset = nonNullDateRangeData[context.datasetIndex];
-                            const dataPoint = dataset.content[context.dataIndex];
-
-                            const percentage = (dataPoint.prevalence * 100).toFixed(2);
-                            const count = dataPoint.count.toFixed(0);
-                            const total = dataPoint.total.toFixed(0);
-
-                            return `${dataset.displayName}: ${percentage}%, ${count}/${total} samples`;
-                        },
-                    },
-                },
-            },
-        },
-    };
 
     return <GsChart configuration={config} />;
 };

--- a/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage-chart.tsx
+++ b/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage-chart.tsx
@@ -1,4 +1,5 @@
 import { Chart, type ChartConfiguration, registerables, type TooltipItem } from 'chart.js';
+import { useMemo } from 'preact/hooks';
 
 import { type YearMonthDayClass } from '../../utils/temporalClass';
 import GsChart from '../components/chart';
@@ -39,31 +40,33 @@ const RelativeGrowthAdvantageChart = ({
     yAxisMaxConfig,
     maintainAspectRatio,
 }: RelativeGrowthAdvantageChartProps) => {
-    const maxY =
-        yAxisScaleType !== 'logit'
-            ? getYAxisMax(Math.max(...data.proportion), yAxisMaxConfig?.[yAxisScaleType])
-            : undefined;
+    const config = useMemo<ChartConfiguration>(() => {
+        const maxY =
+            yAxisScaleType !== 'logit'
+                ? getYAxisMax(Math.max(...data.proportion), yAxisMaxConfig?.[yAxisScaleType])
+                : undefined;
 
-    const config: ChartConfiguration = {
-        type: 'line',
-        data: {
-            labels: data.t,
-            datasets: datasets(data),
-        },
-        options: {
-            maintainAspectRatio,
-            animation: false,
-            scales: {
-                y: { ...getYAxisScale(yAxisScaleType), max: maxY },
+        return {
+            type: 'line',
+            data: {
+                labels: data.t,
+                datasets: datasets(data),
             },
-            plugins: {
-                legend: {
-                    display: false,
+            options: {
+                maintainAspectRatio,
+                animation: false,
+                scales: {
+                    y: { ...getYAxisScale(yAxisScaleType), max: maxY },
                 },
-                tooltip: tooltip(),
+                plugins: {
+                    legend: {
+                        display: false,
+                    },
+                    tooltip: tooltip(),
+                },
             },
-        },
-    };
+        };
+    }, [data, yAxisScaleType, yAxisMaxConfig, maintainAspectRatio]);
 
     return (
         <div className='flex h-full flex-col'>


### PR DESCRIPTION

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

While reviewing #713 I noticed that some of the chart configs aren't memoized. I believe we can boost the performance a little by wrapping them in a `useMemo`.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
