### PR TITLE
refactor(components): make sure that the Downshift value is never `undefined`

### DIFF
--- a/components/src/preact/components/downshift-combobox.tsx
+++ b/components/src/preact/components/downshift-combobox.tsx
@@ -15,7 +15,7 @@ export function DownshiftCombobox<Item>({
     inputClassName = '',
 }: {
     allItems: Item[];
-    value?: Item | null;
+    value: Item | null;
     filterItemsByInputValue: (item: Item, value: string) => boolean;
     createEvent: (item: Item | null) => CustomEvent;
     itemToString: (item: Item | undefined | null) => string;
@@ -23,7 +23,7 @@ export function DownshiftCombobox<Item>({
     formatItemInList: (item: Item) => ComponentChild;
     inputClassName?: string;
 }) {
-    const [selectedItem, setSelectedItem] = useState(() => value);
+    const [selectedItem, setSelectedItem] = useState<Item | null>(() => value);
     const [itemsFilter, setItemsFilter] = useState(() => itemToString(selectedItem));
 
     useEffect(() => {
@@ -37,6 +37,11 @@ export function DownshiftCombobox<Item>({
     );
     const divRef = useRef<HTMLDivElement>(null);
     const [inputIsInvalid, setInputIsInvalid] = useState(false);
+
+    const selectItem = (item: Item | null) => {
+        setSelectedItem(item);
+        divRef.current?.dispatchEvent(createEvent(item));
+    };
 
     const shadowRoot = divRef.current?.shadowRoot ?? undefined;
 
@@ -58,7 +63,6 @@ export function DownshiftCombobox<Item>({
         highlightedIndex,
         getItemProps,
         inputValue,
-        selectItem,
         closeMenu,
     } = useCombobox({
         onInputValueChange({ inputValue }) {
@@ -66,10 +70,7 @@ export function DownshiftCombobox<Item>({
             setItemsFilter(inputValue.trim());
         },
         onSelectedItemChange({ selectedItem }) {
-            setSelectedItem(selectedItem);
-            if (selectedItem !== null) {
-                divRef.current?.dispatchEvent(createEvent(selectedItem));
-            }
+            selectItem(selectedItem);
         },
         items,
         itemToString(item) {
@@ -81,7 +82,6 @@ export function DownshiftCombobox<Item>({
 
     const onInputBlur = () => {
         if (inputValue === '') {
-            divRef.current?.dispatchEvent(createEvent(null));
             selectItem(null);
             return;
         }
@@ -97,7 +97,6 @@ export function DownshiftCombobox<Item>({
     };
 
     const clearInput = () => {
-        divRef.current?.dispatchEvent(createEvent(null));
         selectItem(null);
     };
 

--- a/components/src/preact/lineageFilter/lineage-filter.tsx
+++ b/components/src/preact/lineageFilter/lineage-filter.tsx
@@ -77,16 +77,16 @@ const LineageSelector = ({
             allItems={data}
             value={value}
             filterItemsByInputValue={filterByInputValue}
-            createEvent={(item: string | null) => new LineageFilterChangedEvent({ [lapisField]: item ?? undefined })}
-            itemToString={(item: string | undefined | null) => item ?? ''}
+            createEvent={(item) => new LineageFilterChangedEvent({ [lapisField]: item ?? undefined })}
+            itemToString={(item) => item ?? ''}
             placeholderText={placeholderText}
             formatItemInList={(item: string) => item}
         />
     );
 };
 
-function filterByInputValue(item: string, inputValue: string | undefined | null) {
-    if (inputValue === undefined || inputValue === null || inputValue === '') {
+function filterByInputValue(item: string, inputValue: string | null) {
+    if (inputValue === null || inputValue === '') {
         return true;
     }
     return item?.toLowerCase().includes(inputValue?.toLowerCase() || '');

--- a/components/src/preact/locationFilter/location-filter.tsx
+++ b/components/src/preact/locationFilter/location-filter.tsx
@@ -87,12 +87,10 @@ const LocationSelector = ({
     return (
         <DownshiftCombobox
             allItems={allItems}
-            value={selectedItem}
+            value={selectedItem ?? null}
             filterItemsByInputValue={filterByInputValue}
-            createEvent={(item: SelectItem | null) =>
-                new LocationChangedEvent(item?.lapisFilter ?? emptyLocationFilter(fields))
-            }
-            itemToString={(item: SelectItem | undefined | null) => item?.label ?? ''}
+            createEvent={(item) => new LocationChangedEvent(item?.lapisFilter ?? emptyLocationFilter(fields))}
+            itemToString={(item) => item?.label ?? ''}
             placeholderText={placeholderText}
             formatItemInList={(item: SelectItem) => (
                 <>
@@ -107,8 +105,8 @@ const LocationSelector = ({
     );
 };
 
-function filterByInputValue(item: SelectItem, inputValue: string | undefined | null) {
-    if (inputValue === undefined || inputValue === null) {
+function filterByInputValue(item: SelectItem, inputValue: string | null) {
+    if (inputValue === null) {
         return true;
     }
     return (

--- a/components/src/preact/textFilter/text-filter.stories.tsx
+++ b/components/src/preact/textFilter/text-filter.stories.tsx
@@ -104,13 +104,15 @@ export const RemoveInitialValue: StoryObj<TextFilterProps> = {
         await step('Remove initial value', async () => {
             await fireEvent.click(canvas.getByRole('button', { name: 'clear selection' }));
 
-            await expect(changedListenerMock).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    detail: {
-                        host: undefined,
-                    },
-                }),
-            );
+            await waitFor(async () => {
+                await expect(changedListenerMock).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        detail: {
+                            host: undefined,
+                        },
+                    }),
+                );
+            });
         });
     },
 };

--- a/components/src/preact/textFilter/text-filter.tsx
+++ b/components/src/preact/textFilter/text-filter.tsx
@@ -85,12 +85,10 @@ const TextSelector = ({
     return (
         <DownshiftCombobox
             allItems={data}
-            value={initialSelectedItem}
+            value={initialSelectedItem ?? null}
             filterItemsByInputValue={filterByInputValue}
-            createEvent={(item: SelectItem | null) =>
-                new TextFilterChangedEvent({ [lapisField]: item?.value ?? undefined })
-            }
-            itemToString={(item: SelectItem | undefined | null) => item?.value ?? ''}
+            createEvent={(item) => new TextFilterChangedEvent({ [lapisField]: item?.value ?? undefined })}
+            itemToString={(item) => item?.value ?? ''}
             placeholderText={placeholderText}
             formatItemInList={(item: SelectItem) => {
                 return (
@@ -104,8 +102,8 @@ const TextSelector = ({
     );
 };
 
-function filterByInputValue(item: SelectItem, inputValue: string | undefined | null) {
-    if (inputValue === undefined || inputValue === null || inputValue === '') {
+function filterByInputValue(item: SelectItem, inputValue: string | null) {
+    if (inputValue === null || inputValue === '') {
         return true;
     }
     return item.value?.toLowerCase().includes(inputValue?.toLowerCase() || '');

--- a/components/src/web-components/input/gs-text-filter.stories.ts
+++ b/components/src/web-components/input/gs-text-filter.stories.ts
@@ -1,4 +1,4 @@
-import { expect, fireEvent, fn, userEvent, waitFor } from '@storybook/test';
+import { expect, fn, userEvent, waitFor } from '@storybook/test';
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 
@@ -152,22 +152,15 @@ export const FiresEvents: StoryObj<Required<TextFilterProps>> = {
         });
 
         await step('Remove initial value', async () => {
-            await fireEvent.click(canvas.getByRole('button', { name: 'clear selection' }));
+            await userEvent.click(canvas.getByRole('button', { name: 'clear selection' }));
 
-            await expect(listenerMock).toHaveBeenCalledWith(
+            await expect(listenerMock).toHaveBeenLastCalledWith(
                 expect.objectContaining({
                     detail: {
                         host: undefined,
                     },
                 }),
             );
-        });
-
-        await step('Empty input', async () => {
-            inputField().blur();
-            await expect(listenerMock.mock.calls.at(-1)![0].detail).toStrictEqual({
-                host: undefined,
-            });
         });
     },
     args: {


### PR DESCRIPTION



resolves #848

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->


Because downshift assumes that an `undefined` `value` means it's uncontrolled. For the "nothing is selected" state we should make sure to use `null` instead.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
