### PR TITLE
feat(components): gs-text-input: make it possible to paste values and accept them on blur

### DIFF
--- a/components/src/preact/textFilter/text-filter.stories.tsx
+++ b/components/src/preact/textFilter/text-filter.stories.tsx
@@ -1,5 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/preact';
-import { expect, fireEvent, fn, waitFor, within } from '@storybook/test';
+import { expect, fireEvent, fn, userEvent, waitFor, within } from '@storybook/test';
 
 import data from './__mockData__/aggregated_hosts.json';
 import { TextFilter, type TextFilterProps } from './text-filter';
@@ -111,6 +111,64 @@ export const RemoveInitialValue: StoryObj<TextFilterProps> = {
                     },
                 }),
             );
+        });
+    },
+};
+
+export const KeepsPartialInputInInputField: StoryObj<TextFilterProps> = {
+    ...Default,
+    render: (args) => (
+        <>
+            <button data-testid='focusHelper'>Focus helper</button>
+            <LapisUrlContextProvider value={LAPIS_URL}>
+                <TextFilter {...args} />
+            </LapisUrlContextProvider>
+        </>
+    ),
+    args: {
+        ...Default.args,
+        value: '',
+    },
+    play: async ({ canvasElement, step }) => {
+        const canvas = within(canvasElement);
+
+        const changedListenerMock = fn();
+        await step('Setup event listener mock', () => {
+            canvasElement.addEventListener('gs-text-filter-changed', changedListenerMock);
+        });
+        const inputField = () => canvas.getByPlaceholderText('Enter a host name', { exact: false });
+        async function typeAndBlur(input: string) {
+            await userEvent.click(inputField());
+            await userEvent.type(inputField(), input);
+            await userEvent.click(canvas.getByTestId('focusHelper'));
+        }
+
+        await waitFor(async () => {
+            await expect(inputField()).toHaveValue('');
+        });
+
+        await step('Type a value that it not valid yet and focus out', async () => {
+            await typeAndBlur('Homo sapi');
+            await waitFor(async () => {
+                await expect(inputField()).toHaveValue('Homo sapi');
+            });
+            await expect(changedListenerMock).not.toHaveBeenCalled();
+        });
+
+        await step('Complete the input value and expect an event', async () => {
+            await typeAndBlur('ens');
+            await waitFor(async () => {
+                await expect(inputField()).toHaveValue('Homo sapiens');
+            });
+            await waitFor(async () => {
+                await expect(changedListenerMock).toHaveBeenLastCalledWith(
+                    expect.objectContaining({
+                        detail: {
+                            host: 'Homo sapiens',
+                        },
+                    }),
+                );
+            });
         });
     },
 };


### PR DESCRIPTION


resolves #812


### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

We have to control the `selectedItem` ourselves instead of leaving it to downshift, because otherwise it will be reset to the `value` that is provided to the web component.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
