### PR TITLE
feat(components): render calendar inside shadow dom

### DIFF
--- a/components/src/preact/dateRangeFilter/date-picker.tsx
+++ b/components/src/preact/dateRangeFilter/date-picker.tsx
@@ -22,8 +22,10 @@ export function DatePicker({
 
     const [datePicker, setDatePicker] = useState<flatpickr.Instance | null>(null);
 
+    const calendarRef = useRef<HTMLDivElement>(null);
+
     useEffect(() => {
-        if (!inputRef.current) {
+        if (!inputRef.current || !calendarRef.current) {
             return;
         }
 
@@ -33,6 +35,7 @@ export function DatePicker({
             defaultDate: value,
             minDate,
             maxDate,
+            appendTo: calendarRef.current,
         });
 
         setDatePicker(instance);
@@ -54,13 +57,16 @@ export function DatePicker({
     };
 
     return (
-        <input
-            className={`input w-full ${className}`}
-            type='text'
-            placeholder={placeholderText}
-            ref={inputRef}
-            onChange={handleChange}
-            onBlur={handleChange}
-        />
+        <div className={'w-full'}>
+            <input
+                className={`input w-full ${className}`}
+                type='text'
+                placeholder={placeholderText}
+                ref={inputRef}
+                onChange={handleChange}
+                onBlur={handleChange}
+            />
+            <div ref={calendarRef} />
+        </div>
     );
 }

--- a/components/src/web-components/input/gs-date-range-filter.tsx
+++ b/components/src/web-components/input/gs-date-range-filter.tsx
@@ -1,3 +1,5 @@
+import flatpickrStyle from 'flatpickr/dist/flatpickr.css?inline';
+import { unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import type { DetailedHTMLProps, HTMLAttributes } from 'react';
 
@@ -5,6 +7,8 @@ import { DateRangeFilter, type DateRangeFilterProps } from '../../preact/dateRan
 import { type DateRangeOptionChangedEvent } from '../../preact/dateRangeFilter/dateRangeOption';
 import { type Equals, type Expect } from '../../utils/typeAssertions';
 import { PreactLitAdapter } from '../PreactLitAdapter';
+
+const flatpickrCss = unsafeCSS(flatpickrStyle);
 
 /**
  * ## Context
@@ -52,6 +56,8 @@ import { PreactLitAdapter } from '../PreactLitAdapter';
  */
 @customElement('gs-date-range-filter')
 export class DateRangeFilterComponent extends PreactLitAdapter {
+    static override styles = [...PreactLitAdapter.styles, flatpickrCss];
+
     /**
      * An array of date range options that the select field should provide.
      * The `label` will be shown to the user, and it will be available as `value`.


### PR DESCRIPTION
Resolves #806


### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

Flatpickr has a built in method to render the calendar to other elements. I just used that. This way the calendar is inside the shadow dom and we can move the css of flatpickr inside our components.

We can see if we can use this also for our other dropdown components.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
