### PR TITLE
fix(components): gs-statistics: don't display `NaN` when counts are 0

### DIFF
--- a/components/src/preact/statistic/statistics.stories.tsx
+++ b/components/src/preact/statistic/statistics.stories.tsx
@@ -80,6 +80,73 @@ export const Default: StoryObj<StatisticsProps> = {
     },
 };
 
+export const ValuesAre0: StoryObj<StatisticsProps> = {
+    ...Default,
+    parameters: {
+        fetchMock: {
+            mocks: [
+                {
+                    matcher: {
+                        name: 'denominatorData',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            fields: [],
+                            country: 'USA',
+                            division: 'Alabama',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: {
+                            data: [
+                                {
+                                    count: 0,
+                                },
+                            ],
+                            info: {
+                                dataVersion: '1712315293',
+                                requestId: '4603a85e-ae5e-495d-aee5-778a3af862c1',
+                            },
+                        },
+                    },
+                },
+                {
+                    matcher: {
+                        name: 'numeratorData',
+                        url: AGGREGATED_ENDPOINT,
+                        body: {
+                            fields: [],
+                            country: 'USA',
+                        },
+                    },
+                    response: {
+                        status: 200,
+                        body: {
+                            data: [
+                                {
+                                    count: 0,
+                                },
+                            ],
+                            info: {
+                                dataVersion: '1712315293',
+                                requestId: '4603a85e-ae5e-495d-aee5-778a3af862c1',
+                            },
+                        },
+                    },
+                },
+            ],
+        },
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        await waitFor(async () => {
+            await expect(canvas.getByText('0')).toBeInTheDocument();
+            await expect(canvas.getByText('-.--%')).toBeInTheDocument();
+        });
+    },
+};
+
 export const FiresFinishedLoadingEvent: StoryObj<StatisticsProps> = {
     ...Default,
     play: playThatExpectsFinishedLoadingEvent(),

--- a/components/src/preact/statistic/statistics.tsx
+++ b/components/src/preact/statistic/statistics.tsx
@@ -74,7 +74,9 @@ const MetricDataTabs: FunctionComponent<MetricDataTabsProps> = ({ data }) => {
 
             <div className='stat'>
                 <div className='stat-title'>Overall proportion</div>
-                <div className='stat-value text-2xl sm:text-4xl'>{formatProportion(proportion)}</div>
+                <div className='stat-value text-2xl sm:text-4xl'>
+                    {isFinite(proportion) ? formatProportion(proportion) : '-.--%'}
+                </div>
                 <div className='stat-desc text-wrap'>The proportion among all sequenced samples</div>
             </div>
         </div>


### PR DESCRIPTION


### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->
Before:
![image](https://github.com/user-attachments/assets/ecc5c32c-016d-43ab-829c-ad161c1935d4)
After:
![image](https://github.com/user-attachments/assets/af3fb9a8-86e9-4ee1-a7cd-0bbc85aefe8d)


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
