### PR TITLE
719 date range selector add undefined status

### DIFF
--- a/components/src/preact/components/clearable-select.stories.tsx
+++ b/components/src/preact/components/clearable-select.stories.tsx
@@ -1,0 +1,75 @@
+import { type Meta, type StoryObj } from '@storybook/preact';
+import { fn, userEvent, within } from '@storybook/test';
+
+import { ClearableSelect, type ClearableSelectProps } from './clearable-select';
+import { expectOptionSelected } from '../shared/stories/expectOptionSelected';
+
+const meta: Meta<ClearableSelectProps> = {
+    title: 'Component/ClearableSelect',
+    component: ClearableSelect,
+    parameters: { fetchMock: {} },
+};
+
+export default meta;
+
+export const Default: StoryObj<ClearableSelectProps> = {
+    render: (args) => (
+        <div class='flex justify-center px-4 py-16'>
+            <ClearableSelect {...args} />
+        </div>
+    ),
+    args: {
+        items: ['firstOption', 'secondOption'],
+        onChange: fn(),
+    },
+    play: async ({ canvasElement, step }) => {
+        await step('Show default placeholder', async () => {
+            await expectOptionSelected(canvasElement, 'Select an option');
+        });
+    },
+};
+
+export const UseInitialSelectedItem: StoryObj<ClearableSelectProps> = {
+    ...Default,
+    args: {
+        ...Default.args,
+        initiallySelectedItem: 'firstOption',
+    },
+    play: async ({ canvasElement, step }) => {
+        await step('Show initiallySelectedItem', async () => {
+            await expectOptionSelected(canvasElement, 'firstOption');
+        });
+    },
+};
+
+export const SwitchToOption: StoryObj<ClearableSelectProps> = {
+    ...Default,
+    play: async ({ canvasElement, step }) => {
+        const canvas = within(canvasElement);
+
+        await step('Select an option', async () => {
+            await userEvent.selectOptions(getSelectElement(canvas), 'firstOption');
+            await expectOptionSelected(canvasElement, 'firstOption');
+        });
+    },
+};
+
+export const ClearOption: StoryObj<ClearableSelectProps> = {
+    ...Default,
+    args: {
+        ...Default.args,
+        initiallySelectedItem: 'firstOption',
+    },
+    play: async ({ canvasElement, step }) => {
+        const canvas = within(canvasElement);
+
+        await step('Clear the selected option', async () => {
+            await userEvent.click(canvas.getByRole('button', { name: '×' }));
+            await expectOptionSelected(canvasElement, 'Select an option');
+        });
+    },
+};
+
+const getSelectElement = (canvas: ReturnType<typeof within>) => {
+    return canvas.getByRole('combobox');
+};

--- a/components/src/preact/components/clearable-select.tsx
+++ b/components/src/preact/components/clearable-select.tsx
@@ -1,0 +1,76 @@
+import { type ChangeEvent } from 'preact/compat';
+import { useEffect, useState } from 'preact/hooks';
+
+import { type WithClassName } from '../shared/WithClassName/WithClassName';
+import { DeleteIcon } from '../shared/icons/DeleteIcon';
+
+export const undefinedValue = '__undefined__';
+
+export type ClearableSelectProps = {
+    items: string[];
+    initiallySelectedItem?: string | null;
+    onChange?: (item: string | null) => void;
+    placeholderText?: string;
+    value?: string | null;
+    selectClassName?: string;
+};
+
+export function ClearableSelect({
+    items,
+    initiallySelectedItem,
+    onChange,
+    placeholderText,
+    className,
+    value,
+    selectClassName,
+}: WithClassName<ClearableSelectProps>) {
+    const [selectedOption, setSelectedOption] = useState<string | null>(initiallySelectedItem ?? null);
+
+    useEffect(() => {
+        if (value !== undefined) {
+            setSelectedOption(value);
+        }
+    }, [value]);
+
+    const handleClear = () => {
+        setSelectedOption(null);
+        if (onChange) {
+            onChange(null);
+        }
+    };
+
+    const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+        const newValue = event.currentTarget.value;
+        setSelectedOption(newValue);
+        if (onChange) {
+            onChange(newValue);
+        }
+    };
+
+    return (
+        <div className={`relative inline min-w-24 ${className}`}>
+            <select
+                className={`w-full select select-bordered pr-14 ${selectClassName}`}
+                value={selectedOption ?? undefinedValue}
+                onChange={handleChange}
+            >
+                <option value={undefinedValue} disabled>
+                    {placeholderText ?? 'Select an option'}
+                </option>
+                {items.map((item) => (
+                    <option key={item} value={item}>
+                        {item}
+                    </option>
+                ))}
+            </select>
+            {selectedOption && (
+                <button
+                    onClick={handleClear}
+                    className='absolute right-10 top-1/2 -translate-y-1/2 bg-transparent border-0 cursor-pointer'
+                >
+                    <DeleteIcon />
+                </button>
+            )}
+        </div>
+    );
+}

--- a/components/src/preact/components/downshift-combobox.tsx
+++ b/components/src/preact/components/downshift-combobox.tsx
@@ -2,6 +2,8 @@ import { useCombobox } from 'downshift/preact';
 import { type ComponentChild } from 'preact';
 import { useMemo, useRef, useState } from 'preact/hooks';
 
+import { DeleteIcon } from '../shared/icons/DeleteIcon';
+
 export function DownshiftCombobox<Item>({
     allItems,
     value,
@@ -10,18 +12,18 @@ export function DownshiftCombobox<Item>({
     itemToString,
     placeholderText,
     formatItemInList,
+    inputClassName = '',
 }: {
     allItems: Item[];
-    value?: Item;
+    value?: Item | null;
     filterItemsByInputValue: (item: Item, value: string) => boolean;
     createEvent: (item: Item | null) => CustomEvent;
     itemToString: (item: Item | undefined | null) => string;
     placeholderText?: string;
     formatItemInList: (item: Item) => ComponentChild;
+    inputClassName?: string;
 }) {
-    const initialSelectedItem = value ?? null;
-
-    const [itemsFilter, setItemsFilter] = useState(itemToString(initialSelectedItem));
+    const [itemsFilter, setItemsFilter] = useState(itemToString(value));
     const items = useMemo(
         () => allItems.filter((item) => filterItemsByInputValue(item, itemsFilter)),
         [allItems, filterItemsByInputValue, itemsFilter],
@@ -65,7 +67,7 @@ export function DownshiftCombobox<Item>({
         itemToString(item) {
             return itemToString(item);
         },
-        initialSelectedItem,
+        selectedItem: value,
         environment,
     });
 
@@ -89,7 +91,7 @@ export function DownshiftCombobox<Item>({
         <div ref={divRef} className={'relative w-full'}>
             <div className='w-full flex flex-col gap-1'>
                 <div
-                    className='flex gap-0.5 input input-bordered min-w-32'
+                    className={`flex gap-0.5 input input-bordered min-w-32 ${inputClassName}`}
                     onBlur={(event) => {
                         if (event.relatedTarget != buttonRef.current) {
                             closeMenu();
@@ -109,7 +111,7 @@ export function DownshiftCombobox<Item>({
                         onClick={clearInput}
                         tabIndex={-1}
                     >
-                        ×
+                        <DeleteIcon />
                     </button>
                     <button
                         aria-label='toggle menu'

--- a/components/src/preact/dateRangeFilter/computeInitialValues.spec.ts
+++ b/components/src/preact/dateRangeFilter/computeInitialValues.spec.ts
@@ -18,36 +18,34 @@ const dateRangeOptions = [
 ];
 
 describe('computeInitialValues', () => {
+    it('should return undefined for unedfined value', () => {
+        const result = computeInitialValues(undefined, earliestDate, dateRangeOptions);
+
+        expect(result).toBeUndefined();
+    });
+
     it('should compute initial value if value is dateRangeOption label', () => {
         const result = computeInitialValues(fromToOption, earliestDate, dateRangeOptions);
 
-        expect(result.initialSelectedDateRange).toEqual(fromToOption);
-        expectDateMatches(result.initialSelectedDateFrom, new Date(dateFromOptionValue));
-        expectDateMatches(result.initialSelectedDateTo, new Date(dateToOptionValue));
+        expect(result?.initialSelectedDateRange).toEqual(fromToOption);
+        expectDateMatches(result?.initialSelectedDateFrom, new Date(dateFromOptionValue));
+        expectDateMatches(result?.initialSelectedDateTo, new Date(dateToOptionValue));
     });
 
     it('should use today as "dateTo" if it is unset in selected option', () => {
         const result = computeInitialValues(fromOption, earliestDate, dateRangeOptions);
 
-        expect(result.initialSelectedDateRange).toEqual(fromOption);
-        expectDateMatches(result.initialSelectedDateFrom, new Date(dateFromOptionValue));
-        expectDateMatches(result.initialSelectedDateTo, today);
+        expect(result?.initialSelectedDateRange).toEqual(fromOption);
+        expectDateMatches(result?.initialSelectedDateFrom, new Date(dateFromOptionValue));
+        expectDateMatches(result?.initialSelectedDateTo, today);
     });
 
     it('should use earliest date as "dateFrom" if it is unset in selected option', () => {
         const result = computeInitialValues(toOption, earliestDate, dateRangeOptions);
 
-        expect(result.initialSelectedDateRange).toEqual(toOption);
-        expectDateMatches(result.initialSelectedDateFrom, new Date(earliestDate));
-        expectDateMatches(result.initialSelectedDateTo, new Date(dateToOptionValue));
-    });
-
-    it('should fall back to full range if initial value is not set', () => {
-        const result = computeInitialValues(undefined, earliestDate, dateRangeOptions);
-
-        expect(result.initialSelectedDateRange).toBeUndefined();
-        expectDateMatches(result.initialSelectedDateFrom, new Date(earliestDate));
-        expectDateMatches(result.initialSelectedDateTo, today);
+        expect(result?.initialSelectedDateRange).toEqual(toOption);
+        expectDateMatches(result?.initialSelectedDateFrom, new Date(earliestDate));
+        expectDateMatches(result?.initialSelectedDateTo, new Date(dateToOptionValue));
     });
 
     it('should throw when initial value is unknown', () => {
@@ -66,18 +64,18 @@ describe('computeInitialValues', () => {
         const initialDateFrom = '2020-01-01';
         const result = computeInitialValues({ dateFrom: initialDateFrom }, earliestDate, dateRangeOptions);
 
-        expect(result.initialSelectedDateRange).toBeUndefined();
-        expectDateMatches(result.initialSelectedDateFrom, new Date(initialDateFrom));
-        expectDateMatches(result.initialSelectedDateTo, today);
+        expect(result?.initialSelectedDateRange).toBeUndefined();
+        expectDateMatches(result?.initialSelectedDateFrom, new Date(initialDateFrom));
+        expectDateMatches(result?.initialSelectedDateTo, today);
     });
 
     it('should select from earliest date until date if only dateTo is given', () => {
         const initialDateTo = '2020-01-01';
         const result = computeInitialValues({ dateTo: initialDateTo }, earliestDate, dateRangeOptions);
 
-        expect(result.initialSelectedDateRange).toBeUndefined();
-        expectDateMatches(result.initialSelectedDateFrom, new Date(earliestDate));
-        expectDateMatches(result.initialSelectedDateTo, new Date(initialDateTo));
+        expect(result?.initialSelectedDateRange).toBeUndefined();
+        expectDateMatches(result?.initialSelectedDateFrom, new Date(earliestDate));
+        expectDateMatches(result?.initialSelectedDateTo, new Date(initialDateTo));
     });
 
     it('should select date range is dateFrom and dateTo are given', () => {
@@ -92,9 +90,9 @@ describe('computeInitialValues', () => {
             dateRangeOptions,
         );
 
-        expect(result.initialSelectedDateRange).toBeUndefined();
-        expectDateMatches(result.initialSelectedDateFrom, new Date(initialDateFrom));
-        expectDateMatches(result.initialSelectedDateTo, new Date(initialDateTo));
+        expect(result?.initialSelectedDateRange).toBeUndefined();
+        expectDateMatches(result?.initialSelectedDateFrom, new Date(initialDateFrom));
+        expectDateMatches(result?.initialSelectedDateTo, new Date(initialDateTo));
     });
 
     it('should set initial "to" to "from" if "from" is after "to"', () => {
@@ -109,9 +107,9 @@ describe('computeInitialValues', () => {
             dateRangeOptions,
         );
 
-        expect(result.initialSelectedDateRange).toBeUndefined();
-        expectDateMatches(result.initialSelectedDateFrom, new Date(initialDateFrom));
-        expectDateMatches(result.initialSelectedDateTo, new Date(initialDateFrom));
+        expect(result?.initialSelectedDateRange).toBeUndefined();
+        expectDateMatches(result?.initialSelectedDateFrom, new Date(initialDateFrom));
+        expectDateMatches(result?.initialSelectedDateTo, new Date(initialDateFrom));
     });
 
     it('should throw if initial "from" is not a valid date', () => {
@@ -126,9 +124,9 @@ describe('computeInitialValues', () => {
         );
     });
 
-    function expectDateMatches(actual: Date, expected: Date) {
-        expect(actual.getFullYear()).toEqual(expected.getFullYear());
-        expect(actual.getMonth()).toEqual(expected.getMonth());
-        expect(actual.getDate()).toEqual(expected.getDate());
+    function expectDateMatches(actual: Date | undefined, expected: Date | undefined) {
+        expect(actual?.getFullYear()).toEqual(expected?.getFullYear());
+        expect(actual?.getMonth()).toEqual(expected?.getMonth());
+        expect(actual?.getDate()).toEqual(expected?.getDate());
     }
 });

--- a/components/src/preact/dateRangeFilter/computeInitialValues.ts
+++ b/components/src/preact/dateRangeFilter/computeInitialValues.ts
@@ -2,22 +2,9 @@ import { type DateRangeOption, type DateRangeValue } from './dateRangeOption';
 import { getDatesForSelectorValue, getSelectableOptions } from './selectableOptions';
 import { UserFacingError } from '../components/error-display';
 
-export function computeInitialValues(
-    value: DateRangeValue | undefined,
-    earliestDate: string,
-    dateRangeOptions: DateRangeOption[],
-): {
-    initialSelectedDateRange: string | undefined;
-    initialSelectedDateFrom: Date;
-    initialSelectedDateTo: Date;
-} {
+export function computeInitialValues(value: DateRangeValue, earliestDate: string, dateRangeOptions: DateRangeOption[]) {
     if (value === undefined) {
-        const { dateFrom, dateTo } = getDatesForSelectorValue(undefined, dateRangeOptions, earliestDate);
-        return {
-            initialSelectedDateRange: undefined,
-            initialSelectedDateFrom: dateFrom,
-            initialSelectedDateTo: dateTo,
-        };
+        return undefined;
     }
 
     if (typeof value === 'string') {

--- a/components/src/preact/dateRangeFilter/date-picker.tsx
+++ b/components/src/preact/dateRangeFilter/date-picker.tsx
@@ -1,0 +1,66 @@
+import 'flatpickr/dist/flatpickr.min.css';
+import flatpickr from 'flatpickr';
+import { useEffect, useRef, useState } from 'preact/hooks';
+
+import { type WithClassName } from '../shared/WithClassName/WithClassName';
+
+export function DatePicker({
+    onChange,
+    value,
+    minDate,
+    maxDate,
+    placeholderText,
+    className,
+}: WithClassName<{
+    onChange?: (date: Date | undefined) => void;
+    value?: Date;
+    minDate?: Date;
+    maxDate?: Date;
+    placeholderText?: string;
+}>) {
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const [datePicker, setDatePicker] = useState<flatpickr.Instance | null>(null);
+
+    useEffect(() => {
+        if (!inputRef.current) {
+            return;
+        }
+
+        const instance = flatpickr(inputRef.current, {
+            allowInput: true,
+            dateFormat: 'Y-m-d',
+            defaultDate: value,
+            minDate,
+            maxDate,
+        });
+
+        setDatePicker(instance);
+
+        return () => {
+            instance.destroy();
+        };
+    }, [maxDate, minDate, onChange, value]);
+
+    if (value === undefined && inputRef.current) {
+        inputRef.current.value = '';
+    }
+
+    const handleChange = () => {
+        const newValue = datePicker?.selectedDates[0];
+        if (onChange) {
+            onChange(newValue);
+        }
+    };
+
+    return (
+        <input
+            className={`input input-bordered w-full ${className}`}
+            type='text'
+            placeholder={placeholderText}
+            ref={inputRef}
+            onChange={handleChange}
+            onBlur={handleChange}
+        />
+    );
+}

--- a/components/src/preact/dateRangeFilter/dateRangeOption.ts
+++ b/components/src/preact/dateRangeFilter/dateRangeOption.ts
@@ -22,20 +22,20 @@ export const dateRangeOptionSchema = z.object({
 
 export type DateRangeOption = z.infer<typeof dateRangeOptionSchema>;
 
-export const dateRangeValueSchema = z.union([
-    z.string(),
-    z.object({
-        dateFrom: z.string().date().optional(),
-        dateTo: z.string().date().optional(),
-    }),
-]);
+export const dateRangeValueSchema = z
+    .union([
+        z.string(),
+        z.object({
+            dateFrom: z.string().date().optional(),
+            dateTo: z.string().date().optional(),
+        }),
+    ])
+    .optional();
 
 export type DateRangeValue = z.infer<typeof dateRangeValueSchema>;
 
-export type DateRangeSelectOption = Required<DateRangeValue>;
-
-export class DateRangeOptionChangedEvent extends CustomEvent<DateRangeSelectOption> {
-    constructor(detail: DateRangeSelectOption) {
+export class DateRangeOptionChangedEvent extends CustomEvent<DateRangeValue> {
+    constructor(detail: DateRangeValue) {
         super('gs-date-range-option-changed', {
             detail,
             bubbles: true,

--- a/components/src/preact/shared/WithClassName/WithClassName.ts
+++ b/components/src/preact/shared/WithClassName/WithClassName.ts
@@ -1,0 +1,1 @@
+export type WithClassName<T = object> = T & { className?: string };

--- a/components/src/preact/shared/icons/DeleteIcon.tsx
+++ b/components/src/preact/shared/icons/DeleteIcon.tsx
@@ -1,0 +1,3 @@
+export function DeleteIcon() {
+    return <>×</>;
+}

--- a/components/src/preact/shared/stories/expectOptionSelected.tsx
+++ b/components/src/preact/shared/stories/expectOptionSelected.tsx
@@ -1,0 +1,7 @@
+import { expect, within } from '@storybook/test';
+
+export const expectOptionSelected = async (canvasElement: HTMLElement, option: string) => {
+    const canvas = within(canvasElement);
+    const placeholderOption = canvas.getByRole('combobox').querySelector('option:checked');
+    await expect(placeholderOption).toHaveTextContent(option);
+};

--- a/components/src/utilEntrypoint.ts
+++ b/components/src/utilEntrypoint.ts
@@ -1,6 +1,6 @@
 export {
     type DateRangeOption,
-    type DateRangeSelectOption,
+    type DateRangeValue,
     dateRangeOptionPresets,
     DateRangeOptionChangedEvent,
 } from './preact/dateRangeFilter/dateRangeOption';

--- a/components/src/web-components/input/gs-date-range-filter.tsx
+++ b/components/src/web-components/input/gs-date-range-filter.tsx
@@ -73,7 +73,6 @@ export class DateRangeFilterComponent extends PreactLitAdapter {
      * - If it is a string, then it must be a valid label from the `dateRangeOptions`.
      * - If it is an object, then it accepts dates in the format `YYYY-MM-DD` for the keys `dateFrom` and `dateTo`.
      *   Keys that are not set will default to the `earliestDate` or the current date respectively.
-     * - If the attribute is not set, the component will default to the range `earliestDate` until today.
      *
      * The `detail` of the `gs-date-range-option-changed` event can be used for this attribute,
      * if you want to control this component in your JS application.
@@ -105,6 +104,12 @@ export class DateRangeFilterComponent extends PreactLitAdapter {
     width: string = '100%';
 
     /**
+     * The placeholder to display on the select dropdown.
+     */
+    @property({ type: String })
+    placeholder: string | undefined = undefined;
+
+    /**
      * The name of the metadata field in LAPIS that contains the date information.
      */
     @property({ type: String })
@@ -118,6 +123,7 @@ export class DateRangeFilterComponent extends PreactLitAdapter {
                 value={this.value}
                 lapisDateField={this.lapisDateField}
                 width={this.width}
+                placeholder={this.placeholder}
             />
         );
     }

--- a/components/tailwind.config.mjs
+++ b/components/tailwind.config.mjs
@@ -6,7 +6,13 @@ import daisyui from 'daisyui';
 const tailwindConfig = {
     content: ['src/**/*.{ts,tsx,html}', 'index.html'],
     theme: {
-        extend: {},
+        extend: {
+            containers: {
+                '2xs': '18rem',
+                '3xs': '16rem',
+                '4xs': '14rem',
+            },
+        },
     },
     plugins: [daisyui, containerQueries, addIconSelectors(['mdi', 'mdi-light'])],
     daisyui: {


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #719

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
- Allows to provide "undefined" as a value to the date range filter component. 
- Allows to remove value from input
- Adapt design, so it has rounded borders, like the other filter components

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
With value:
![grafik](https://github.com/user-attachments/assets/b6f43bb8-2992-4d80-bb3f-a0bdccb4ea4d)

With undefined value
![grafik](https://github.com/user-attachments/assets/a0233409-f3c4-4ebd-9e2a-df5143de9499)


With only one date defined
![grafik](https://github.com/user-attachments/assets/0ef72ffb-1cc5-4ee2-8527-694a5283735f)



### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
