### PR TITLE
fix(components): apply daisyui styles to host instead of root

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,3 +29,18 @@ where
 * `<name of the upstream branch>` is the name of the branch for which the changelog should be generated.
 
 __NOTE: This command does not respect local changes. It will pull the commit messages from the remote repository.__
+
+## CSS
+
+We use [Tailwind](https://tailwindcss.com/) and [DaisyUI](https://daisyui.com/) for styling.
+Prefer Tailwind or DaisyUI classes for styling the components.
+Only use custom CSS files and classes or inline styles if those don't work for your usecase.
+
+Notice that Tailwind and DaisyUI classes cannot be generated dynamically,
+because Tailwind scans the code at build time to generate the necessary style sheets.
+
+Make sure that you don't include any CSS files in the components like this:
+`import './my-component.css'`.
+If vite finds imports like these, it will generate a CSS file in the output.
+We don't want that. All styles should already be included in the components.
+Instead, apply the CSS files to the Lit components using the `static styles` field. 

--- a/components/.storybook-preact/applyDaisyUiToRootInsteadOfHost.css
+++ b/components/.storybook-preact/applyDaisyUiToRootInsteadOfHost.css
@@ -1,0 +1,7 @@
+/*
+We don't have a shadow root in the Preact tests, i.e. we need to reset the root to :root.
+*/
+@plugin "daisyui" {
+    themes: light --default;
+    root: ':root';
+}

--- a/components/.storybook-preact/preview.ts
+++ b/components/.storybook-preact/preview.ts
@@ -1,9 +1,14 @@
 import type { Preview } from '@storybook/preact';
 import { clearAllMocks } from '@storybook/test';
 
-import '../src/styles/tailwind.css';
 import { withActions } from '@storybook/addon-actions/decorator';
 import { GS_ERROR_EVENT_TYPE } from '../src/preact/components/error-display';
+
+import '../src/styles/tailwind.css';
+import './applyDaisyUiToRootInsteadOfHost.css';
+import '../src/preact/components/min-max-percent-slider.css';
+import 'gridjs/dist/theme/mermaid.css';
+import 'flatpickr/dist/flatpickr.min.css';
 
 const preview: Preview = {
     parameters: {

--- a/components/.storybook/preview.tsx
+++ b/components/.storybook/preview.tsx
@@ -1,5 +1,4 @@
 import { Preview, setCustomElementsManifest } from '@storybook/web-components';
-import '../src/styles/tailwind.css';
 import { REFERENCE_GENOME_ENDPOINT, WISE_REFERENCE_GENOME_ENDPOINT } from '../src/constants';
 import referenceGenome from '../src/lapisApi/__mockData__/referenceGenome.json';
 import customElements from '../custom-elements.json';

--- a/components/README.md
+++ b/components/README.md
@@ -14,7 +14,6 @@ Usage with a bundler in HTML:
 <body>
     <script>
         import '@genspectrum/dashboard-components/components';
-        import '@genspectrum/dashboard-components/style.css';
     </script>
     <gs-app lapis="https://your.lapis.url"></gs-app>
 </body>
@@ -41,7 +40,6 @@ We also provide a standalone version of the components that can be used without 
             type="module"
             src="https://unpkg.com/@genspectrum/dashboard-components@latest/standalone-bundle/dashboard-components.js"
         ></script>
-        <link rel="stylesheet" href="https://unpkg.com/@genspectrum/dashboard-components@latest/dist/style.css" />
     </head>
     <body>
         <gs-app lapis="https://your.lapis.url"></gs-app>

--- a/components/package.json
+++ b/components/package.json
@@ -38,8 +38,7 @@
             "require": "./dist/util.js"
         },
         "./custom-elements.json": "./custom-elements.json",
-        "./package.json": "./package.json",
-        "./style.css": "./dist/style.css"
+        "./package.json": "./package.json"
     },
     "files": [
         "dist",

--- a/components/src/preact/components/info.tsx
+++ b/components/src/preact/components/info.tsx
@@ -103,7 +103,6 @@ function generateFullExampleCode(componentCode: string, componentName: string) {
     return `<html>
 <head>
   <script type="module" src="https://unpkg.com/@genspectrum/dashboard-components@latest/standalone-bundle/dashboard-components.js"></script>
-  <link rel="stylesheet" href="https://unpkg.com/@genspectrum/dashboard-components@latest/dist/style.css" />
 </head>
 
 <body>

--- a/components/src/preact/components/min-max-range-slider.tsx
+++ b/components/src/preact/components/min-max-range-slider.tsx
@@ -1,8 +1,6 @@
 import { type FunctionComponent, type JSX } from 'preact';
 import { useState } from 'preact/hooks';
 
-import './min-max-percent-slider.css';
-
 export interface MinMaxPercentSliderProps {
     min: number;
     max: number;

--- a/components/src/preact/components/table.tsx
+++ b/components/src/preact/components/table.tsx
@@ -3,8 +3,6 @@ import { type OneDArray, type TColumn, type TData } from 'gridjs/dist/src/types'
 import { type ComponentChild } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 
-import 'gridjs/dist/theme/mermaid.css';
-
 export const tableStyle = {
     table: {
         fontSize: '12px',

--- a/components/src/preact/dateRangeFilter/date-picker.tsx
+++ b/components/src/preact/dateRangeFilter/date-picker.tsx
@@ -1,4 +1,3 @@
-import 'flatpickr/dist/flatpickr.min.css';
 import flatpickr from 'flatpickr';
 import { useEffect, useRef, useState } from 'preact/hooks';
 

--- a/components/src/styles/replaceCssProperties.stories.tsx
+++ b/components/src/styles/replaceCssProperties.stories.tsx
@@ -1,0 +1,49 @@
+import { css } from '@lit/reactive-element';
+import { type Meta, type StoryObj } from '@storybook/preact';
+import { expect } from '@storybook/test';
+import { type FunctionComponent } from 'preact';
+
+import { replaceCssProperties } from './replaceCssProperties';
+
+const DummyComponent: FunctionComponent = () => 'This just runs a function in the browser';
+
+const meta: Meta = {
+    title: 'Test/replaceCssProperties',
+    component: DummyComponent,
+};
+
+export default meta;
+
+/**
+ * This test somehow doesn't work with vitest on node, because the @properties are not parsed by `css()`.
+ */
+export const InvalidProps: StoryObj = {
+    play: async () => {
+        const styleSheet = css`
+            .some-other-rule {
+                color: red;
+            }
+
+            @property --test-with-initial-value {
+                syntax: '*';
+                inherits: false;
+                initial-value: solid;
+            }
+
+            @property --test-without-initial-value {
+                syntax: '*';
+                inherits: false;
+            }
+        `.styleSheet!;
+
+        replaceCssProperties(styleSheet);
+
+        const resultingCss = [...styleSheet.cssRules]
+            .map((rule) => rule.cssText)
+            .join('\n')
+            .replaceAll(' ', '');
+
+        await expect(resultingCss).toContain(':host{--test-with-initial-value:solid;}');
+        await expect(resultingCss).toContain('.some-other-rule{color:red;}');
+    },
+};

--- a/components/src/styles/replaceCssProperties.ts
+++ b/components/src/styles/replaceCssProperties.ts
@@ -1,0 +1,25 @@
+/**
+ * Replaces `@property` rules in a CSSStyleSheet with a `:host` rule.
+ *
+ * Tailwind uses `@property` rules, but they don't work in the shadow DOM.
+ * https://github.com/tailwindlabs/tailwindcss/issues/15005
+ *
+ * Inspired by https://github.com/tailwindlabs/tailwindcss/issues/15005#issuecomment-2737489813
+ */
+export function replaceCssProperties(styleSheet: CSSStyleSheet) {
+    const properties: string[] = [];
+
+    [...styleSheet.cssRules]
+        .map((rule, index) => [rule, index] as const)
+        .reverse()
+        .forEach(([rule, index]) => {
+            if (rule instanceof CSSPropertyRule && rule.initialValue !== null) {
+                styleSheet.deleteRule(index);
+                properties.push(`${rule.name}: ${rule.initialValue}`);
+            }
+        });
+
+    if (properties.length > 0) {
+        styleSheet.insertRule(`:host { ${properties.join('; ')} }`);
+    }
+}

--- a/components/src/styles/tailwind.css
+++ b/components/src/styles/tailwind.css
@@ -2,6 +2,7 @@
 
 @plugin "daisyui" {
   themes: light --default;
+  root: ':host';
 }
 @plugin "@iconify/tailwind4" {
   prefixes: mdi, mdi-light;

--- a/components/src/web-components/PreactLitAdapter.tsx
+++ b/components/src/web-components/PreactLitAdapter.tsx
@@ -10,13 +10,16 @@ import { type ReferenceGenome } from '../lapisApi/ReferenceGenome';
 import { LapisUrlContextProvider } from '../preact/LapisUrlContext';
 import { INITIAL_REFERENCE_GENOMES, ReferenceGenomeContext } from '../preact/ReferenceGenomeContext';
 import minMaxPercentSliderCss from '../preact/components/min-max-percent-slider.css?inline';
+import { replaceCssProperties } from '../styles/replaceCssProperties';
 import tailwindStyle from '../styles/tailwind.css?inline';
-
-import '../styles/tailwind.css';
-import '../preact/components/min-max-percent-slider.css';
 
 const tailwindElementCss = unsafeCSS(tailwindStyle);
 const minMaxPercentSliderElementCss = unsafeCSS(minMaxPercentSliderCss);
+
+const styleSheet = tailwindElementCss.styleSheet;
+if (styleSheet !== undefined) {
+    replaceCssProperties(styleSheet);
+}
 
 export abstract class PreactLitAdapter extends ReactiveElement {
     static override styles = [tailwindElementCss, minMaxPercentSliderElementCss];

--- a/components/src/web-components/PreactLitAdapterWithGridJsStyles.tsx
+++ b/components/src/web-components/PreactLitAdapterWithGridJsStyles.tsx
@@ -3,8 +3,6 @@ import { unsafeCSS } from 'lit';
 
 import { PreactLitAdapter } from './PreactLitAdapter';
 
-import 'gridjs/dist/theme/mermaid.css';
-
 const gridJsElementCss = unsafeCSS(gridJsStyle);
 
 export abstract class PreactLitAdapterWithGridJsStyles extends PreactLitAdapter {

--- a/components/src/web-components/gs-app.stories.ts
+++ b/components/src/web-components/gs-app.stories.ts
@@ -82,7 +82,9 @@ export const WithNoLapisUrl: StoryObj<StoryProps> = {
         const canvas = within(canvasElement);
 
         await waitFor(async () => {
-            await expect(canvas.getByText("Error: Invalid LAPIS URL: 'notAValidUrl'", { exact: false })).toBeVisible();
+            await expect(
+                canvas.getByText("Error in gs-app: Invalid LAPIS URL: 'notAValidUrl'", { exact: false }),
+            ).toBeVisible();
         });
     },
 };
@@ -119,7 +121,9 @@ export const FailsToFetchReferenceGenome: StoryObj<StoryProps> = {
         const canvas = within(canvasElement);
 
         await waitFor(async () => {
-            await expect(canvas.getByText('Error: Cannot fetch reference genome.', { exact: false })).toBeVisible();
+            await expect(
+                canvas.getByText('Error in gs-app: Cannot fetch reference genome.', { exact: false }),
+            ).toBeVisible();
         });
     },
 };

--- a/components/src/web-components/gs-app.ts
+++ b/components/src/web-components/gs-app.ts
@@ -98,7 +98,10 @@ export class AppComponent extends LitElement {
 }
 
 function GsAppError(error: string) {
-    return html` <div class="m-2 w-full alert alert-error">Error: ${error}</div>`;
+    // We're in the light dom, we must not use Tailwind so that we don't pollute the user's styles.
+    return html`<div style="padding: 0.5rem; border: solid red; background-color: lightcoral; border-radius: 0.5rem;">
+        Error in gs-app: ${error}
+    </div>`;
 }
 
 declare global {

--- a/components/vite.release-standalone.config.ts
+++ b/components/vite.release-standalone.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
             entry: {
                 'dashboard-components': 'src/standaloneEntrypoint.ts',
             },
-            cssFileName: 'style',
         },
         sourcemap: true,
         minify: true,

--- a/components/vite.release.config.ts
+++ b/components/vite.release.config.ts
@@ -11,7 +11,6 @@ export default defineConfig({
                 components: 'src/componentsEntrypoint.ts',
                 util: 'src/utilEntrypoint.ts',
             },
-            cssFileName: 'style',
         },
         sourcemap: true,
         minify: false,

--- a/examples/React/src/App.tsx
+++ b/examples/React/src/App.tsx
@@ -1,7 +1,6 @@
 import {useEffect, useState} from 'react';
 import {DateRangeOption, dateRangeOptionPresets} from '@genspectrum/dashboard-components/util';
 import '@genspectrum/dashboard-components/components';
-import '@genspectrum/dashboard-components/style.css';
 
 function App() {
     const [location, setLocation] = useState({
@@ -81,7 +80,7 @@ function App() {
             ></gs-date-range-filter>
             <div style={{display: 'flex', flexDirection: 'row'}}>
                 <div>
-                    <h1 className='text-xl bold'>Prevalence over time</h1>
+                    <h1>Prevalence over time</h1>
                     <gs-prevalence-over-time
                         numeratorFilters={JSON.stringify([numerator])}
                         denominatorFilter={JSON.stringify(denominator)}
@@ -94,7 +93,7 @@ function App() {
                     ></gs-prevalence-over-time>
                 </div>
                 <div style={{height: '300px', width: '1000px'}}>
-                    <h1 className='text-xl bold'>Prevalence over time</h1>
+                    <h1>Prevalence over time</h1>
                     <gs-prevalence-over-time
                         numeratorFilters={JSON.stringify([numerator])}
                         denominatorFilter={JSON.stringify(denominator)}
@@ -107,7 +106,7 @@ function App() {
                     ></gs-prevalence-over-time>
                 </div>
             </div>
-            <h1 className='text-xl bold'>Prevalence over time</h1>
+            <h1>Prevalence over time</h1>
             <div>
                 <gs-prevalence-over-time
                     numeratorFilters={JSON.stringify([numerator])}
@@ -118,7 +117,7 @@ function App() {
                     views='["line", "table"]'
                 ></gs-prevalence-over-time>
             </div>
-            <h1 className='text-xl bold'>Relative Growth Advantage</h1>
+            <h1>Relative Growth Advantage</h1>
             <gs-relative-growth-advantage
                 numeratorFilter={JSON.stringify(numerator.lapisFilter)}
                 denominatorFilter={JSON.stringify(denominator)}

--- a/examples/plainJavascript/index.html
+++ b/examples/plainJavascript/index.html
@@ -8,10 +8,6 @@
             type="module"
             src="node_modules/@genspectrum/dashboard-components/dist/components.js"
         ></script>
-        <link
-            rel="stylesheet"
-            href="node_modules/@genspectrum/dashboard-components/dist/style.css"
-        />
     </head>
     <body>
         <gs-app lapis="https://lapis.cov-spectrum.org/open/v2/">


### PR DESCRIPTION


resolves #807
resolves #804



### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->
See https://daisyui.com/docs/config/#root
The default is
```
@plugin "daisyui" {
  root: ':root';
}
```
which only targets the HTML document. We need to apply the styles to `:host`.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
