### PR TITLE
docs(components): show introduction as initial page in storybook

### DIFF
--- a/components/src/web-components/_introduction.mdx
+++ b/components/src/web-components/_introduction.mdx
@@ -1,3 +1,5 @@
+[//]: # "This file is prefixed with _ so that it is found first and used as Storybook's landing page"
+
 import { Meta } from '@storybook/blocks';
 
 <Meta title='Introduction' />


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #935

### Summary

I couldn't find a config/option to set the landing page for storybook (`--initial-page` only changes what the dev server opens initially and doesn't solve our problem) but could solve it by prefixing the file of the introduction page with a `_` so that it comes first.


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
