### PR TITLE
fix(components): disable outline selecting map regions in Chrome

### DIFF
--- a/components/src/preact/sequencesByLocation/leafletStyleModifications.css
+++ b/components/src/preact/sequencesByLocation/leafletStyleModifications.css
@@ -1,3 +1,8 @@
 .leaflet-container {
     background: transparent;
 }
+
+.leaflet-interactive {
+    outline: none;
+    cursor: pointer;
+}


### PR DESCRIPTION
Chrome has a default CSS enty that enables "bounding boxes" around SVG paths when selecting them; Firefox does not show those (by default). Explicitly disable them as they are distracting.

<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #729

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
