### PR TITLE
fix(examples): fix commonjs import of leaflet for plain js

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -20,6 +20,18 @@ Usage with a bundler in HTML:
 </body>
 ```
 
+**Note for vite (and potentially other bundlers) users**:
+There is currently an issue with one of our peer dependencies: leaflet.
+Vite will use the commonjs style of leaflet, which will create an error, when you run it in the browser.
+`Uncaught SyntaxError: The requested module ... doesn't provide an export named: 'geoJson'`
+To fix this add the following to your `vite.config.js`:
+
+```js
+optimizeDeps: {
+    include: ['leaflet'];
+}
+```
+
 We also provide a standalone version of the components that can be used without installing the dependencies:
 
 ```html

--- a/examples/plainJavascript/package.json
+++ b/examples/plainJavascript/package.json
@@ -2,6 +2,7 @@
     "name": "plainjavascript",
     "version": "1.0.0",
     "description": "A demo page for using the genspectrum dashboard components in plain javascript",
+    "type": "module",
     "scripts": {
         "dev": "vite dev",
         "start": "vite dev",
@@ -9,6 +10,6 @@
     },
     "dependencies": {
         "@genspectrum/dashboard-components": "file:../../components/genspectrum-dashboard-components.tgz",
-        "vite": "^5.2.8"
+        "vite": "^6.2.4"
     }
 }

--- a/examples/plainJavascript/vite.config.js
+++ b/examples/plainJavascript/vite.config.js
@@ -1,0 +1,7 @@
+import {defineConfig} from 'vite'
+
+export default defineConfig({
+    optimizeDeps: {
+        include: ['leaflet']
+    }
+})


### PR DESCRIPTION
### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
Fixes the following error for the plain js example:
![grafik](https://github.com/user-attachments/assets/53f2701f-13a2-4373-8d55-4b843a6d580d)

The issue was the wrong export from leaflet, which is then used as commonjs and not esm.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
~~- [ ] The implemented feature is covered by an appropriate test.~~
