### PR TITLE
fix(components): gs-date-range-filter make it explicit that the event contains `null` when deleting the input

### DIFF
--- a/components/src/preact/dateRangeFilter/computeInitialValues.spec.ts
+++ b/components/src/preact/dateRangeFilter/computeInitialValues.spec.ts
@@ -18,8 +18,8 @@ const dateRangeOptions = [
 ];
 
 describe('computeInitialValues', () => {
-    it('should return undefined for unedfined value', () => {
-        const result = computeInitialValues(undefined, earliestDate, dateRangeOptions);
+    it('should return undefined for null value', () => {
+        const result = computeInitialValues(null, earliestDate, dateRangeOptions);
 
         expect(result).toBeUndefined();
     });

--- a/components/src/preact/dateRangeFilter/computeInitialValues.ts
+++ b/components/src/preact/dateRangeFilter/computeInitialValues.ts
@@ -3,7 +3,7 @@ import { getDatesForSelectorValue, getSelectableOptions } from './selectableOpti
 import { UserFacingError } from '../components/error-display';
 
 export function computeInitialValues(value: DateRangeValue, earliestDate: string, dateRangeOptions: DateRangeOption[]) {
-    if (value === undefined) {
+    if (value === null) {
         return undefined;
     }
 

--- a/components/src/preact/dateRangeFilter/date-range-filter.stories.tsx
+++ b/components/src/preact/dateRangeFilter/date-range-filter.stories.tsx
@@ -56,7 +56,7 @@ const meta: Meta<DateRangeFilterProps> = {
     args: {
         dateRangeOptions: [dateRangeOptionPresets.lastMonth, dateRangeOptionPresets.allTimes, customDateRange],
         earliestDate,
-        value: undefined,
+        value: null,
         lapisDateField: 'aDateColumn',
         width: '100%',
         placeholder,
@@ -194,16 +194,14 @@ export const ChangingTheValueProgrammatically: StoryObj<DateRangeFilterProps> = 
     ...Primary,
     render: (args) => {
         const StatefulWrapper = () => {
-            const [value, setValue] = useState<DateRangeValue | undefined>('Last month');
+            const [value, setValue] = useState<DateRangeValue>('Last month');
             const ref = useRef<HTMLDivElement>(null);
 
             useEffect(() => {
                 ref.current?.addEventListener('gs-date-range-option-changed', (event) => {
-                    const newValue = (event as CustomEvent).detail;
-                    setValue(newValue ?? undefined);
+                    setValue(event.detail);
                 });
             }, []);
-
             return (
                 <div ref={ref}>
                     <LapisUrlContextProvider value={LAPIS_URL}>

--- a/components/src/preact/dateRangeFilter/date-range-filter.tsx
+++ b/components/src/preact/dateRangeFilter/date-range-filter.tsx
@@ -179,13 +179,18 @@ export const DateRangeFilterInner = ({
     };
 
     const fireOptionChangedEvent = (state: DateRangeFilterState) => {
-        const eventDetail =
-            state?.label === customOption
-                ? {
-                      dateFrom: state.dateFrom !== undefined ? toYYYYMMDD(state.dateFrom) : undefined,
-                      dateTo: state.dateTo !== undefined ? toYYYYMMDD(state.dateTo) : undefined,
-                  }
-                : state?.label;
+        const eventDetail = (() => {
+            if (state === null) {
+                return null;
+            }
+            if (state.label === customOption) {
+                return {
+                    dateFrom: state.dateFrom !== undefined ? toYYYYMMDD(state.dateFrom) : undefined,
+                    dateTo: state.dateTo !== undefined ? toYYYYMMDD(state.dateTo) : undefined,
+                };
+            }
+            return state.label;
+        })();
 
         divRef.current?.dispatchEvent(new DateRangeOptionChangedEvent(eventDetail));
     };

--- a/components/src/preact/dateRangeFilter/dateRangeOption.ts
+++ b/components/src/preact/dateRangeFilter/dateRangeOption.ts
@@ -30,7 +30,7 @@ export const dateRangeValueSchema = z
             dateTo: z.string().date().optional(),
         }),
     ])
-    .optional();
+    .nullable();
 
 export type DateRangeValue = z.infer<typeof dateRangeValueSchema>;
 

--- a/components/src/web-components/input/gs-date-range-filter.stories.ts
+++ b/components/src/web-components/input/gs-date-range-filter.stories.ts
@@ -98,7 +98,7 @@ export const TestRenderAttributesInHtmlInsteadOfUsingPropertyExpression: StoryOb
                 <gs-date-range-filter
                     .dateRangeOptions=${args.dateRangeOptions}
                     earliestDate="${args.earliestDate}"
-                    value="${args.value}"
+                    value="${args.value ?? 'null'}"
                     width="${args.width}"
                     lapisDateField="${args.lapisDateField}"
                     placeholder="${args.placeholder}"

--- a/components/src/web-components/input/gs-date-range-filter.tsx
+++ b/components/src/web-components/input/gs-date-range-filter.tsx
@@ -38,12 +38,14 @@ import { PreactLitAdapter } from '../PreactLitAdapter';
  *  Use this event, when you want to use the filter directly as a LAPIS filter.
  *
  *
- * @fires {CustomEvent<{ string | {dateFrom: string, dateTo: string}}>} gs-date-range-option-changed
+ * @fires {CustomEvent<string | {dateFrom: string, dateTo: string} | null>} gs-date-range-option-changed
  * Fired when:
  * - The select field is changed,
  * - A date is selected in either of the date pickers,
- * - A date was typed into either of the date input fields, and the input field loses focus ("on blur").
- * Contains the selected dateRangeOption or when users select custom values it contains the selected dates.
+ * - A date was typed into either of the date input fields, and the input field loses focus ("on blur"),
+ * - The user deletes the current value by clicking the 'x' button.
+ * Contains the selected dateRangeOption or when users select custom values it contains the selected dates
+ * or `null` when the input was deleted.
  *
  * Use this event, when you want to control this component in your JS application.
  * You can supply the `detail` of this event to the `value` attribute of this component.
@@ -80,7 +82,7 @@ export class DateRangeFilterComponent extends PreactLitAdapter {
     @property({
         converter: (value) => {
             if (value === null) {
-                return undefined;
+                return null;
             }
             try {
                 const result = JSON.parse(value) as unknown;
@@ -93,7 +95,7 @@ export class DateRangeFilterComponent extends PreactLitAdapter {
             }
         },
     })
-    value: string | { dateFrom?: string; dateTo?: string } | undefined = undefined;
+    value: string | { dateFrom?: string; dateTo?: string } | null = null;
 
     /**
      * The width of the component.


### PR DESCRIPTION



Discovered in the context of https://github.com/GenSpectrum/dashboards/issues/617

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

The code seems to have sent `undefined` with the event "gs-date-range-option-changed", but both Chrome and Firefox show `null` as event.detail.
### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
~~- [ ] The implemented feature is covered by an appropriate test.~~
