### PR TITLE
fix(components): make sure to render the downshift combobox with the correct items

### DIFF
--- a/components/src/preact/components/downshift-combobox.tsx
+++ b/components/src/preact/components/downshift-combobox.tsx
@@ -1,6 +1,6 @@
 import { useCombobox } from 'downshift/preact';
 import { type ComponentChild } from 'preact';
-import { useRef, useState } from 'preact/hooks';
+import { useMemo, useRef, useState } from 'preact/hooks';
 
 export function DownshiftCombobox<Item>({
     allItems,
@@ -21,8 +21,10 @@ export function DownshiftCombobox<Item>({
 }) {
     const initialSelectedItem = value ?? null;
 
-    const [items, setItems] = useState(
-        allItems.filter((item) => filterItemsByInputValue(item, itemToString(initialSelectedItem))),
+    const [itemsFilter, setItemsFilter] = useState(itemToString(initialSelectedItem));
+    const items = useMemo(
+        () => allItems.filter((item) => filterItemsByInputValue(item, itemsFilter)),
+        [allItems, filterItemsByInputValue, itemsFilter],
     );
     const divRef = useRef<HTMLDivElement>(null);
 
@@ -52,7 +54,7 @@ export function DownshiftCombobox<Item>({
         closeMenu,
     } = useCombobox({
         onInputValueChange({ inputValue }) {
-            setItems(allItems.filter((item) => filterItemsByInputValue(item, inputValue)));
+            setItemsFilter(inputValue);
         },
         onSelectedItemChange({ selectedItem }) {
             if (selectedItem !== null) {


### PR DESCRIPTION


### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
On the dashboards, usually the location filter would update it's combobox items as follows:
* fetch the autocomplete options
* render the autocomplete options
* change the lapisFilter (e.g. by changing the selected date range)
* fetch the autocomplete options
* show the loading state, unmounting the combobox and __forgetting the old autocomplete options__
* render the new autocomplete options

https://github.com/GenSpectrum/dashboards/pull/539 had red e2e tests, because the following happened:
* fetch autocomplete options for a filter that would return no option
* change the lapisFilter before the first fetch finishes to something that would return a number of options
* the first fetch finishes and persists zero autocomplete items in a `useState`
* the second fetch finishes, but its items would not be persisted in the `useState`, because the component already has its state
* The downshift combobox would still show no options, although it got items now

Fix: make sure that the items are not a state, but get computed on every render from the input (`allItems`) and the state (`inputValue`) instead
### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
