### PR TITLE
fix(components): gs-sequences-by-location: don't crash table view when there is no data

### DIFF
--- a/components/src/preact/sequencesByLocation/sequences-by-location-table.tsx
+++ b/components/src/preact/sequencesByLocation/sequences-by-location-table.tsx
@@ -32,7 +32,7 @@ export const SequencesByLocationTable: FunctionComponent<SequencesByLocationTabl
             sort: true,
             formatter: (cell: number) => formatProportion(cell),
         },
-        ...('isShownOnMap' in tableData[0]
+        ...(tableData.length > 0 && 'isShownOnMap' in tableData[0]
             ? [{ id: 'isShownOnMap', name: 'shown on map', sort: true, width: '20%' }]
             : []),
     ];

--- a/components/src/preact/sequencesByLocation/sequences-by-location.stories.tsx
+++ b/components/src/preact/sequencesByLocation/sequences-by-location.stories.tsx
@@ -1,4 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/preact';
+import { expect, waitFor, within } from '@storybook/test';
 
 import worldAtlas from './__mockData__/worldAtlas.json';
 import { AGGREGATED_ENDPOINT, LAPIS_URL } from '../../constants';
@@ -88,6 +89,48 @@ export const Default: StoryObj<SequencesByLocationProps> = {
                 aggregatedWorldMatcher,
             ],
         },
+    },
+};
+
+export const NoData: StoryObj<SequencesByLocationProps> = {
+    ...Default,
+    parameters: {
+        fetchMock: {
+            mocks: [
+                {
+                    matcher: {
+                        name: 'worldMap',
+                        url: worldMapUrl,
+                    },
+                    response: {
+                        status: 200,
+                        body: worldAtlas,
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'aggregatedData',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            fields: ['country'],
+                            dateFrom: '2022-01-01',
+                            dateTo: '2022-04-01',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: { data: [] },
+                    },
+                },
+            ],
+        },
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        await waitFor(async () => {
+            await expect(canvas.getByText('No data available.')).toBeVisible();
+        });
     },
 };
 

--- a/components/src/preact/sequencesByLocation/sequences-by-location.tsx
+++ b/components/src/preact/sequencesByLocation/sequences-by-location.tsx
@@ -20,6 +20,7 @@ import { ResizeContainer } from '../components/resize-container';
 import { useQuery } from '../useQuery';
 import { mapSourceSchema } from './loadMapSource';
 import { lapisFilterSchema, views } from '../../types';
+import { NoDataDisplay } from '../components/no-data-display';
 import Tabs from '../components/tabs';
 import { getMaintainAspectRatio } from '../shared/charts/getMaintainAspectRatio';
 
@@ -74,6 +75,10 @@ const SequencesByLocationMapInner: FunctionComponent<SequencesByLocationProps> =
 
     if (error) {
         throw error;
+    }
+
+    if (data.tableData.length === 0) {
+        return <NoDataDisplay />;
     }
 
     return <SequencesByLocationMapTabs data={data} originalComponentProps={props} />;


### PR DESCRIPTION


### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
The table view of `gs-sequences-by-location` crashes when LAPIS doesn't return any data for the specified filters.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->


Before:
![grafik](https://github.com/user-attachments/assets/e19a57d0-7507-4ffd-9668-a5a45490e831)

After:
![grafik](https://github.com/user-attachments/assets/10f8dfbe-3a57-4761-88c8-05f735a2d33a)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
