### PR TITLE
fix(components): recompute dateRangeOptionPresets every day

### DIFF
--- a/components/src/preact/dateRangeFilter/date-range-filter.stories.tsx
+++ b/components/src/preact/dateRangeFilter/date-range-filter.stories.tsx
@@ -55,7 +55,7 @@ const meta: Meta<DateRangeFilterProps> = {
         },
     },
     args: {
-        dateRangeOptions: [dateRangeOptionPresets.lastMonth, dateRangeOptionPresets.allTimes, customDateRange],
+        dateRangeOptions: [dateRangeOptionPresets().lastMonth, dateRangeOptionPresets().allTimes, customDateRange],
         earliestDate,
         value: null,
         lapisDateField: 'aDateColumn',
@@ -150,7 +150,7 @@ export const SetsValueOnBlur: StoryObj<DateRangeFilterProps> = {
     ...Primary,
     args: {
         ...Primary.args,
-        value: dateRangeOptionPresets.lastMonth.label,
+        value: dateRangeOptionPresets().lastMonth.label,
     },
     play: async ({ canvasElement, step }) => {
         const { canvas, filterChangedListenerMock, optionChangedListenerMock } = await prepare(canvasElement, step);
@@ -211,7 +211,7 @@ export const ChangingTheValueProgrammatically: StoryObj<DateRangeFilterProps> = 
                     <button className='btn' onClick={() => setValue(customDateRange.label)}>
                         Set to Custom
                     </button>
-                    <button className='btn' onClick={() => setValue(dateRangeOptionPresets.lastMonth.label)}>
+                    <button className='btn' onClick={() => setValue(dateRangeOptionPresets().lastMonth.label)}>
                         Set to Last month
                     </button>
                 </div>

--- a/components/src/preact/dateRangeFilter/dateRangeOption.ts
+++ b/components/src/preact/dateRangeFilter/dateRangeOption.ts
@@ -45,55 +45,81 @@ export class DateRangeOptionChangedEvent extends CustomEvent<DateRangeValue> {
     }
 }
 
-const today = new Date();
+type DateRangeOptionPresets = {
+    last2Weeks: DateRangeOption;
+    lastMonth: DateRangeOption;
+    last2Months: DateRangeOption;
+    last3Months: DateRangeOption;
+    last6Months: DateRangeOption;
+    lastYear: DateRangeOption;
+    allTimes: DateRangeOption;
+};
 
-const twoWeeksAgo = new Date();
-twoWeeksAgo.setDate(today.getDate() - 14);
-
-const lastMonth = new Date(today);
-lastMonth.setMonth(today.getMonth() - 1);
-
-const last2Months = new Date(today);
-last2Months.setMonth(today.getMonth() - 2);
-
-const last3Months = new Date(today);
-last3Months.setMonth(today.getMonth() - 3);
-
-const last6Months = new Date(today);
-last6Months.setMonth(today.getMonth() - 6);
-
-const lastYear = new Date(today);
-lastYear.setFullYear(today.getFullYear() - 1);
+let dateRangeOptionsPresetsCacheDate: string | null = null;
+let dateRangeOptionPresetsCache: DateRangeOptionPresets | null = null;
 
 /**
  * Presets for the `gs-date-range-filter` component that can be used as `dateRangeOptions`.
  */
-export const dateRangeOptionPresets = {
-    last2Weeks: {
-        label: 'Last 2 weeks',
-        dateFrom: toYYYYMMDD(twoWeeksAgo),
-    },
-    lastMonth: {
-        label: 'Last month',
-        dateFrom: toYYYYMMDD(lastMonth),
-    },
-    last2Months: {
-        label: 'Last 2 months',
-        dateFrom: toYYYYMMDD(last2Months),
-    },
-    last3Months: {
-        label: 'Last 3 months',
-        dateFrom: toYYYYMMDD(last3Months),
-    },
-    last6Months: {
-        label: 'Last 6 months',
-        dateFrom: toYYYYMMDD(last6Months),
-    },
-    lastYear: {
-        label: 'Last year',
-        dateFrom: toYYYYMMDD(lastYear),
-    },
-    allTimes: {
-        label: 'All times',
-    },
-} satisfies Record<string, DateRangeOption>;
+export const dateRangeOptionPresets = (): DateRangeOptionPresets => {
+    const today = new Date();
+    const todayString = new Date().toISOString().slice(0, 10);
+
+    if (
+        dateRangeOptionPresetsCache === null ||
+        dateRangeOptionsPresetsCacheDate === null ||
+        dateRangeOptionsPresetsCacheDate !== todayString
+    ) {
+        dateRangeOptionsPresetsCacheDate = todayString;
+
+        const twoWeeksAgo = new Date();
+        twoWeeksAgo.setDate(today.getDate() - 14);
+
+        const lastMonth = new Date(today);
+        lastMonth.setMonth(today.getMonth() - 1);
+
+        const last2Months = new Date(today);
+        last2Months.setMonth(today.getMonth() - 2);
+
+        const last3Months = new Date(today);
+        last3Months.setMonth(today.getMonth() - 3);
+
+        const last6Months = new Date(today);
+        last6Months.setMonth(today.getMonth() - 6);
+
+        const lastYear = new Date(today);
+        lastYear.setFullYear(today.getFullYear() - 1);
+
+        dateRangeOptionPresetsCache = {
+            last2Weeks: {
+                label: 'Last 2 weeks',
+                dateFrom: toYYYYMMDD(twoWeeksAgo),
+            },
+            lastMonth: {
+                label: 'Last month',
+                dateFrom: toYYYYMMDD(lastMonth),
+            },
+            last2Months: {
+                label: 'Last 2 months',
+                dateFrom: toYYYYMMDD(last2Months),
+            },
+            last3Months: {
+                label: 'Last 3 months',
+                dateFrom: toYYYYMMDD(last3Months),
+            },
+            last6Months: {
+                label: 'Last 6 months',
+                dateFrom: toYYYYMMDD(last6Months),
+            },
+            lastYear: {
+                label: 'Last year',
+                dateFrom: toYYYYMMDD(lastYear),
+            },
+            allTimes: {
+                label: 'All times',
+            },
+        };
+    }
+
+    return dateRangeOptionPresetsCache;
+};

--- a/components/src/web-components/input/gs-date-range-filter.stories.ts
+++ b/components/src/web-components/input/gs-date-range-filter.stories.ts
@@ -59,14 +59,14 @@ const meta: Meta<Required<DateRangeFilterProps>> = {
     },
     args: {
         dateRangeOptions: [
-            dateRangeOptionPresets.lastMonth,
-            dateRangeOptionPresets.last3Months,
-            dateRangeOptionPresets.allTimes,
+            dateRangeOptionPresets().lastMonth,
+            dateRangeOptionPresets().last3Months,
+            dateRangeOptionPresets().allTimes,
             { label: '2021', dateFrom: '2021-01-01', dateTo: '2021-12-31' },
             customDateRange,
         ],
         earliestDate: '1970-01-01',
-        value: dateRangeOptionPresets.lastMonth.label,
+        value: dateRangeOptionPresets().lastMonth.label,
         lapisDateField: 'aDateColumn',
         width: '100%',
         placeholder: 'Date range',


### PR DESCRIPTION
BREAKING CHANGE: dateRangeOptionPresets is now a function instead of a constant

### Summary

This solves the underlying issue of #721 by recomputing the dateRangeOptionPresets every day.

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
