### PR TITLE
feat(components): gs-mutation-filter: show error when the reference genomes are empty

### DIFF
--- a/components/src/preact/ReferenceGenomeContext.ts
+++ b/components/src/preact/ReferenceGenomeContext.ts
@@ -2,4 +2,17 @@ import { createContext } from 'preact';
 
 import { type ReferenceGenome } from '../lapisApi/ReferenceGenome';
 
-export const ReferenceGenomeContext = createContext<ReferenceGenome>({ nucleotideSequences: [], genes: [] });
+const UNINITIALIZED_SEQUENCE = '__uninitialized__';
+
+export const ReferenceGenomeContext = createContext<ReferenceGenome>({
+    nucleotideSequences: [{ name: UNINITIALIZED_SEQUENCE, sequence: '' }],
+    genes: [],
+});
+
+export function isNotInitialized(referenceGenome: ReferenceGenome) {
+    return (
+        referenceGenome.genes.length === 0 &&
+        referenceGenome.nucleotideSequences.length === 1 &&
+        referenceGenome.nucleotideSequences[0].name === UNINITIALIZED_SEQUENCE
+    );
+}

--- a/components/src/preact/components/ReferenceGenomesAwaiter.tsx
+++ b/components/src/preact/components/ReferenceGenomesAwaiter.tsx
@@ -1,8 +1,7 @@
 import { type ComponentChildren, type FunctionalComponent } from 'preact';
 import { useContext } from 'preact/hooks';
 
-import { type ReferenceGenome } from '../../lapisApi/ReferenceGenome';
-import { ReferenceGenomeContext } from '../ReferenceGenomeContext';
+import { isNotInitialized, ReferenceGenomeContext } from '../ReferenceGenomeContext';
 
 /**
  * Sometimes the reference genome is not immediately available.
@@ -19,7 +18,3 @@ export const ReferenceGenomesAwaiter: FunctionalComponent<{ children: ComponentC
 
     return <>{children}</>;
 };
-
-function isNotInitialized(referenceGenome: ReferenceGenome) {
-    return referenceGenome.nucleotideSequences.length === 0 && referenceGenome.genes.length === 0;
-}

--- a/components/src/preact/mutationFilter/mutation-filter.stories.tsx
+++ b/components/src/preact/mutationFilter/mutation-filter.stories.tsx
@@ -1,4 +1,4 @@
-import { type PreactRenderer, type Meta, type StoryObj } from '@storybook/preact';
+import { type Meta, type PreactRenderer, type StoryObj } from '@storybook/preact';
 import { expect, fireEvent, fn, userEvent, waitFor, within } from '@storybook/test';
 import { type StepFunction } from '@storybook/types';
 
@@ -8,6 +8,7 @@ import { LAPIS_URL } from '../../constants';
 import referenceGenome from '../../lapisApi/__mockData__/referenceGenome.json';
 import { LapisUrlContextProvider } from '../LapisUrlContext';
 import { ReferenceGenomeContext } from '../ReferenceGenomeContext';
+import { playThatExpectsErrorMessage } from '../shared/stories/expectErrorMessage';
 
 const meta: Meta<MutationFilterProps> = {
     title: 'Input/MutationFilter',
@@ -217,6 +218,21 @@ export const WithInitialValue: StoryObj<MutationFilterProps> = {
             );
         });
     },
+};
+
+export const WithNoReferenceSequencesDefined: StoryObj<MutationFilterProps> = {
+    ...Default,
+    render: (args) => (
+        <LapisUrlContextProvider value={LAPIS_URL}>
+            <ReferenceGenomeContext.Provider value={{ nucleotideSequences: [], genes: [] }}>
+                <MutationFilter {...args} />
+            </ReferenceGenomeContext.Provider>
+        </LapisUrlContextProvider>
+    ),
+    play: playThatExpectsErrorMessage(
+        'Error - No reference sequences available',
+        'This organism has neither nucleotide nor amino acid sequences',
+    ),
 };
 
 async function prepare(canvasElement: HTMLElement, step: StepFunction<PreactRenderer, unknown>) {

--- a/components/src/preact/mutationFilter/mutation-filter.tsx
+++ b/components/src/preact/mutationFilter/mutation-filter.tsx
@@ -10,6 +10,7 @@ import { type MutationsFilter, mutationsFilterSchema } from '../../types';
 import { type DeletionClass, type InsertionClass, type SubstitutionClass } from '../../utils/mutations';
 import { ReferenceGenomeContext } from '../ReferenceGenomeContext';
 import { ErrorBoundary } from '../components/error-boundary';
+import { UserFacingError } from '../components/error-display';
 import { singleGraphColorRGBByName } from '../shared/charts/colors';
 
 const mutationFilterInnerPropsSchema = z.object({
@@ -53,6 +54,13 @@ export const MutationFilterInner: FunctionComponent<MutationFilterInnerProps> = 
     );
 
     const filterRef = useRef<HTMLDivElement>(null);
+
+    if (referenceGenome.nucleotideSequences.length === 0 && referenceGenome.genes.length === 0) {
+        throw new UserFacingError(
+            'No reference sequences available',
+            'This organism has neither nucleotide nor amino acid sequences configured in its reference genome. You cannot filter by mutations.',
+        );
+    }
 
     const handleRemoveValue = (option: ParsedMutationFilter) => {
         const newSelectedFilters = {


### PR DESCRIPTION

resolves #704


### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![grafik](https://github.com/user-attachments/assets/5c234fe1-b036-45a2-b1e1-4a398765e193)

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
