### PR TITLE
fix(components): reset error when the component props have changed

### DIFF
--- a/components/src/preact/components/error-boundary.tsx
+++ b/components/src/preact/components/error-boundary.tsx
@@ -1,5 +1,5 @@
 import { type RenderableProps } from 'preact';
-import { useErrorBoundary, useMemo } from 'preact/hooks';
+import { useEffect, useErrorBoundary, useMemo } from 'preact/hooks';
 import { type ZodSchema } from 'zod';
 
 import { ErrorDisplay, type ErrorDisplayProps, InvalidPropsError } from './error-display';
@@ -21,6 +21,16 @@ export const ErrorBoundary = <T extends Record<string, unknown>>({
 }: RenderableProps<ErrorBoundaryProps<T>>) => {
     const [internalError, resetError] = useErrorBoundary();
     const componentPropsParseError = useCheckComponentProps(schema, componentProps);
+
+    useEffect(
+        () => {
+            if (internalError) {
+                resetError();
+            }
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- this should run if and only if the props of the component change
+        [componentProps],
+    );
 
     if (internalError) {
         return (


### PR DESCRIPTION

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
* Take the "Text input - Default" story
* change the `lapisField` to "hos" (i.e. making it an invalid field)
* The component will show an error, because LAPIS shows an error
* change  the `lapisField` to "host" (i.e. making it a valid field again)

 Before: It would still show an error until you click "Try again" 
Now: It rerenders and doesn't show an error anymore

Related to https://github.com/GenSpectrum/dashboards/issues/530
### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
