### PR TITLE
feat(components): export input type of NumberRangeFilter

### DIFF
--- a/components/src/utilEntrypoint.ts
+++ b/components/src/utilEntrypoint.ts
@@ -40,3 +40,5 @@ export { TextFilterChangedEvent } from './preact/textFilter/TextFilterChangedEve
 export type { MutationAnnotations, MutationAnnotation } from './web-components/mutation-annotations-context';
 
 export { gsEventNames } from './utils/gsEventNames';
+
+export { type NumberRange } from './preact/numberRangeFilter/NumberRangeFilterChangedEvent';


### PR DESCRIPTION
Exports the input type of the new NumberRangeFilter so they can be used at the consuming side.

