### PR TITLE
fix(components): accept lineage definitions without "aliases" key

### DIFF
--- a/components/src/lapisApi/LineageDefinition.ts
+++ b/components/src/lapisApi/LineageDefinition.ts
@@ -2,7 +2,7 @@ import z from 'zod';
 
 const lineage = z.object({
     parents: z.array(z.string()).optional(),
-    aliases: z.array(z.string()),
+    aliases: z.array(z.string()).optional(),
 });
 
 export const lineageDefinitionResponseSchema = z.record(lineage);

--- a/components/src/preact/lineageFilter/fetchLineageAutocompleteList.spec.ts
+++ b/components/src/preact/lineageFilter/fetchLineageAutocompleteList.spec.ts
@@ -47,6 +47,44 @@ describe('fetchLineageAutocompleteList', () => {
         ]);
     });
 
+    test('should work without aliases', async () => {
+        lapisRequestMocks.aggregated(
+            { fields: [lineageField], ...lapisFilter },
+            {
+                data: [
+                    {
+                        [lineageField]: 'A',
+                        count: 1,
+                    },
+                ],
+            },
+        );
+
+        lapisRequestMocks.lineageDefinition(
+            {
+                A: {},
+            },
+            lineageField,
+        );
+
+        const result = await fetchLineageAutocompleteList({
+            lapisUrl: DUMMY_LAPIS_URL,
+            lapisField: lineageField,
+            lapisFilter,
+        });
+
+        expect(result).to.deep.equal([
+            {
+                lineage: 'A',
+                count: 1,
+            },
+            {
+                lineage: 'A*',
+                count: 1,
+            },
+        ]);
+    });
+
     test('should add sublineage values', async () => {
         lapisRequestMocks.aggregated(
             { fields: [lineageField], ...lapisFilter },


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #920

This PR make the components to accept lineage definition files from LAPIS where `aliases` are not defined.

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~[ ] All necessary documentation has been adapted.~
- [x] The implemented feature is covered by an appropriate test.
