### PR TITLE
fix(components): pin `vite-plugin-dts` to 4.5.0 to export JSX.IntrinsicElements namespace declarations

### DIFF
--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -74,9 +74,9 @@
                 "storybook": "^8.0.9",
                 "storybook-addon-fetch-mock": "^2.0.0",
                 "tailwindcss": "^4.0.9",
-                "typescript": "~5.8.2",
+                "typescript": "^5.8.2",
                 "vite": "^6.0.3",
-                "vite-plugin-dts": "^4.0.3",
+                "vite-plugin-dts": "4.5.0",
                 "vitest": "^3.0.2"
             }
         },
@@ -14473,20 +14473,20 @@
             "license": "MIT"
         },
         "node_modules/vite-plugin-dts": {
-            "version": "4.5.3",
-            "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.5.3.tgz",
-            "integrity": "sha512-P64VnD00dR+e8S26ESoFELqc17+w7pKkwlBpgXteOljFyT0zDwD8hH4zXp49M/kciy//7ZbVXIwQCekBJjfWzA==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.5.0.tgz",
+            "integrity": "sha512-M1lrPTdi7gilLYRZoLmGYnl4fbPryVYsehPN9JgaxjJKTs8/f7tuAlvCCvOLB5gRDQTTKnptBcB0ACsaw2wNLw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@microsoft/api-extractor": "^7.50.1",
+                "@microsoft/api-extractor": "^7.49.1",
                 "@rollup/pluginutils": "^5.1.4",
                 "@volar/typescript": "^2.4.11",
                 "@vue/language-core": "2.2.0",
                 "compare-versions": "^6.1.1",
                 "debug": "^4.4.0",
                 "kolorist": "^1.8.0",
-                "local-pkg": "^1.0.0",
+                "local-pkg": "^0.5.1",
                 "magic-string": "^0.30.17"
             },
             "peerDependencies": {
@@ -14497,6 +14497,35 @@
                 "vite": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/vite-plugin-dts/node_modules/local-pkg": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+            "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mlly": "^1.7.3",
+                "pkg-types": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/vite-plugin-dts/node_modules/pkg-types": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+            "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "confbox": "^0.1.8",
+                "mlly": "^1.7.4",
+                "pathe": "^2.0.1"
             }
         },
         "node_modules/vite/node_modules/fsevents": {

--- a/components/package.json
+++ b/components/package.json
@@ -145,7 +145,7 @@
         "tailwindcss": "^4.0.9",
         "typescript": "^5.8.2",
         "vite": "^6.0.3",
-        "vite-plugin-dts": "^4.0.3",
+        "vite-plugin-dts": "4.5.0",
         "vitest": "^3.0.2"
     }
 }


### PR DESCRIPTION


### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

In the last dependency update (#818), `vite-plugin-dts` was upgraded from 4.5.0 to 4.5.3. After that, our JSX.IntrinsicElements declarations (e.g. this one: https://github.com/GenSpectrum/dashboard-components/blob/0c7d6cab120e59295db70495b4467b4c1e463dae/components/src/web-components/gs-app.ts#L110-L117) were not included in the built output anymore (in `dist/components.d.ts`). Thus, the typecheck in the dashboards failed, claiming that e.g. `gs-app` is not a valid JSX component name. 4.5.0 is the last version that works.

https://github.com/qmhc/vite-plugin-dts/issues/419 seems to be the exact same issue.


### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
