### PR TITLE
fix(components): initialize the reference genomes context with a value that is recognized as "uninitialized"

### DIFF
--- a/components/src/preact/ReferenceGenomeContext.ts
+++ b/components/src/preact/ReferenceGenomeContext.ts
@@ -4,10 +4,12 @@ import { type ReferenceGenome } from '../lapisApi/ReferenceGenome';
 
 const UNINITIALIZED_SEQUENCE = '__uninitialized__';
 
-export const ReferenceGenomeContext = createContext<ReferenceGenome>({
+export const INITIAL_REFERENCE_GENOMES = {
     nucleotideSequences: [{ name: UNINITIALIZED_SEQUENCE, sequence: '' }],
     genes: [],
-});
+};
+
+export const ReferenceGenomeContext = createContext<ReferenceGenome>(INITIAL_REFERENCE_GENOMES);
 
 export function isNotInitialized(referenceGenome: ReferenceGenome) {
     return (

--- a/components/src/web-components/PreactLitAdapter.tsx
+++ b/components/src/web-components/PreactLitAdapter.tsx
@@ -8,7 +8,7 @@ import { lapisContext } from './lapis-context';
 import { referenceGenomeContext } from './reference-genome-context';
 import { type ReferenceGenome } from '../lapisApi/ReferenceGenome';
 import { LapisUrlContextProvider } from '../preact/LapisUrlContext';
-import { ReferenceGenomeContext } from '../preact/ReferenceGenomeContext';
+import { INITIAL_REFERENCE_GENOMES, ReferenceGenomeContext } from '../preact/ReferenceGenomeContext';
 import minMaxPercentSliderCss from '../preact/components/min-max-percent-slider.css?inline';
 import tailwindStyle from '../styles/tailwind.css?inline';
 
@@ -40,10 +40,7 @@ export abstract class PreactLitAdapter extends ReactiveElement {
      * This value will automatically be injected by the parent `gs-app` component.
      */
     @consume({ context: referenceGenomeContext, subscribe: true })
-    referenceGenome: ReferenceGenome = {
-        nucleotideSequences: [],
-        genes: [],
-    };
+    referenceGenome: ReferenceGenome = INITIAL_REFERENCE_GENOMES;
 
     override update(changedProperties: PropertyValues) {
         const vdom = (

--- a/components/src/web-components/gs-app.ts
+++ b/components/src/web-components/gs-app.ts
@@ -9,6 +9,7 @@ import { lapisContext } from './lapis-context';
 import { referenceGenomeContext } from './reference-genome-context';
 import { type ReferenceGenome } from '../lapisApi/ReferenceGenome';
 import { fetchReferenceGenome } from '../lapisApi/lapisApi';
+import { INITIAL_REFERENCE_GENOMES } from '../preact/ReferenceGenomeContext';
 
 const lapisUrlSchema = z.string().url();
 
@@ -43,10 +44,7 @@ export class AppComponent extends LitElement {
      * @internal
      */
     @provide({ context: referenceGenomeContext })
-    referenceGenome: ReferenceGenome = {
-        nucleotideSequences: [],
-        genes: [],
-    };
+    referenceGenome: ReferenceGenome = INITIAL_REFERENCE_GENOMES;
 
     /**
      * @internal


### PR DESCRIPTION

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

This is a follow-up to #743.
In the dashboards, the gs-mutation-filter would on the first render get the default of `gs-app`, which will throw and display an error:
"UserFacingError: This organism has neither nucleotide nor amino acid sequences configured in its reference genome. You cannot filter by mutations." To prevent that, we should use the same "uninitialized value" as for the Preact context.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
