### PR TITLE
feat(components): fire `gs-component-finished-loading` event when visualization components are likely to trigger no layout shifts anymore

### DIFF
--- a/components/.storybook-preact/preview.ts
+++ b/components/.storybook-preact/preview.ts
@@ -18,7 +18,7 @@ const preview: Preview = {
                 date: /Date$/i,
             },
         },
-        actions: { handles: [gsEventNames.error] },
+        actions: { handles: [gsEventNames.error, gsEventNames.componentFinishedLoading] },
     },
     decorators: [withActions],
     beforeEach: () => {

--- a/components/.storybook/preview.tsx
+++ b/components/.storybook/preview.tsx
@@ -8,7 +8,7 @@ import { gsEventNames } from '../src/utils/gsEventNames';
 
 setCustomElementsManifest(customElements);
 
-export const previewHandles = [gsEventNames.error];
+export const previewHandles = [gsEventNames.error, gsEventNames.componentFinishedLoading];
 
 const preview: Preview = {
     parameters: {

--- a/components/src/preact/aggregatedData/aggregate.stories.tsx
+++ b/components/src/preact/aggregatedData/aggregate.stories.tsx
@@ -6,6 +6,7 @@ import { Aggregate, type AggregateProps } from './aggregate';
 import { AGGREGATED_ENDPOINT, LAPIS_URL } from '../../constants';
 import { LapisUrlContextProvider } from '../LapisUrlContext';
 import { expectInvalidAttributesErrorMessage, playThatExpectsErrorMessage } from '../shared/stories/expectErrorMessage';
+import { playThatExpectsFinishedLoadingEvent } from '../shared/stories/expectFinishedLoadingEvent';
 
 const meta: Meta<AggregateProps> = {
     title: 'Visualization/Aggregate',
@@ -60,6 +61,11 @@ export const Default: StoryObj<AggregateProps> = {
         pageSize: 10,
         maxNumberOfBars: 20,
     },
+};
+
+export const FiresFinishedLoadingEvent: StoryObj<AggregateProps> = {
+    ...Default,
+    play: playThatExpectsFinishedLoadingEvent(),
 };
 
 export const FailsLoadingData: StoryObj<AggregateProps> = {

--- a/components/src/preact/aggregatedData/aggregate.tsx
+++ b/components/src/preact/aggregatedData/aggregate.tsx
@@ -5,6 +5,7 @@ import { useLapisUrl } from '../LapisUrlContext';
 import { AggregateTable } from './aggregate-table';
 import { type AggregateData, queryAggregateData } from '../../query/queryAggregateData';
 import { lapisFilterSchema, views } from '../../types';
+import { useDispatchFinishedLoadingEvent } from '../../utils/useDispatchFinishedLoadingEvent';
 import { CsvDownloadButton } from '../components/csv-download-button';
 import { ErrorBoundary } from '../components/error-boundary';
 import { Fullscreen } from '../components/fullscreen';
@@ -75,6 +76,8 @@ type AggregatedDataTabsProps = {
 };
 
 const AggregatedDataTabs: FunctionComponent<AggregatedDataTabsProps> = ({ data, originalComponentProps }) => {
+    const tabsRef = useDispatchFinishedLoadingEvent();
+
     const maintainAspectRatio = getMaintainAspectRatio(originalComponentProps.height);
 
     const getTab = (view: AggregateView) => {
@@ -109,7 +112,13 @@ const AggregatedDataTabs: FunctionComponent<AggregatedDataTabsProps> = ({ data, 
 
     const tabs = originalComponentProps.views.map((view) => getTab(view));
 
-    return <Tabs tabs={tabs} toolbar={<Toolbar data={data} originalComponentProps={originalComponentProps} />} />;
+    return (
+        <Tabs
+            ref={tabsRef}
+            tabs={tabs}
+            toolbar={<Toolbar data={data} originalComponentProps={originalComponentProps} />}
+        />
+    );
 };
 
 type ToolbarProps = {

--- a/components/src/preact/components/tabs.tsx
+++ b/components/src/preact/components/tabs.tsx
@@ -1,4 +1,4 @@
-import { type FunctionComponent } from 'preact';
+import { forwardRef } from 'preact/compat';
 import { useState } from 'preact/hooks';
 import { type JSXInternal } from 'preact/src/jsx';
 
@@ -12,7 +12,7 @@ interface ComponentTabsProps {
     toolbar?: JSXInternal.Element | ((activeTab: string) => JSXInternal.Element);
 }
 
-const Tabs: FunctionComponent<ComponentTabsProps> = ({ tabs, toolbar }) => {
+const Tabs = forwardRef<HTMLDivElement, ComponentTabsProps>(({ tabs, toolbar }, ref) => {
     const [activeTab, setActiveTab] = useState(tabs[0]?.title);
 
     const tabElements = (
@@ -40,7 +40,7 @@ const Tabs: FunctionComponent<ComponentTabsProps> = ({ tabs, toolbar }) => {
     const toolbarElement = typeof toolbar === 'function' ? toolbar(activeTab) : toolbar;
 
     return (
-        <div className='h-full w-full flex flex-col'>
+        <div ref={ref} className='h-full w-full flex flex-col'>
             <div className='flex flex-row justify-between flex-wrap'>
                 {tabElements}
                 {toolbar && <div className='py-2 flex flex-wrap gap-y-1'>{toolbarElement}</div>}
@@ -54,6 +54,6 @@ const Tabs: FunctionComponent<ComponentTabsProps> = ({ tabs, toolbar }) => {
             </div>
         </div>
     );
-};
+});
 
 export default Tabs;

--- a/components/src/preact/genomeViewer/CDSPlot.tsx
+++ b/components/src/preact/genomeViewer/CDSPlot.tsx
@@ -2,6 +2,7 @@ import { Fragment, type FunctionComponent } from 'preact';
 import { useMemo, useState } from 'preact/hooks';
 
 import { type CDSFeature } from './loadGff3';
+import { useDispatchFinishedLoadingEvent } from '../../utils/useDispatchFinishedLoadingEvent';
 import { MinMaxRangeSlider } from '../components/min-max-range-slider';
 import Tooltip from '../components/tooltip';
 import { singleGraphColorRGBByName } from '../shared/charts/colors';
@@ -183,6 +184,8 @@ interface CDSProps {
 }
 
 const CDSPlot: FunctionComponent<CDSProps> = (componentProps) => {
+    const ref = useDispatchFinishedLoadingEvent();
+
     const { gffData, genomeLength, width } = componentProps;
 
     const [zoomStart, setZoomStart] = useState(0);
@@ -197,7 +200,7 @@ const CDSPlot: FunctionComponent<CDSProps> = (componentProps) => {
     };
 
     return (
-        <div class='p-4'>
+        <div ref={ref} class='p-4'>
             <CDSBars gffData={gffData} zoomStart={zoomStart} zoomEnd={zoomEnd} />
             <XAxis zoomStart={zoomStart} zoomEnd={zoomEnd} fullWidth={width} />
             <div class='relative w-full h-5'>

--- a/components/src/preact/genomeViewer/genome-data-viewer.stories.tsx
+++ b/components/src/preact/genomeViewer/genome-data-viewer.stories.tsx
@@ -2,6 +2,7 @@ import { type Meta, type StoryObj } from '@storybook/preact';
 
 import { GenomeDataViewer, type GenomeDataViewerProps } from './genome-data-viewer';
 import { playThatExpectsErrorMessage } from '../shared/stories/expectErrorMessage';
+import { playThatExpectsFinishedLoadingEvent } from '../shared/stories/expectFinishedLoadingEvent';
 
 const meta: Meta<GenomeDataViewerProps> = {
     title: 'Visualization/GenomeDataViewer',
@@ -73,6 +74,11 @@ export const Default: StoryObj<GenomeDataViewerProps> = {
             ],
         },
     },
+};
+
+export const FiresFinishedLoadingEvent: StoryObj<GenomeDataViewerProps> = {
+    ...Default,
+    play: playThatExpectsFinishedLoadingEvent(),
 };
 
 export const InvalidProps: StoryObj<GenomeDataViewerProps> = {

--- a/components/src/preact/mutationComparison/mutation-comparison.stories.tsx
+++ b/components/src/preact/mutationComparison/mutation-comparison.stories.tsx
@@ -10,6 +10,7 @@ import { type MutationAnnotations } from '../../web-components/mutation-annotati
 import { LapisUrlContextProvider } from '../LapisUrlContext';
 import { MutationAnnotationsContextProvider } from '../MutationAnnotationsContext';
 import { ReferenceGenomeContext } from '../ReferenceGenomeContext';
+import { playThatExpectsFinishedLoadingEvent } from '../shared/stories/expectFinishedLoadingEvent';
 import { expectMutationAnnotation } from '../shared/stories/expectMutationAnnotation';
 
 const dateToSomeDataset = '2022-01-01';
@@ -140,6 +141,11 @@ export const TwoVariants: StoryObj<MutationComparisonProps> = {
     play: async ({ canvasElement }) => {
         await expectMutationAnnotation(canvasElement, 'C3037T');
     },
+};
+
+export const FiresFinishedLoadingEvent: StoryObj<MutationComparisonProps> = {
+    ...TwoVariants,
+    play: playThatExpectsFinishedLoadingEvent(),
 };
 
 export const FilterForOnlyDeletions: StoryObj<MutationComparisonProps> = {

--- a/components/src/preact/mutationComparison/mutation-comparison.tsx
+++ b/components/src/preact/mutationComparison/mutation-comparison.tsx
@@ -7,6 +7,7 @@ import { MutationComparisonTable } from './mutation-comparison-table';
 import { MutationComparisonVenn } from './mutation-comparison-venn';
 import { filterMutationData, type MutationData, queryMutationData } from './queryMutationData';
 import { namedLapisFilterSchema, sequenceTypeSchema, views } from '../../types';
+import { useDispatchFinishedLoadingEvent } from '../../utils/useDispatchFinishedLoadingEvent';
 import { useLapisUrl } from '../LapisUrlContext';
 import { CsvDownloadButton } from '../components/csv-download-button';
 import { ErrorBoundary } from '../components/error-boundary';
@@ -80,6 +81,8 @@ type MutationComparisonTabsProps = {
 };
 
 const MutationComparisonTabs: FunctionComponent<MutationComparisonTabsProps> = ({ data, originalComponentProps }) => {
+    const tabsRef = useDispatchFinishedLoadingEvent();
+
     const [proportionInterval, setProportionInterval] = useState({ min: 0.5, max: 1 });
     const [displayedMutationTypes, setDisplayedMutationTypes] = useState<DisplayedMutationType[]>([
         { label: 'Substitutions', checked: true, type: 'substitution' },
@@ -127,6 +130,7 @@ const MutationComparisonTabs: FunctionComponent<MutationComparisonTabsProps> = (
 
     return (
         <Tabs
+            ref={tabsRef}
             tabs={tabs}
             toolbar={
                 <Toolbar

--- a/components/src/preact/mutations/mutations.stories.tsx
+++ b/components/src/preact/mutations/mutations.stories.tsx
@@ -17,6 +17,7 @@ import { type MutationAnnotations } from '../../web-components/mutation-annotati
 import { LapisUrlContextProvider } from '../LapisUrlContext';
 import { MutationAnnotationsContextProvider } from '../MutationAnnotationsContext';
 import { ReferenceGenomeContext } from '../ReferenceGenomeContext';
+import { playThatExpectsFinishedLoadingEvent } from '../shared/stories/expectFinishedLoadingEvent';
 import { expectMutationAnnotation } from '../shared/stories/expectMutationAnnotation';
 
 const meta: Meta<MutationsProps> = {
@@ -145,6 +146,11 @@ export const Default: StoryObj<MutationsProps> = {
             ],
         },
     },
+};
+
+export const FiresFinishedLoadingEvent: StoryObj<MutationsProps> = {
+    ...Default,
+    play: playThatExpectsFinishedLoadingEvent(),
 };
 
 export const GridTab: StoryObj<MutationsProps> = {

--- a/components/src/preact/mutations/mutations.tsx
+++ b/components/src/preact/mutations/mutations.tsx
@@ -15,6 +15,7 @@ import {
     type SubstitutionOrDeletionEntry,
     views,
 } from '../../types';
+import { useDispatchFinishedLoadingEvent } from '../../utils/useDispatchFinishedLoadingEvent';
 import { useLapisUrl } from '../LapisUrlContext';
 import { CsvDownloadButton } from '../components/csv-download-button';
 import { ErrorBoundary } from '../components/error-boundary';
@@ -87,6 +88,8 @@ type MutationTabsProps = {
 };
 
 const MutationsTabs: FunctionComponent<MutationTabsProps> = ({ mutationsData, originalComponentProps }) => {
+    const tabsRef = useDispatchFinishedLoadingEvent();
+
     const [proportionInterval, setProportionInterval] = useState({ min: 0.05, max: 1 });
 
     const [displayedSegments, setDisplayedSegments] = useDisplayedSegments(originalComponentProps.sequenceType);
@@ -153,7 +156,7 @@ const MutationsTabs: FunctionComponent<MutationTabsProps> = ({ mutationsData, or
         />
     );
 
-    return <Tabs tabs={tabs} toolbar={toolbar} />;
+    return <Tabs ref={tabsRef} tabs={tabs} toolbar={toolbar} />;
 };
 
 type ToolbarProps = {

--- a/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
@@ -10,6 +10,7 @@ import { LapisUrlContextProvider } from '../LapisUrlContext';
 import { MutationAnnotationsContextProvider } from '../MutationAnnotationsContext';
 import { ReferenceGenomeContext } from '../ReferenceGenomeContext';
 import { expectInvalidAttributesErrorMessage } from '../shared/stories/expectErrorMessage';
+import { playThatExpectsFinishedLoadingEvent } from '../shared/stories/expectFinishedLoadingEvent';
 import { expectMutationAnnotation } from '../shared/stories/expectMutationAnnotation';
 
 const meta: Meta<MutationsOverTimeProps> = {
@@ -81,6 +82,11 @@ export const Default: StoryObj<MutationsOverTimeProps> = {
         initialMeanProportionInterval: { min: 0.05, max: 0.9 },
         pageSizes: [10, 20, 30, 40, 50],
     },
+};
+
+export const FiresFinishedLoadingEvent: StoryObj<MutationsOverTimeProps> = {
+    ...Default,
+    play: playThatExpectsFinishedLoadingEvent(),
 };
 
 export const ShowsMutationAnnotations: StoryObj<MutationsOverTimeProps> = {

--- a/components/src/preact/mutationsOverTime/mutations-over-time.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../types';
 import { type Deletion, type Substitution } from '../../utils/mutations';
 import { toTemporalClass } from '../../utils/temporalClass';
+import { useDispatchFinishedLoadingEvent } from '../../utils/useDispatchFinishedLoadingEvent';
 import { useLapisUrl } from '../LapisUrlContext';
 import { useMutationAnnotationsProvider } from '../MutationAnnotationsContext';
 import { type ColorScale } from '../components/color-scale-selector';
@@ -126,6 +127,8 @@ const MutationsOverTimeTabs: FunctionComponent<MutationOverTimeTabsProps> = ({
     originalComponentProps,
     overallMutationData,
 }) => {
+    const tabsRef = useDispatchFinishedLoadingEvent();
+
     const [mutationFilterValue, setMutationFilterValue] = useState('');
     const annotationProvider = useMutationAnnotationsProvider();
 
@@ -207,7 +210,7 @@ const MutationsOverTimeTabs: FunctionComponent<MutationOverTimeTabsProps> = ({
 
     return (
         <PageSizeContextProvider pageSizes={originalComponentProps.pageSizes}>
-            <Tabs tabs={tabs} toolbar={toolbar} />
+            <Tabs ref={tabsRef} tabs={tabs} toolbar={toolbar} />
         </PageSizeContextProvider>
     );
 };

--- a/components/src/preact/numberSequencesOverTime/number-sequences-over-time.stories.tsx
+++ b/components/src/preact/numberSequencesOverTime/number-sequences-over-time.stories.tsx
@@ -7,6 +7,7 @@ import twoVariantsEG from '../../preact/numberSequencesOverTime/__mockData__/two
 import twoVariantsJN1 from '../../preact/numberSequencesOverTime/__mockData__/twoVariantsJN1.json';
 import { LapisUrlContextProvider } from '../LapisUrlContext';
 import { expectInvalidAttributesErrorMessage } from '../shared/stories/expectErrorMessage';
+import { playThatExpectsFinishedLoadingEvent } from '../shared/stories/expectFinishedLoadingEvent';
 
 export default {
     title: 'Visualization/NumberSequencesOverTime',
@@ -71,8 +72,9 @@ const Template: StoryObj<NumberSequencesOverTimeProps> = {
     },
 };
 
-export const Table = {
+export const FiresFinishedLoadingEvent: StoryObj<NumberSequencesOverTimeProps> = {
     ...Template,
+    play: playThatExpectsFinishedLoadingEvent(),
 };
 
 export const TwoVariants: StoryObj<NumberSequencesOverTimeProps> = {

--- a/components/src/preact/numberSequencesOverTime/number-sequences-over-time.tsx
+++ b/components/src/preact/numberSequencesOverTime/number-sequences-over-time.tsx
@@ -11,6 +11,7 @@ import {
     queryNumberOfSequencesOverTime,
 } from '../../query/queryNumberOfSequencesOverTime';
 import { namedLapisFilterSchema, temporalGranularitySchema, views } from '../../types';
+import { useDispatchFinishedLoadingEvent } from '../../utils/useDispatchFinishedLoadingEvent';
 import { useLapisUrl } from '../LapisUrlContext';
 import { CsvDownloadButton } from '../components/csv-download-button';
 import { ErrorBoundary } from '../components/error-boundary';
@@ -88,6 +89,8 @@ interface NumberSequencesOverTimeTabsProps {
 }
 
 const NumberSequencesOverTimeTabs = ({ data, originalComponentProps }: NumberSequencesOverTimeTabsProps) => {
+    const tabsRef = useDispatchFinishedLoadingEvent();
+
     const [yAxisScaleType, setYAxisScaleType] = useState<ScaleType>('linear');
 
     const maintainAspectRatio = getMaintainAspectRatio(originalComponentProps.height);
@@ -134,6 +137,7 @@ const NumberSequencesOverTimeTabs = ({ data, originalComponentProps }: NumberSeq
 
     return (
         <Tabs
+            ref={tabsRef}
             tabs={originalComponentProps.views.map((view) => getTab(view))}
             toolbar={(activeTab) => (
                 <Toolbar

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.stories.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.stories.tsx
@@ -11,6 +11,7 @@ import numeratorOneDataset from './__mockData__/numeratorFilterOneDataset.json';
 import { PrevalenceOverTime, type PrevalenceOverTimeProps } from './prevalence-over-time';
 import { AGGREGATED_ENDPOINT, LAPIS_URL } from '../../constants';
 import { expectInvalidAttributesErrorMessage } from '../shared/stories/expectErrorMessage';
+import { playThatExpectsFinishedLoadingEvent } from '../shared/stories/expectFinishedLoadingEvent';
 
 export default {
     title: 'Visualization/PrevalenceOverTime',
@@ -119,6 +120,11 @@ export const TwoVariants: StoryObj<PrevalenceOverTimeProps> = {
             ],
         },
     },
+};
+
+export const FiresFinishedLoadingEvent: StoryObj<PrevalenceOverTimeProps> = {
+    ...TwoVariants,
+    play: playThatExpectsFinishedLoadingEvent(),
 };
 
 export const OneVariant: StoryObj<PrevalenceOverTimeProps> = {

--- a/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
+++ b/components/src/preact/prevalenceOverTime/prevalence-over-time.tsx
@@ -9,6 +9,7 @@ import PrevalenceOverTimeLineChart from './prevalence-over-time-line-chart';
 import PrevalenceOverTimeTable from './prevalence-over-time-table';
 import { type PrevalenceOverTimeData, queryPrevalenceOverTime } from '../../query/queryPrevalenceOverTime';
 import { lapisFilterSchema, namedLapisFilterSchema, temporalGranularitySchema, views } from '../../types';
+import { useDispatchFinishedLoadingEvent } from '../../utils/useDispatchFinishedLoadingEvent';
 import { useLapisUrl } from '../LapisUrlContext';
 import { ConfidenceIntervalSelector } from '../components/confidence-interval-selector';
 import { CsvDownloadButton } from '../components/csv-download-button';
@@ -101,6 +102,8 @@ type PrevalenceOverTimeTabsProps = PrevalenceOverTimeProps & {
 };
 
 const PrevalenceOverTimeTabs: FunctionComponent<PrevalenceOverTimeTabsProps> = ({ data, ...componentProps }) => {
+    const tabsRef = useDispatchFinishedLoadingEvent();
+
     const { views, granularity, confidenceIntervalMethods, pageSize, yAxisMaxLinear, yAxisMaxLogarithmic } =
         componentProps;
     const [yAxisScaleType, setYAxisScaleType] = useState<ScaleType>('linear');
@@ -182,7 +185,7 @@ const PrevalenceOverTimeTabs: FunctionComponent<PrevalenceOverTimeTabsProps> = (
         />
     );
 
-    return <Tabs tabs={tabs} toolbar={toolbar} />;
+    return <Tabs ref={tabsRef} tabs={tabs} toolbar={toolbar} />;
 };
 
 type ToolbarProps = PrevalenceOverTimeProps & {

--- a/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.stories.tsx
+++ b/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.stories.tsx
@@ -7,6 +7,7 @@ import { RelativeGrowthAdvantage, type RelativeGrowthAdvantageProps } from './re
 import { AGGREGATED_ENDPOINT, LAPIS_URL } from '../../constants';
 import { LapisUrlContextProvider } from '../LapisUrlContext';
 import { expectInvalidAttributesErrorMessage } from '../shared/stories/expectErrorMessage';
+import { playThatExpectsFinishedLoadingEvent } from '../shared/stories/expectFinishedLoadingEvent';
 
 export default {
     title: 'Visualization/RelativeGrowthAdvantage',
@@ -88,6 +89,11 @@ export const Primary: StoryObj<RelativeGrowthAdvantageProps> = {
             ],
         },
     },
+};
+
+export const FiresFinishedLoadingEvent: StoryObj<RelativeGrowthAdvantageProps> = {
+    ...Primary,
+    play: playThatExpectsFinishedLoadingEvent(),
 };
 
 export const TooFewDataToComputeGrowthAdvantage: StoryObj<RelativeGrowthAdvantageProps> = {

--- a/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
+++ b/components/src/preact/relativeGrowthAdvantage/relative-growth-advantage.tsx
@@ -9,6 +9,7 @@ import {
     type RelativeGrowthAdvantageData,
 } from '../../query/queryRelativeGrowthAdvantage';
 import { lapisFilterSchema, views } from '../../types';
+import { useDispatchFinishedLoadingEvent } from '../../utils/useDispatchFinishedLoadingEvent';
 import { useLapisUrl } from '../LapisUrlContext';
 import { ErrorBoundary } from '../components/error-boundary';
 import { Fullscreen } from '../components/fullscreen';
@@ -103,6 +104,8 @@ const RelativeGrowthAdvantageTabs: FunctionComponent<RelativeGrowthAdvantageTabs
     setYAxisScaleType,
     originalComponentProps,
 }) => {
+    const tabsRef = useDispatchFinishedLoadingEvent();
+
     const maintainAspectRatio = getMaintainAspectRatio(originalComponentProps.height);
 
     const getTab = (view: RelativeGrowthAdvantageView) => {
@@ -138,7 +141,7 @@ const RelativeGrowthAdvantageTabs: FunctionComponent<RelativeGrowthAdvantageTabs
         />
     );
 
-    return <Tabs tabs={tabs} toolbar={toolbar} />;
+    return <Tabs ref={tabsRef} tabs={tabs} toolbar={toolbar} />;
 };
 
 type RelativeGrowthAdvantageToolbarProps = {

--- a/components/src/preact/sequencesByLocation/sequences-by-location.stories.tsx
+++ b/components/src/preact/sequencesByLocation/sequences-by-location.stories.tsx
@@ -7,6 +7,7 @@ import { LapisUrlContextProvider } from '../LapisUrlContext';
 import aggregatedWorld from './__mockData__/aggregatedWorld.json';
 import { SequencesByLocation, type SequencesByLocationProps } from './sequences-by-location';
 import { expectInvalidAttributesErrorMessage, playThatExpectsErrorMessage } from '../shared/stories/expectErrorMessage';
+import { playThatExpectsFinishedLoadingEvent } from '../shared/stories/expectFinishedLoadingEvent';
 
 import 'leaflet/dist/leaflet.css';
 import './leafletStyleModifications.css';
@@ -90,6 +91,11 @@ export const Default: StoryObj<SequencesByLocationProps> = {
             ],
         },
     },
+};
+
+export const FiresFinishedLoadingEvent: StoryObj<SequencesByLocationProps> = {
+    ...Default,
+    play: playThatExpectsFinishedLoadingEvent(),
 };
 
 export const NoData: StoryObj<SequencesByLocationProps> = {

--- a/components/src/preact/sequencesByLocation/sequences-by-location.tsx
+++ b/components/src/preact/sequencesByLocation/sequences-by-location.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../query/computeMapLocationData';
 import { type AggregateData } from '../../query/queryAggregateData';
 import { querySequencesByLocationData } from '../../query/querySequencesByLocationData';
+import { useDispatchFinishedLoadingEvent } from '../../utils/useDispatchFinishedLoadingEvent';
 import { CsvDownloadButton } from '../components/csv-download-button';
 import { ErrorBoundary } from '../components/error-boundary';
 import { Fullscreen } from '../components/fullscreen';
@@ -93,6 +94,8 @@ const SequencesByLocationMapTabs: FunctionComponent<SequencesByLocationMapTabsPr
     originalComponentProps,
     data,
 }) => {
+    const tabsRef = useDispatchFinishedLoadingEvent();
+
     const maintainAspectRatio = getMaintainAspectRatio(originalComponentProps.height);
 
     const getTab = (view: SequencesByLocationMapView) => {
@@ -136,6 +139,7 @@ const SequencesByLocationMapTabs: FunctionComponent<SequencesByLocationMapTabsPr
 
     return (
         <Tabs
+            ref={tabsRef}
             tabs={tabs}
             toolbar={<Toolbar originalComponentProps={originalComponentProps} tableData={data.tableData} />}
         />

--- a/components/src/preact/shared/stories/expectFinishedLoadingEvent.ts
+++ b/components/src/preact/shared/stories/expectFinishedLoadingEvent.ts
@@ -1,0 +1,12 @@
+import { expect, fn, waitFor } from '@storybook/test';
+
+import { gsEventNames } from '../../../utils/gsEventNames';
+
+export function playThatExpectsFinishedLoadingEvent() {
+    return async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+        const componentFinishedLoadingListenerMock = fn();
+        canvasElement.addEventListener(gsEventNames.componentFinishedLoading, componentFinishedLoadingListenerMock);
+
+        await waitFor(() => expect(componentFinishedLoadingListenerMock).toHaveBeenCalled());
+    };
+}

--- a/components/src/preact/statistic/statistics.stories.tsx
+++ b/components/src/preact/statistic/statistics.stories.tsx
@@ -6,6 +6,7 @@ import { LapisUrlContextProvider } from '../LapisUrlContext';
 import denominatorData from './__mockData__/denominator.json';
 import numeratorData from './__mockData__/numerator.json';
 import { Statistics, type StatisticsProps } from './statistics';
+import { playThatExpectsFinishedLoadingEvent } from '../shared/stories/expectFinishedLoadingEvent';
 
 const meta: Meta<StatisticsProps> = {
     title: 'Visualization/Statistics',
@@ -77,4 +78,9 @@ export const Default: StoryObj<StatisticsProps> = {
             await expect(canvas.getByText('50.00%')).toBeInTheDocument();
         });
     },
+};
+
+export const FiresFinishedLoadingEvent: StoryObj<StatisticsProps> = {
+    ...Default,
+    play: playThatExpectsFinishedLoadingEvent(),
 };

--- a/components/src/preact/statistic/statistics.tsx
+++ b/components/src/preact/statistic/statistics.tsx
@@ -3,6 +3,7 @@ import z from 'zod';
 
 import { queryGeneralStatistics } from '../../query/queryGeneralStatistics';
 import { lapisFilterSchema } from '../../types';
+import { useDispatchFinishedLoadingEvent } from '../../utils/useDispatchFinishedLoadingEvent';
 import { useLapisUrl } from '../LapisUrlContext';
 import { ErrorBoundary } from '../components/error-boundary';
 import { LoadingDisplay } from '../components/loading-display';
@@ -60,9 +61,11 @@ type MetricDataTabsProps = {
 };
 
 const MetricDataTabs: FunctionComponent<MetricDataTabsProps> = ({ data }) => {
+    const ref = useDispatchFinishedLoadingEvent();
+
     const { count, proportion } = data;
     return (
-        <div className='flex flex-col sm:flex-row rounded-md border-2 border-gray-100 min-w-[180px]'>
+        <div ref={ref} className='flex flex-col sm:flex-row rounded-md border-2 border-gray-100 min-w-[180px]'>
             <div className='stat'>
                 <div className='stat-title'>Sequences</div>
                 <div className='stat-value text-2xl sm:text-4xl'>{count.toLocaleString('en-us')}</div>

--- a/components/src/preact/wastewater/mutationsOverTime/wastewater-mutations-over-time.stories.tsx
+++ b/components/src/preact/wastewater/mutationsOverTime/wastewater-mutations-over-time.stories.tsx
@@ -9,6 +9,7 @@ import { LapisUrlContextProvider } from '../../LapisUrlContext';
 import { ReferenceGenomeContext } from '../../ReferenceGenomeContext';
 import details from './__mockData__/details.json';
 import type { MutationsOverTimeProps } from '../../mutationsOverTime/mutations-over-time';
+import { playThatExpectsFinishedLoadingEvent } from '../../shared/stories/expectFinishedLoadingEvent';
 
 const meta: Meta<WastewaterMutationsOverTimeProps> = {
     title: 'Wastewater visualization/Wastewater mutations over time',
@@ -67,6 +68,7 @@ export const Default: StoryObj<WastewaterMutationsOverTimeProps> = {
             ],
         },
     },
+    play: playThatExpectsFinishedLoadingEvent(),
 };
 
 export const ChangingRowsPerPageChangesItForEveryTag: StoryObj<WastewaterMutationsOverTimeProps> = {

--- a/components/src/preact/wastewater/mutationsOverTime/wastewater-mutations-over-time.tsx
+++ b/components/src/preact/wastewater/mutationsOverTime/wastewater-mutations-over-time.tsx
@@ -5,6 +5,7 @@ import z from 'zod';
 import { computeWastewaterMutationsOverTimeDataPerLocation } from './computeWastewaterMutationsOverTimeDataPerLocation';
 import { lapisFilterSchema, type SequenceType, sequenceTypeSchema } from '../../../types';
 import { Map2dView } from '../../../utils/map2d';
+import { useDispatchFinishedLoadingEvent } from '../../../utils/useDispatchFinishedLoadingEvent';
 import { useLapisUrl } from '../../LapisUrlContext';
 import { useMutationAnnotationsProvider } from '../../MutationAnnotationsContext';
 import { type ColorScale } from '../../components/color-scale-selector';
@@ -145,6 +146,8 @@ const MutationsOverTimeTabs: FunctionComponent<MutationOverTimeTabsProps> = ({
     mutationOverTimeDataPerLocation,
     originalComponentProps,
 }) => {
+    const tabsRef = useDispatchFinishedLoadingEvent();
+
     const [mutationFilterValue, setMutationFilterValue] = useState('');
     const annotationProvider = useMutationAnnotationsProvider();
 
@@ -196,7 +199,7 @@ const MutationsOverTimeTabs: FunctionComponent<MutationOverTimeTabsProps> = ({
 
     return (
         <PageSizeContextProvider pageSizes={originalComponentProps.pageSizes}>
-            <Tabs tabs={tabs} toolbar={toolbar} />
+            <Tabs ref={tabsRef} tabs={tabs} toolbar={toolbar} />
         </PageSizeContextProvider>
     );
 };

--- a/components/src/utils/gsEventNames.ts
+++ b/components/src/utils/gsEventNames.ts
@@ -1,5 +1,6 @@
 export const gsEventNames = {
     error: 'gs-error',
+    componentFinishedLoading: 'gs-component-finished-loading',
     dateRangeFilterChanged: 'gs-date-range-filter-changed',
     dateRangeOptionChanged: 'gs-date-range-option-changed',
     mutationFilterChanged: 'gs-mutation-filter-changed',

--- a/components/src/utils/useDispatchFinishedLoadingEvent.ts
+++ b/components/src/utils/useDispatchFinishedLoadingEvent.ts
@@ -1,0 +1,19 @@
+import { useEffect, useRef } from 'preact/hooks';
+
+import { gsEventNames } from './gsEventNames';
+
+export function useDispatchFinishedLoadingEvent() {
+    const ref = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (ref.current === null) {
+            return;
+        }
+
+        ref.current.dispatchEvent(
+            new CustomEvent(gsEventNames.componentFinishedLoading, { bubbles: true, composed: true }),
+        );
+    }, [ref]);
+
+    return ref;
+}

--- a/components/src/web-components/visualization/gs-aggregate.tsx
+++ b/components/src/web-components/visualization/gs-aggregate.tsx
@@ -30,6 +30,9 @@ import { PreactLitAdapterWithGridJsStyles } from '../PreactLitAdapterWithGridJsS
  *
  * The chart shows the bars with the highest aggregated `count`.
  * The number of bars can be adjusted with the `maxNumberOfBars` property.
+ *
+ * @fires {CustomEvent<undefined>} gs-component-finished-loading
+ * Fired when the component has finished loading the required data from LAPIS.
  */
 @customElement('gs-aggregate')
 export class AggregateComponent extends PreactLitAdapterWithGridJsStyles {

--- a/components/src/web-components/visualization/gs-genome-data-viewer.tsx
+++ b/components/src/web-components/visualization/gs-genome-data-viewer.tsx
@@ -10,6 +10,8 @@ import { PreactLitAdapter } from '../PreactLitAdapter';
  * This component shows the Coding Sequence (CDS) of a genome using a gff3 file as input.
  * The CDS shows which parts of the genome are translated into proteins.
  *
+ * @fires {CustomEvent<undefined>} gs-component-finished-loading
+ * Fired when the component has finished loading the required data.
  */
 @customElement('gs-genome-data-viewer')
 export class GenomeDataViewerComponent extends PreactLitAdapter {

--- a/components/src/web-components/visualization/gs-mutation-comparison.tsx
+++ b/components/src/web-components/visualization/gs-mutation-comparison.tsx
@@ -34,6 +34,9 @@ import { type MutationAnnotations, mutationAnnotationsContext } from '../mutatio
  * selected proportion interval.
  * Thus, changing the proportion interval may change a mutations from being "common" between the datasets
  * to being "for one dataset only".
+ *
+ * @fires {CustomEvent<undefined>} gs-component-finished-loading
+ * Fired when the component has finished loading the required data from LAPIS.
  */
 @customElement('gs-mutation-comparison')
 export class MutationComparisonComponent extends PreactLitAdapterWithGridJsStyles {

--- a/components/src/web-components/visualization/gs-mutations-over-time.tsx
+++ b/components/src/web-components/visualization/gs-mutations-over-time.tsx
@@ -38,6 +38,9 @@ import { type MutationAnnotations, mutationAnnotationsContext } from '../mutatio
  * Users can filter the displayed rows by mean proportion via a slider in the toolbar.
  * The mean proportion of each row is calculated by LAPIS over the whole data range that the component displays.
  * The initial mean proportion can be set via `initialMeanProportionInterval`.
+ *
+ * @fires {CustomEvent<undefined>} gs-component-finished-loading
+ * Fired when the component has finished loading the required data from LAPIS.
  */
 @customElement('gs-mutations-over-time')
 export class MutationsOverTimeComponent extends PreactLitAdapterWithGridJsStyles {

--- a/components/src/web-components/visualization/gs-mutations.tsx
+++ b/components/src/web-components/visualization/gs-mutations.tsx
@@ -60,6 +60,8 @@ import { type MutationAnnotations, mutationAnnotationsContext } from '../mutatio
  *
  * The insertions view shows the count of all insertions for the dataset.
  *
+ * @fires {CustomEvent<undefined>} gs-component-finished-loading
+ * Fired when the component has finished loading the required data from LAPIS.
  */
 @customElement('gs-mutations')
 export class MutationsComponent extends PreactLitAdapterWithGridJsStyles {

--- a/components/src/web-components/visualization/gs-number-sequences-over-time.tsx
+++ b/components/src/web-components/visualization/gs-number-sequences-over-time.tsx
@@ -19,6 +19,9 @@ import { PreactLitAdapterWithGridJsStyles } from '../PreactLitAdapterWithGridJsS
  * Thus, the `lapisFilter` implicitly also defines the range that is shown on the x-axis.
  * If you want to restrict the x-axis to a smaller date range,
  * then you need to set appropriate filter values in the `lapisFilter`.
+ *
+ * @fires {CustomEvent<undefined>} gs-component-finished-loading
+ * Fired when the component has finished loading the required data from LAPIS.
  */
 @customElement('gs-number-sequences-over-time')
 export class NumberSequencesOverTimeComponent extends PreactLitAdapterWithGridJsStyles {

--- a/components/src/web-components/visualization/gs-prevalence-over-time.tsx
+++ b/components/src/web-components/visualization/gs-prevalence-over-time.tsx
@@ -41,6 +41,9 @@ import { PreactLitAdapterWithGridJsStyles } from '../PreactLitAdapterWithGridJsS
  * ### Table View
  *
  * Displays the prevalence over time as a table with one row per time point.
+ *
+ * @fires {CustomEvent<undefined>} gs-component-finished-loading
+ * Fired when the component has finished loading the required data from LAPIS.
  */
 @customElement('gs-prevalence-over-time')
 export class PrevalenceOverTimeComponent extends PreactLitAdapterWithGridJsStyles {

--- a/components/src/web-components/visualization/gs-relative-growth-advantage.tsx
+++ b/components/src/web-components/visualization/gs-relative-growth-advantage.tsx
@@ -33,6 +33,9 @@ import { PreactLitAdapter } from '../PreactLitAdapter';
  * The dots in the plot show the proportions of the focal variant (defined by the `numeratorFilter`) to the baseline variant (defined by the `denominatorFilter`)
  * for every day as observed in the data.
  * The line shows a logistic curve fitted to the data points, including a 95% confidence interval.
+ *
+ * @fires {CustomEvent<undefined>} gs-component-finished-loading
+ * Fired when the component has finished loading the required data from LAPIS.
  */
 @customElement('gs-relative-growth-advantage')
 export class RelativeGrowthAdvantageComponent extends PreactLitAdapter {

--- a/components/src/web-components/visualization/gs-sequences-by-location.tsx
+++ b/components/src/web-components/visualization/gs-sequences-by-location.tsx
@@ -94,6 +94,9 @@ const leafletModificationsCss = unsafeCSS(leafletStyleModifications);
  * - `lapisLocationField`,
  * - `count` (the number of samples in this location matching the `lapisFilter`),
  * - `proportion` (`count` / sum of the `count` of all locations).
+ *
+ * @fires {CustomEvent<undefined>} gs-component-finished-loading
+ * Fired when the component has finished loading the required data from LAPIS.
  */
 @customElement('gs-sequences-by-location')
 export class SequencesByLocationComponent extends PreactLitAdapterWithGridJsStyles {

--- a/components/src/web-components/visualization/gs-statistics.tsx
+++ b/components/src/web-components/visualization/gs-statistics.tsx
@@ -10,6 +10,9 @@ import { PreactLitAdapterWithGridJsStyles } from '../PreactLitAdapterWithGridJsS
  *
  * This component displays general statistics (number of sequences, overall proportion)
  * for a given numerator and denominator filter.
+ *
+ * @fires {CustomEvent<undefined>} gs-component-finished-loading
+ * Fired when the component has finished loading the required data from LAPIS.
  */
 @customElement('gs-statistics')
 export class StatisticsComponent extends PreactLitAdapterWithGridJsStyles {

--- a/components/src/web-components/wastewaterVisualization/gs-wastewater-mutations-over-time.tsx
+++ b/components/src/web-components/wastewaterVisualization/gs-wastewater-mutations-over-time.tsx
@@ -24,6 +24,9 @@ import { type MutationAnnotations, mutationAnnotationsContext } from '../mutatio
  * This component also assumes that the LAPIS instance has the field `date` which can be used for the time axis.
  *
  * @slot infoText - Additional information text to be shown in the info modal (the "?" button).
+ *
+ * @fires {CustomEvent<undefined>} gs-component-finished-loading
+ * Fired when the component has finished loading the required data from LAPIS.
  */
 @customElement('gs-wastewater-mutations-over-time')
 export class WastewaterMutationsOverTimeComponent extends PreactLitAdapterWithGridJsStyles {


### PR DESCRIPTION


<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #860

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

This uses a simple `useEffect` when the data has been loaded and the tabs are rendered for the first time. I'm not sure whether that's good enough, but we can still change the details when exactly an event is fire later. The current implementation has the advantage that it is quite simple. I'd rather first try it out on the dashboards.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
