### PR TITLE
fix(components): bug with displayMutations in mutations-over-time

### DIFF
--- a/components/src/preact/mutationsOverTime/getFilteredMutationsOverTimeData.ts
+++ b/components/src/preact/mutationsOverTime/getFilteredMutationsOverTimeData.ts
@@ -47,7 +47,7 @@ export function getFilteredMutationOverTimeData({
             return true;
         }
 
-        if (displayMutationsSet !== null && !displayMutationsSet.has(entry.mutation.code)) {
+        if (displayMutationsSet !== null && !displayMutationsSet.has(entry.mutation.code.toUpperCase())) {
             return true;
         }
 


### PR DESCRIPTION
### Summary

This fixes a bug that causes `<gs-mutations-over-time ... displayMutations='["ORF1a:T103L"]' />` to ignore the specified mutation and show nothing because the gene contains a lowercase `a`.


### Screenshot

<img width="1210" alt="image" src="https://github.com/user-attachments/assets/6b76a05f-3525-4550-a911-07ba92382726" />
