### PR TITLE
fix(components): make it possible to copy an annotated mutation in Firefox

### DIFF
--- a/components/src/preact/components/annotated-mutation.tsx
+++ b/components/src/preact/components/annotated-mutation.tsx
@@ -63,7 +63,7 @@ const AnnotatedMutationWithoutContext: FunctionComponent<AnnotatedMutationWithou
     );
 
     return (
-        <ButtonWithModalDialog modalContent={modalContent} modalRef={modalRef}>
+        <ButtonWithModalDialog buttonClassName={'select-text'} modalContent={modalContent} modalRef={modalRef}>
             {mutation.code}
             <sup>
                 {mutationAnnotations


### PR DESCRIPTION



resolves #778



### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

Apparently Firefox doesn't let you copy the content of a button.
### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
