### PR TITLE
fix(components): gs-date-range-selector `value`: make sure that strings are recognized as strings

### DIFF
--- a/components/.eslintrc.json
+++ b/components/.eslintrc.json
@@ -33,7 +33,8 @@
             "warn",
             {
                 "argsIgnorePattern": "^_",
-                "varsIgnorePattern": "^_"
+                "varsIgnorePattern": "^_",
+                "caughtErrorsIgnorePattern": "^_"
             }
         ],
         "@typescript-eslint/consistent-type-imports": [

--- a/components/src/web-components/input/gs-date-range-selector.stories.ts
+++ b/components/src/web-components/input/gs-date-range-selector.stories.ts
@@ -65,6 +65,7 @@ const meta: Meta<Required<DateRangeSelectorProps>> = {
             dateRangeOptionPresets.lastMonth,
             dateRangeOptionPresets.last3Months,
             dateRangeOptionPresets.allTimes,
+            { label: '2021', dateFrom: '2021-01-01', dateTo: '2021-12-31' },
             customDateRange,
         ],
         earliestDate: '1970-01-01',
@@ -90,6 +91,50 @@ export const Default: StoryObj<Required<DateRangeSelectorProps>> = {
                 ></gs-date-range-selector>
             </div>
         </gs-app>`,
+};
+
+export const TestRenderAttributesInHtmlInsteadOfUsingPropertyExpression: StoryObj<Required<DateRangeSelectorProps>> = {
+    render: (args) =>
+        html` <gs-app lapis="${LAPIS_URL}">
+            <div class="max-w-screen-lg">
+                <gs-date-range-selector
+                    .dateRangeOptions=${args.dateRangeOptions}
+                    earliestDate="${args.earliestDate}"
+                    value="${args.value}"
+                    width="${args.width}"
+                    lapisDateField="${args.lapisDateField}"
+                ></gs-date-range-selector>
+            </div>
+        </gs-app>`,
+    play: async ({ canvasElement }) => {
+        const canvas = await withinShadowRoot(canvasElement, 'gs-date-range-selector');
+
+        await waitFor(async () => {
+            await expect(selectField(canvas)).toHaveValue('Last month');
+        });
+    },
+    argTypes: {
+        value: {
+            control: {
+                type: 'text',
+            },
+        },
+    },
+};
+
+export const TestSettingANumericValueIsTreatedAsString: StoryObj<Required<DateRangeSelectorProps>> = {
+    ...TestRenderAttributesInHtmlInsteadOfUsingPropertyExpression,
+    args: {
+        ...TestRenderAttributesInHtmlInsteadOfUsingPropertyExpression.args,
+        value: '2021',
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = await withinShadowRoot(canvasElement, 'gs-date-range-selector');
+
+        await waitFor(async () => {
+            await expect(selectField(canvas)).toHaveValue('2021');
+        });
+    },
 };
 
 export const FiresEvents: StoryObj<Required<DateRangeSelectorProps>> = {

--- a/components/src/web-components/input/gs-date-range-selector.tsx
+++ b/components/src/web-components/input/gs-date-range-selector.tsx
@@ -78,7 +78,22 @@ export class DateRangeSelectorComponent extends PreactLitAdapter {
      * The `detail` of the `gs-date-range-option-changed` event can be used for this attribute,
      * if you want to control this component in your JS application.
      */
-    @property({ type: Object })
+    @property({
+        converter: (value) => {
+            if (value === null) {
+                return undefined;
+            }
+            try {
+                const result = JSON.parse(value) as unknown;
+                if (typeof result !== 'object' && typeof result !== 'string') {
+                    return value;
+                }
+                return result;
+            } catch (_) {
+                return value;
+            }
+        },
+    })
     value: string | { dateFrom?: string; dateTo?: string } | undefined = undefined;
 
     /**


### PR DESCRIPTION


### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->


 Due to using `@property({ type: Object })`, lit would always `JSON.parse` the attribute:
 - `value="Last month"` would be invalid, because it's not a valid JSON string
 - using additional quotes like `value=""Last month""` would be valid, because that is a valid JSON string
 - `value="2021"` would be invalid, because JSON.parse would parse it into a number, which is not accepted by the zod schema

 This make sure that we treat everything as a string if it doesn't parse into an object.
 JSON strings (with the additional quotes) will still be treated as a string.

 We didn't notice this in Storybook, because due to using
 ```
 html`<gs-date-range-selector .value=${args.value}/>`
 ```
 it seems that lit directly set the properties in the class instead of passing it via text in the HTML
 (i.e. setting the attributes).
https://lit.dev/docs/templates/expressions/#property-expressions
 (The browser dev tools show `<gs-date-range-selector>` without any attributes)
### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
