### PR TITLE
fix(components): gs-mutations-over-time: hide x-axis labels when there is no data to be displayed

### DIFF
--- a/components/src/preact/mutationsOverTime/mutations-over-time-grid.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time-grid.tsx
@@ -39,63 +39,64 @@ const MutationsOverTimeGrid: FunctionComponent<MutationsOverTimeGridProps> = ({
                     to reduce the number of mutations.
                 </div>
             )}
-            {allMutations.length === 0 && (
+            {allMutations.length === 0 ? (
                 <div className={'flex justify-center'}>No data available for your filters.</div>
+            ) : (
+                <div
+                    ref={gridRef}
+                    style={{
+                        display: 'grid',
+                        gridTemplateRows: `repeat(${shownMutations.length}, 24px)`,
+                        gridTemplateColumns: `${MUTATION_CELL_WIDTH_REM}rem repeat(${dates.length}, minmax(0.05rem, 1fr))`,
+                    }}
+                    className='text-center'
+                >
+                    {dates.map((date, columnIndex) => (
+                        <div
+                            className='@container font-semibold'
+                            style={{ gridRowStart: 1, gridColumnStart: columnIndex + 2 }}
+                            key={date.dateString}
+                        >
+                            <p {...styleGridHeader(columnIndex, dates)}>{date.dateString}</p>
+                        </div>
+                    ))}
+                    {shownMutations.map((mutation, rowIndex) => {
+                        return (
+                            <Fragment key={`fragment-${mutation.code}`}>
+                                <div
+                                    key={`mutation-${mutation.code}`}
+                                    style={{ gridRowStart: rowIndex + 2, gridColumnStart: 1 }}
+                                >
+                                    <MutationCell mutation={mutation} />
+                                </div>
+                                {dates.map((date, columnIndex) => {
+                                    const value = data.get(mutation, date) ?? null;
+                                    const tooltipPosition = getTooltipPosition(
+                                        rowIndex,
+                                        shownMutations.length,
+                                        columnIndex,
+                                        dates.length,
+                                    );
+                                    return (
+                                        <div
+                                            style={{ gridRowStart: rowIndex + 2, gridColumnStart: columnIndex + 2 }}
+                                            key={`${mutation.code}-${date.dateString}`}
+                                        >
+                                            <ProportionCell
+                                                value={value}
+                                                date={date}
+                                                mutation={mutation}
+                                                tooltipPosition={tooltipPosition}
+                                                colorScale={colorScale}
+                                            />
+                                        </div>
+                                    );
+                                })}
+                            </Fragment>
+                        );
+                    })}
+                </div>
             )}
-            <div
-                ref={gridRef}
-                style={{
-                    display: 'grid',
-                    gridTemplateRows: `repeat(${shownMutations.length}, 24px)`,
-                    gridTemplateColumns: `${MUTATION_CELL_WIDTH_REM}rem repeat(${dates.length}, minmax(0.05rem, 1fr))`,
-                }}
-                className='text-center'
-            >
-                {dates.map((date, columnIndex) => (
-                    <div
-                        className='@container font-semibold'
-                        style={{ gridRowStart: 1, gridColumnStart: columnIndex + 2 }}
-                        key={date.dateString}
-                    >
-                        <p {...styleGridHeader(columnIndex, dates)}>{date.dateString}</p>
-                    </div>
-                ))}
-                {shownMutations.map((mutation, rowIndex) => {
-                    return (
-                        <Fragment key={`fragment-${mutation.code}`}>
-                            <div
-                                key={`mutation-${mutation.code}`}
-                                style={{ gridRowStart: rowIndex + 2, gridColumnStart: 1 }}
-                            >
-                                <MutationCell mutation={mutation} />
-                            </div>
-                            {dates.map((date, columnIndex) => {
-                                const value = data.get(mutation, date) ?? null;
-                                const tooltipPosition = getTooltipPosition(
-                                    rowIndex,
-                                    shownMutations.length,
-                                    columnIndex,
-                                    dates.length,
-                                );
-                                return (
-                                    <div
-                                        style={{ gridRowStart: rowIndex + 2, gridColumnStart: columnIndex + 2 }}
-                                        key={`${mutation.code}-${date.dateString}`}
-                                    >
-                                        <ProportionCell
-                                            value={value}
-                                            date={date}
-                                            mutation={mutation}
-                                            tooltipPosition={tooltipPosition}
-                                            colorScale={colorScale}
-                                        />
-                                    </div>
-                                );
-                            })}
-                        </Fragment>
-                    );
-                })}
-            </div>
         </>
     );
 };


### PR DESCRIPTION

resolves #748


### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
![grafik](https://github.com/user-attachments/assets/af50ca0b-66ab-4c14-b793-44a3665dcf5e)

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
