### PR TITLE
feat(components): use new mutationsOverTime LAPIS endpoint in the mutations-over-time component

### DIFF
--- a/components/src/lapisApi/lapisApi.ts
+++ b/components/src/lapisApi/lapisApi.ts
@@ -9,6 +9,8 @@ import {
     mutationsResponse,
     problemDetail,
     type ProblemDetail,
+    type MutationsOverTimeRequest,
+    mutationsOverTimeResponse,
 } from './lapisTypes';
 import { type SequenceType } from '../types';
 import { lineageDefinitionResponseSchema } from './LineageDefinition';
@@ -110,6 +112,28 @@ export async function fetchSubstitutionsOrDeletions(
     );
 
     return mutationsResponse.parse(await response.json());
+}
+
+export async function fetchMutationsOverTime(
+    lapisUrl: string,
+    body: MutationsOverTimeRequest,
+    sequenceType: SequenceType,
+    signal?: AbortSignal,
+) {
+    const response = await callLapis(
+        mutationsOverTimeEndpoint(lapisUrl, sequenceType),
+        {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(body),
+            signal,
+        },
+        `${sequenceType} mutations over time`,
+    );
+
+    return mutationsOverTimeResponse.parse(await response.json());
 }
 
 export async function fetchReferenceGenome(lapisUrl: string, signal?: AbortSignal) {
@@ -214,6 +238,11 @@ export const substitutionsOrDeletionsEndpoint = (lapisUrl: string, sequenceType:
     return sequenceType === 'amino acid'
         ? `${lapisUrl}/sample/aminoAcidMutations`
         : `${lapisUrl}/sample/nucleotideMutations`;
+};
+export const mutationsOverTimeEndpoint = (lapisUrl: string, sequenceType: SequenceType) => {
+    return sequenceType === 'amino acid'
+        ? `${lapisUrl}/component/aminoAcidMutationsOverTime`
+        : `${lapisUrl}/component/nucleotideMutationsOverTime`;
 };
 export const referenceGenomeEndpoint = (lapisUrl: string) => `${lapisUrl}/sample/referenceGenome`;
 export const lineageDefinitionEndpoint = (lapisUrl: string, lapisField: string) =>

--- a/components/src/lapisApi/lapisTypes.ts
+++ b/components/src/lapisApi/lapisTypes.ts
@@ -7,6 +7,13 @@ export const orderBy = z.object({
     type: orderByType,
 });
 
+const filterValue = z.union([z.string(), z.number(), z.boolean(), z.null(), z.undefined(), z.array(z.string())]);
+
+const dateRange = z.object({
+    dateFrom: z.string(),
+    dateTo: z.string(),
+});
+
 export const lapisBaseRequest = z
     .object({
         limit: z.number().optional(),
@@ -14,7 +21,7 @@ export const lapisBaseRequest = z
         fields: z.array(z.string()).optional(),
         orderBy: z.array(orderBy).optional(),
     })
-    .catchall(z.union([z.boolean(), z.undefined(), z.string(), z.number(), z.null(), z.array(z.string())]));
+    .catchall(filterValue);
 export type LapisBaseRequest = z.infer<typeof lapisBaseRequest>;
 
 export const mutationsRequest = lapisBaseRequest.extend({ minProportion: z.number().optional() });
@@ -31,6 +38,33 @@ const mutationProportionCount = z.object({
 });
 export const mutationsResponse = makeLapisResponse(z.array(mutationProportionCount));
 export type MutationsResponse = z.infer<typeof mutationsResponse>;
+
+export const mutationsOverTimeRequest = z.object({
+    filters: z.record(filterValue),
+    downloadAsFile: z.boolean().optional(),
+    downloadFileBasename: z.string().optional(),
+    compression: z.enum(['gzip', 'none']).optional(),
+    includeMutations: z.array(z.string()).optional(),
+    dateRanges: z.array(dateRange).optional(),
+    dateField: z.string().optional(),
+});
+export type MutationsOverTimeRequest = z.infer<typeof mutationsOverTimeRequest>;
+
+export const mutationsOverTimeResponse = makeLapisResponse(
+    z.object({
+        mutations: z.array(z.string()),
+        dateRanges: z.array(dateRange),
+        data: z.array(
+            z.array(
+                z.object({
+                    count: z.number(),
+                    coverage: z.number(),
+                }),
+            ),
+        ),
+    }),
+);
+export type MutationsOverTimeResponse = z.infer<typeof mutationsOverTimeResponse>;
 
 const insertionCount = z.object({
     insertion: z.string(),

--- a/components/src/preact/mutationsOverTime/__mockData__/aminoAcidMutationsByDay.ts
+++ b/components/src/preact/mutationsOverTime/__mockData__/aminoAcidMutationsByDay.ts
@@ -11,6 +11,7 @@ export const aminoAcidMutationsByDay: MutationOverTimeMockData = {
         granularity: 'day',
         lapisDateField: 'date',
         lapis: 'https://lapis.cov-spectrum.org/open/v2',
+        useNewEndpoint: false,
     },
     response: {
         overallMutationData: [

--- a/components/src/preact/mutationsOverTime/__mockData__/byWeek.ts
+++ b/components/src/preact/mutationsOverTime/__mockData__/byWeek.ts
@@ -11,6 +11,7 @@ export const byWeek: MutationOverTimeMockData = {
         granularity: 'week',
         lapisDateField: 'date',
         lapis: 'https://lapis.cov-spectrum.org/open/v2',
+        useNewEndpoint: false,
     },
     response: {
         overallMutationData: [

--- a/components/src/preact/mutationsOverTime/__mockData__/defaultMockData.ts
+++ b/components/src/preact/mutationsOverTime/__mockData__/defaultMockData.ts
@@ -11,6 +11,7 @@ export const defaultMockData: MutationOverTimeMockData = {
         granularity: 'month',
         lapisDateField: 'date',
         lapis: 'https://lapis.cov-spectrum.org/open/v2',
+        useNewEndpoint: false,
     },
     response: {
         overallMutationData: [

--- a/components/src/preact/mutationsOverTime/__mockData__/noDataWhenNoMutationsAreInFilter.ts
+++ b/components/src/preact/mutationsOverTime/__mockData__/noDataWhenNoMutationsAreInFilter.ts
@@ -10,6 +10,7 @@ export const noDataWhenNoMutationsAreInFilter: MutationOverTimeMockData = {
         granularity: 'year',
         lapisDateField: 'date',
         lapis: 'https://lapis.cov-spectrum.org/open/v2',
+        useNewEndpoint: false,
     },
     response: {
         overallMutationData: [],

--- a/components/src/preact/mutationsOverTime/__mockData__/noDataWhenThereAreNoDatesInFilter.ts
+++ b/components/src/preact/mutationsOverTime/__mockData__/noDataWhenThereAreNoDatesInFilter.ts
@@ -10,6 +10,7 @@ export const noDataWhenNoMutationsAreInFilter: MutationOverTimeMockData = {
         granularity: 'year',
         lapisDateField: 'date',
         lapis: 'https://lapis.cov-spectrum.org/open/v2',
+        useNewEndpoint: false,
     },
     response: {
         overallMutationData: [],

--- a/components/src/preact/mutationsOverTime/__mockData__/showsMessageWhenTooManyMutations.ts
+++ b/components/src/preact/mutationsOverTime/__mockData__/showsMessageWhenTooManyMutations.ts
@@ -10,6 +10,7 @@ export const showsMessageWhenTooManyMutations: MutationOverTimeMockData = {
         granularity: 'year',
         lapisDateField: 'date',
         lapis: 'https://lapis.cov-spectrum.org/open/v2',
+        useNewEndpoint: false,
     },
     response: {
         overallMutationData: [

--- a/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
@@ -36,6 +36,7 @@ const meta: Meta<MutationsOverTimeProps> = {
         displayMutations: { control: 'object' },
         initialMeanProportionInterval: { control: 'object' },
         pageSizes: { control: 'object' },
+        useNewEndpoint: { control: 'boolean' },
     },
     parameters: {
         fetchMock: {},
@@ -80,6 +81,7 @@ export const Default: StoryObj<MutationsOverTimeProps> = {
         granularity: 'month',
         lapisDateField: 'date',
         initialMeanProportionInterval: { min: 0.05, max: 0.9 },
+        useNewEndpoint: false,
         pageSizes: [10, 20, 30, 40, 50],
     },
 };

--- a/components/src/preact/mutationsOverTime/mutations-over-time.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.tsx
@@ -12,6 +12,7 @@ import {
 } from './getFilteredMutationsOverTimeData';
 import { type MutationOverTimeWorkerResponse } from './mutationOverTimeWorker';
 import MutationsOverTimeGrid from './mutations-over-time-grid';
+import { type MutationOverTimeQuery } from '../../query/queryMutationsOverTime';
 import {
     lapisFilterSchema,
     sequenceTypeSchema,
@@ -52,6 +53,7 @@ const mutationOverTimeSchema = z.object({
     views: z.array(mutationsOverTimeViewSchema),
     granularity: temporalGranularitySchema,
     lapisDateField: z.string().min(1),
+    useNewEndpoint: z.boolean().optional(),
     displayMutations: displayMutationsSchema.optional(),
     initialMeanProportionInterval: z.object({
         min: z.number().min(0).max(1),
@@ -76,19 +78,23 @@ export const MutationsOverTime: FunctionComponent<MutationsOverTimeProps> = (com
     );
 };
 
-export const MutationsOverTimeInner: FunctionComponent<MutationsOverTimeProps> = (componentProps) => {
+export const MutationsOverTimeInner: FunctionComponent<MutationsOverTimeProps> = ({
+    useNewEndpoint = false,
+    ...componentProps
+}) => {
     const lapis = useLapisUrl();
     const { lapisFilter, sequenceType, granularity, lapisDateField } = componentProps;
 
-    const messageToWorker = useMemo(() => {
+    const messageToWorker: MutationOverTimeQuery = useMemo(() => {
         return {
             lapisFilter,
             sequenceType,
             granularity,
             lapisDateField,
             lapis,
+            useNewEndpoint,
         };
-    }, [granularity, lapis, lapisDateField, lapisFilter, sequenceType]);
+    }, [granularity, lapis, lapisDateField, lapisFilter, sequenceType, useNewEndpoint]);
 
     const { data, error, isLoading } = useWebWorker<MutationOverTimeWorkerResponse>(
         messageToWorker,

--- a/components/src/query/queryMutationsOverTimeNewEndpoint.spec.ts
+++ b/components/src/query/queryMutationsOverTimeNewEndpoint.spec.ts
@@ -1,0 +1,935 @@
+import { describe, expect, it } from 'vitest';
+
+import { queryMutationsOverTimeData } from './queryMutationsOverTime';
+import { DUMMY_LAPIS_URL, lapisRequestMocks } from '../../vitest.setup';
+
+describe('queryMutationsOverTimeNewEndpoint', () => {
+    it('should fetch for a filter without date and sort by mutation and date', async () => {
+        const lapisFilter = { field1: 'value1', field2: 'value2' };
+        const dateField = 'dateField';
+
+        lapisRequestMocks.multipleAggregated([
+            // this request is expected to get 'all dates in dataset' - since the user hasn't provided a date range
+            {
+                body: { ...lapisFilter, fields: [dateField] },
+                response: {
+                    data: [
+                        { count: 1, [dateField]: '2023-01-01' },
+                        { count: 2, [dateField]: '2023-01-03' },
+                    ],
+                },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-01',
+                    dateFieldTo: '2023-01-01',
+                    fields: [],
+                },
+                response: { data: [{ count: 11 }] },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-02',
+                    dateFieldTo: '2023-01-02',
+                    fields: [],
+                },
+                response: { data: [{ count: 12 }] },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-03',
+                    dateFieldTo: '2023-01-03',
+                    fields: [],
+                },
+                response: { data: [{ count: 13 }] },
+            },
+        ]);
+        lapisRequestMocks.multipleMutations(
+            [
+                {
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-01',
+                        dateFieldTo: '2023-01-03',
+                        minProportion: 0.001,
+                    },
+                    response: {
+                        data: [getSomeTestMutation(0.21, 6), getSomeOtherTestMutation(0.22, 4)],
+                    },
+                },
+            ],
+            'nucleotide',
+        );
+        const dateRanges = [
+            {
+                dateFrom: '2023-01-01',
+                dateTo: '2023-01-01',
+            },
+            {
+                dateFrom: '2023-01-02',
+                dateTo: '2023-01-02',
+            },
+            {
+                dateFrom: '2023-01-03',
+                dateTo: '2023-01-03',
+            },
+        ];
+        lapisRequestMocks.mutationsOverTime(
+            [
+                {
+                    body: {
+                        filters: lapisFilter,
+                        dateRanges,
+                        includeMutations: ['otherSequenceName:G234C', 'sequenceName:A123T'],
+                        dateField,
+                    },
+                    response: {
+                        data: {
+                            data: [
+                                [
+                                    { count: 4, coverage: 10 },
+                                    { count: 0, coverage: 10 },
+                                    { count: 0, coverage: 10 },
+                                ],
+                                [
+                                    { count: 1, coverage: 10 },
+                                    { count: 2, coverage: 10 },
+                                    { count: 3, coverage: 10 },
+                                ],
+                            ],
+                            dateRanges,
+                            mutations: ['otherSequenceName:G234C', 'sequenceName:A123T'],
+                        },
+                    },
+                },
+            ],
+            'nucleotide',
+        );
+
+        const { mutationOverTimeData, overallMutationData } = await queryMutationsOverTimeData({
+            lapisFilter,
+            sequenceType: 'nucleotide',
+            lapis: DUMMY_LAPIS_URL,
+            lapisDateField: dateField,
+            granularity: 'day',
+            useNewEndpoint: true,
+        });
+
+        const expectedData = [
+            [
+                { type: 'value', proportion: 0.4, count: 4, totalCount: 11 },
+                { type: 'value', proportion: 0, count: 0, totalCount: 12 },
+                { type: 'value', proportion: 0, count: 0, totalCount: 13 },
+            ],
+            [
+                { type: 'value', proportion: 0.1, count: 1, totalCount: 11 },
+                { type: 'value', proportion: 0.2, count: 2, totalCount: 12 },
+                { type: 'value', proportion: 0.3, count: 3, totalCount: 13 },
+            ],
+        ];
+        expect(mutationOverTimeData.getAsArray()).to.deep.equal(expectedData);
+
+        const sequences = mutationOverTimeData.getFirstAxisKeys();
+        expect(sequences[0].code).toBe('otherSequenceName:G234C');
+        expect(sequences[1].code).toBe('sequenceName:A123T');
+
+        const dates = mutationOverTimeData.getSecondAxisKeys();
+        expect(dates[0].dateString).toBe('2023-01-01');
+        expect(dates[1].dateString).toBe('2023-01-02');
+        expect(dates[2].dateString).toBe('2023-01-03');
+
+        expect(overallMutationData).to.deep.equal([
+            {
+                type: 'substitution',
+                mutation: {
+                    valueAtReference: 'G',
+                    substitutionValue: 'C',
+                    position: 234,
+                    segment: 'otherSequenceName',
+                    code: 'otherSequenceName:G234C',
+                    type: 'substitution',
+                },
+                count: 4,
+                proportion: 0.22,
+            },
+            {
+                type: 'substitution',
+                mutation: {
+                    valueAtReference: 'A',
+                    substitutionValue: 'T',
+                    position: 123,
+                    segment: 'sequenceName',
+                    code: 'sequenceName:A123T',
+                    type: 'substitution',
+                },
+                count: 6,
+                proportion: 0.21,
+            },
+        ]);
+    });
+
+    it('should fetch for dates with no mutations', async () => {
+        const lapisFilter = { field1: 'value1', field2: 'value2' };
+        const dateField = 'dateField';
+
+        lapisRequestMocks.multipleAggregated([
+            {
+                body: { ...lapisFilter, fields: [dateField] },
+                response: {
+                    data: [
+                        { count: 1, [dateField]: '2023-01-01' },
+                        { count: 2, [dateField]: '2023-01-03' },
+                    ],
+                },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-01',
+                    dateFieldTo: '2023-01-01',
+                    fields: [],
+                },
+                response: { data: [{ count: 11 }] },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-02',
+                    dateFieldTo: '2023-01-02',
+                    fields: [],
+                },
+                response: { data: [{ count: 0 }] },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-03',
+                    dateFieldTo: '2023-01-03',
+                    fields: [],
+                },
+                response: { data: [{ count: 13 }] },
+            },
+        ]);
+
+        lapisRequestMocks.multipleMutations(
+            [
+                {
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-01',
+                        dateFieldTo: '2023-01-03',
+                        minProportion: 0.001,
+                    },
+                    response: {
+                        data: [getSomeTestMutation(0.2, 4), getSomeOtherTestMutation(0.4, 4)],
+                    },
+                },
+            ],
+            'nucleotide',
+        );
+
+        const dateRanges = [
+            {
+                dateFrom: '2023-01-01',
+                dateTo: '2023-01-01',
+            },
+            {
+                dateFrom: '2023-01-02',
+                dateTo: '2023-01-02',
+            },
+            {
+                dateFrom: '2023-01-03',
+                dateTo: '2023-01-03',
+            },
+        ];
+
+        lapisRequestMocks.mutationsOverTime(
+            [
+                {
+                    body: {
+                        filters: lapisFilter,
+                        dateRanges,
+                        includeMutations: ['otherSequenceName:G234C', 'sequenceName:A123T'],
+                        dateField,
+                    },
+                    response: {
+                        data: {
+                            data: [
+                                [
+                                    { count: 4, coverage: 10 },
+                                    { count: 0, coverage: 10 },
+                                    { count: 0, coverage: 10 },
+                                ],
+                                [
+                                    { count: 1, coverage: 10 },
+                                    { count: 0, coverage: 10 },
+                                    { count: 3, coverage: 10 },
+                                ],
+                            ],
+                            dateRanges,
+                            mutations: ['otherSequenceName:G234C', 'sequenceName:A123T'],
+                        },
+                    },
+                },
+            ],
+            'nucleotide',
+        );
+
+        const { mutationOverTimeData } = await queryMutationsOverTimeData({
+            lapisFilter,
+            sequenceType: 'nucleotide',
+            lapis: DUMMY_LAPIS_URL,
+            lapisDateField: dateField,
+            granularity: 'day',
+            useNewEndpoint: true,
+        });
+
+        expect(mutationOverTimeData.getAsArray()).to.deep.equal([
+            [
+                { type: 'value', proportion: 0.4, count: 4, totalCount: 11 },
+                { type: 'value', proportion: 0, count: 0, totalCount: 0 },
+                { type: 'value', proportion: 0, count: 0, totalCount: 13 },
+            ],
+            [
+                { type: 'value', proportion: 0.1, count: 1, totalCount: 11 },
+                { type: 'value', proportion: 0, count: 0, totalCount: 0 },
+                { type: 'value', proportion: 0.3, count: 3, totalCount: 13 },
+            ],
+        ]);
+
+        const sequences = mutationOverTimeData.getFirstAxisKeys();
+        expect(sequences[0].code).toBe('otherSequenceName:G234C');
+        expect(sequences[1].code).toBe('sequenceName:A123T');
+
+        const dates = mutationOverTimeData.getSecondAxisKeys();
+        expect(dates[0].dateString).toBe('2023-01-01');
+        expect(dates[1].dateString).toBe('2023-01-02');
+        expect(dates[2].dateString).toBe('2023-01-03');
+    });
+
+    it('should return empty map when no mutations are found', async () => {
+        const lapisFilter = { field1: 'value1', field2: 'value2' };
+        const dateField = 'dateField';
+
+        lapisRequestMocks.multipleAggregated([
+            {
+                body: { ...lapisFilter, fields: [dateField] },
+                response: {
+                    data: [
+                        { count: 1, [dateField]: '2023-01-01' },
+                        { count: 2, [dateField]: '2023-01-03' },
+                    ],
+                },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-01',
+                    dateFieldTo: '2023-01-01',
+                    fields: [],
+                },
+                response: { data: [{ count: 11 }] },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-02',
+                    dateFieldTo: '2023-01-02',
+                    fields: [],
+                },
+                response: { data: [{ count: 12 }] },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-03',
+                    dateFieldTo: '2023-01-03',
+                    fields: [],
+                },
+                response: { data: [{ count: 13 }] },
+            },
+        ]);
+
+        lapisRequestMocks.multipleMutations(
+            [
+                {
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-01',
+                        dateFieldTo: '2023-01-03',
+                        minProportion: 0.001,
+                    },
+                    response: {
+                        data: [],
+                    },
+                },
+            ],
+            'nucleotide',
+        );
+
+        const dateRanges = [
+            {
+                dateFrom: '2023-01-01',
+                dateTo: '2023-01-01',
+            },
+            {
+                dateFrom: '2023-01-02',
+                dateTo: '2023-01-02',
+            },
+            {
+                dateFrom: '2023-01-03',
+                dateTo: '2023-01-03',
+            },
+        ];
+
+        lapisRequestMocks.mutationsOverTime(
+            [
+                {
+                    body: {
+                        filters: lapisFilter,
+                        dateRanges,
+                        includeMutations: [],
+                        dateField,
+                    },
+                    response: {
+                        data: {
+                            data: [],
+                            dateRanges,
+                            mutations: [],
+                        },
+                    },
+                },
+            ],
+            'nucleotide',
+        );
+
+        const { mutationOverTimeData } = await queryMutationsOverTimeData({
+            lapisFilter,
+            sequenceType: 'nucleotide',
+            lapis: DUMMY_LAPIS_URL,
+            lapisDateField: dateField,
+            granularity: 'day',
+            useNewEndpoint: true,
+        });
+
+        expect(mutationOverTimeData.getAsArray()).to.deep.equal([]);
+        expect(mutationOverTimeData.getFirstAxisKeys()).to.deep.equal([]);
+        const dates = mutationOverTimeData.getSecondAxisKeys();
+        expect(dates.length).toBe(3);
+        expect(dates[0].dateString).toBe('2023-01-01');
+        expect(dates[1].dateString).toBe('2023-01-02');
+        expect(dates[2].dateString).toBe('2023-01-03');
+    });
+
+    it('should use dateFrom from filter', async () => {
+        const dateField = 'dateField';
+        const lapisFilter = { field1: 'value1', field2: 'value2', [`${dateField}From`]: '2023-01-02' };
+
+        lapisRequestMocks.multipleAggregated([
+            {
+                body: { ...lapisFilter, fields: [dateField] },
+                response: {
+                    data: [
+                        { count: 1, [dateField]: '2023-01-01' },
+                        { count: 2, [dateField]: '2023-01-03' },
+                    ],
+                },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-02',
+                    dateFieldTo: '2023-01-02',
+                    fields: [],
+                },
+                response: { data: [{ count: 11 }] },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-03',
+                    dateFieldTo: '2023-01-03',
+                    fields: [],
+                },
+                response: { data: [{ count: 12 }] },
+            },
+        ]);
+
+        lapisRequestMocks.multipleMutations(
+            [
+                {
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-02',
+                        dateFieldTo: '2023-01-03',
+                        minProportion: 0.001,
+                    },
+                    response: {
+                        data: [getSomeTestMutation(0.25, 5)],
+                    },
+                },
+            ],
+            'nucleotide',
+        );
+
+        const dateRanges = [
+            {
+                dateFrom: '2023-01-02',
+                dateTo: '2023-01-02',
+            },
+            {
+                dateFrom: '2023-01-03',
+                dateTo: '2023-01-03',
+            },
+        ];
+
+        lapisRequestMocks.mutationsOverTime(
+            [
+                {
+                    body: {
+                        filters: lapisFilter,
+                        dateRanges,
+                        includeMutations: ['sequenceName:A123T'],
+                        dateField,
+                    },
+                    response: {
+                        data: {
+                            data: [
+                                [
+                                    { count: 2, coverage: 10 },
+                                    { count: 3, coverage: 10 },
+                                ],
+                            ],
+                            dateRanges,
+                            mutations: ['sequenceName:A123T'],
+                        },
+                    },
+                },
+            ],
+            'nucleotide',
+        );
+
+        const { mutationOverTimeData } = await queryMutationsOverTimeData({
+            lapisFilter,
+            sequenceType: 'nucleotide',
+            lapis: DUMMY_LAPIS_URL,
+            lapisDateField: dateField,
+            granularity: 'day',
+            useNewEndpoint: true,
+        });
+
+        expect(mutationOverTimeData.getAsArray()).to.deep.equal([
+            [
+                { type: 'value', proportion: 0.2, count: 2, totalCount: 11 },
+                { type: 'value', proportion: 0.3, count: 3, totalCount: 12 },
+            ],
+        ]);
+
+        const sequences = mutationOverTimeData.getFirstAxisKeys();
+        expect(sequences[0].code).toBe('sequenceName:A123T');
+
+        const dates = mutationOverTimeData.getSecondAxisKeys();
+        expect(dates[0].dateString).toBe('2023-01-02');
+        expect(dates[1].dateString).toBe('2023-01-03');
+    });
+
+    it('should use dateTo from filter', async () => {
+        const dateField = 'dateField';
+        const lapisFilter = { field1: 'value1', field2: 'value2', [`${dateField}To`]: '2023-01-02' };
+
+        lapisRequestMocks.multipleAggregated([
+            {
+                body: { ...lapisFilter, fields: [dateField] },
+                response: {
+                    data: [
+                        { count: 1, [dateField]: '2023-01-01' },
+                        { count: 2, [dateField]: '2023-01-03' },
+                    ],
+                },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-01',
+                    dateFieldTo: '2023-01-01',
+                    fields: [],
+                },
+                response: { data: [{ count: 11 }] },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-02',
+                    dateFieldTo: '2023-01-02',
+                    fields: [],
+                },
+                response: { data: [{ count: 12 }] },
+            },
+        ]);
+
+        lapisRequestMocks.multipleMutations(
+            [
+                {
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-01',
+                        dateFieldTo: '2023-01-02',
+                        minProportion: 0.001,
+                    },
+                    response: {
+                        data: [getSomeTestMutation(0.15, 3)],
+                    },
+                },
+            ],
+            'nucleotide',
+        );
+
+        const dateRanges = [
+            {
+                dateFrom: '2023-01-01',
+                dateTo: '2023-01-01',
+            },
+            {
+                dateFrom: '2023-01-02',
+                dateTo: '2023-01-02',
+            },
+        ];
+
+        lapisRequestMocks.mutationsOverTime(
+            [
+                {
+                    body: {
+                        filters: lapisFilter,
+                        dateRanges,
+                        includeMutations: ['sequenceName:A123T'],
+                        dateField,
+                    },
+                    response: {
+                        data: {
+                            data: [
+                                [
+                                    { count: 1, coverage: 10 },
+                                    { count: 2, coverage: 10 },
+                                ],
+                            ],
+                            dateRanges,
+                            mutations: ['sequenceName:A123T'],
+                        },
+                    },
+                },
+            ],
+            'nucleotide',
+        );
+
+        const { mutationOverTimeData } = await queryMutationsOverTimeData({
+            lapisFilter,
+            sequenceType: 'nucleotide',
+            lapis: DUMMY_LAPIS_URL,
+            lapisDateField: dateField,
+            granularity: 'day',
+            useNewEndpoint: true,
+        });
+
+        expect(mutationOverTimeData.getAsArray()).to.deep.equal([
+            [
+                { type: 'value', proportion: 0.1, count: 1, totalCount: 11 },
+                { type: 'value', proportion: 0.2, count: 2, totalCount: 12 },
+            ],
+        ]);
+
+        const sequences = mutationOverTimeData.getFirstAxisKeys();
+        expect(sequences[0].code).toBe('sequenceName:A123T');
+
+        const dates = mutationOverTimeData.getSecondAxisKeys();
+        expect(dates[0].dateString).toBe('2023-01-01');
+        expect(dates[1].dateString).toBe('2023-01-02');
+    });
+
+    it('should use date from filter', async () => {
+        const dateField = 'dateField';
+        const lapisFilter = { field1: 'value1', field2: 'value2', [dateField]: '2023-01-02' };
+
+        lapisRequestMocks.multipleAggregated([
+            {
+                body: { ...lapisFilter, fields: [dateField] },
+                response: {
+                    data: [
+                        { count: 1, [dateField]: '2023-01-01' },
+                        { count: 2, [dateField]: '2023-01-03' },
+                    ],
+                },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-02',
+                    dateFieldTo: '2023-01-02',
+                    fields: [],
+                },
+                response: { data: [{ count: 11 }] },
+            },
+        ]);
+
+        lapisRequestMocks.multipleMutations(
+            [
+                {
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-02',
+                        dateFieldTo: '2023-01-02',
+                        minProportion: 0.001,
+                    },
+                    response: { data: [getSomeTestMutation(0.2, 2)] },
+                },
+            ],
+            'nucleotide',
+        );
+
+        const dateRanges = [
+            {
+                dateFrom: '2023-01-02',
+                dateTo: '2023-01-02',
+            },
+        ];
+
+        lapisRequestMocks.mutationsOverTime(
+            [
+                {
+                    body: {
+                        filters: lapisFilter,
+                        dateRanges,
+                        includeMutations: ['sequenceName:A123T'],
+                        dateField,
+                    },
+                    response: {
+                        data: {
+                            data: [[{ count: 2, coverage: 10 }]],
+                            dateRanges,
+                            mutations: ['sequenceName:A123T'],
+                        },
+                    },
+                },
+            ],
+            'nucleotide',
+        );
+
+        const { mutationOverTimeData } = await queryMutationsOverTimeData({
+            lapisFilter,
+            sequenceType: 'nucleotide',
+            lapis: DUMMY_LAPIS_URL,
+            lapisDateField: dateField,
+            granularity: 'day',
+            useNewEndpoint: true,
+        });
+
+        expect(mutationOverTimeData.getAsArray()).to.deep.equal([
+            [{ type: 'value', proportion: 0.2, count: 2, totalCount: 11 }],
+        ]);
+
+        const sequences = mutationOverTimeData.getFirstAxisKeys();
+        expect(sequences[0].code).toBe('sequenceName:A123T');
+
+        const dates = mutationOverTimeData.getSecondAxisKeys();
+        expect(dates[0].dateString).toBe('2023-01-02');
+    });
+
+    it('should fetch data including the first and last day of the granularity', async () => {
+        const lapisFilter = { field1: 'value1', field2: 'value2' };
+        const dateField = 'dateField';
+
+        lapisRequestMocks.multipleAggregated([
+            {
+                body: { ...lapisFilter, fields: [dateField] },
+                response: {
+                    data: [
+                        { count: 1, [dateField]: '2023-01-05' },
+                        { count: 2, [dateField]: '2023-02-15' },
+                    ],
+                },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-01-01',
+                    dateFieldTo: '2023-01-31',
+                    fields: [],
+                },
+                response: { data: [{ count: 11 }] },
+            },
+            {
+                body: {
+                    ...lapisFilter,
+                    dateFieldFrom: '2023-02-01',
+                    dateFieldTo: '2023-02-28',
+                    fields: [],
+                },
+                response: { data: [{ count: 12 }] },
+            },
+        ]);
+
+        lapisRequestMocks.multipleMutations(
+            [
+                {
+                    body: {
+                        ...lapisFilter,
+                        dateFieldFrom: '2023-01-01',
+                        dateFieldTo: '2023-02-28',
+                        minProportion: 0.001,
+                    },
+                    response: {
+                        data: [getSomeTestMutation(0.21, 6), getSomeOtherTestMutation(0.22, 4)],
+                    },
+                },
+            ],
+            'nucleotide',
+        );
+
+        const dateRanges = [
+            {
+                dateFrom: '2023-01-01',
+                dateTo: '2023-01-31',
+            },
+            {
+                dateFrom: '2023-02-01',
+                dateTo: '2023-02-28',
+            },
+        ];
+
+        lapisRequestMocks.mutationsOverTime(
+            [
+                {
+                    body: {
+                        filters: lapisFilter,
+                        dateRanges,
+                        includeMutations: ['otherSequenceName:G234C', 'sequenceName:A123T'],
+                        dateField,
+                    },
+                    response: {
+                        data: {
+                            data: [
+                                [
+                                    { count: 2, coverage: 10 },
+                                    { count: 3, coverage: 10 },
+                                ],
+                                [
+                                    { count: 4, coverage: 10 },
+                                    { count: 5, coverage: 10 },
+                                ],
+                            ],
+                            dateRanges,
+                            mutations: ['otherSequenceName:G234C', 'sequenceName:A123T'],
+                        },
+                    },
+                },
+            ],
+            'nucleotide',
+        );
+
+        const { mutationOverTimeData } = await queryMutationsOverTimeData({
+            lapisFilter,
+            sequenceType: 'nucleotide',
+            lapis: DUMMY_LAPIS_URL,
+            lapisDateField: dateField,
+            granularity: 'month',
+            useNewEndpoint: true,
+        });
+
+        expect(mutationOverTimeData.getAsArray()).to.deep.equal([
+            [
+                { type: 'value', proportion: 0.2, count: 2, totalCount: 11 },
+                { type: 'value', proportion: 0.3, count: 3, totalCount: 12 },
+            ],
+            [
+                { type: 'value', proportion: 0.4, count: 4, totalCount: 11 },
+                { type: 'value', proportion: 0.5, count: 5, totalCount: 12 },
+            ],
+        ]);
+
+        const sequences = mutationOverTimeData.getFirstAxisKeys();
+        expect(sequences[0].code).toBe('otherSequenceName:G234C');
+        expect(sequences[1].code).toBe('sequenceName:A123T');
+
+        const dates = mutationOverTimeData.getSecondAxisKeys();
+        expect(dates[0].dateString).toBe('2023-01');
+        expect(dates[1].dateString).toBe('2023-02');
+    });
+
+    it('should return empty data when there are no dates in filter', async () => {
+        const lapisFilter = { field1: 'value1', field2: 'value2' };
+        const dateField = 'dateField';
+
+        lapisRequestMocks.multipleAggregated([
+            {
+                body: { ...lapisFilter, fields: [dateField] },
+                response: {
+                    data: [],
+                },
+            },
+        ]);
+
+        lapisRequestMocks.mutationsOverTime(
+            [
+                {
+                    body: {
+                        filters: lapisFilter,
+                        dateRanges: [],
+                        includeMutations: [],
+                        dateField,
+                    },
+                    response: {
+                        data: {
+                            data: [],
+                            dateRanges: [],
+                            mutations: [],
+                        },
+                    },
+                },
+            ],
+            'nucleotide',
+        );
+
+        const { mutationOverTimeData } = await queryMutationsOverTimeData({
+            lapisFilter,
+            sequenceType: 'nucleotide',
+            lapis: DUMMY_LAPIS_URL,
+            lapisDateField: dateField,
+            granularity: 'month',
+            useNewEndpoint: true,
+        });
+
+        expect(mutationOverTimeData.getAsArray()).to.deep.equal([]);
+
+        const sequences = mutationOverTimeData.getFirstAxisKeys();
+        expect(sequences.length).toBe(0);
+
+        const dates = mutationOverTimeData.getSecondAxisKeys();
+        expect(dates.length).toBe(0);
+    });
+
+    function getSomeTestMutation(proportion: number, count: number) {
+        return {
+            mutation: 'sequenceName:A123T',
+            proportion,
+            count,
+            sequenceName: 'sequenceName',
+            mutationFrom: 'A',
+            mutationTo: 'T',
+            position: 123,
+        };
+    }
+
+    function getSomeOtherTestMutation(proportion: number, count: number) {
+        return {
+            mutation: 'otherSequenceName:G234C',
+            proportion,
+            count,
+            sequenceName: 'otherSequenceName',
+            mutationFrom: 'G',
+            mutationTo: 'C',
+            position: 234,
+        };
+    }
+});

--- a/components/src/web-components/visualization/gs-mutations-over-time.spec-d.ts
+++ b/components/src/web-components/visualization/gs-mutations-over-time.spec-d.ts
@@ -32,6 +32,9 @@ describe('gs-mutations-over-time', () => {
         expectTypeOf<typeof MutationsOverTimeComponent.prototype.initialMeanProportionInterval>().toEqualTypeOf<
             MutationsOverTimeProps['initialMeanProportionInterval']
         >();
+        expectTypeOf<typeof MutationsOverTimeComponent.prototype.useNewEndpoint>().toEqualTypeOf<
+            MutationsOverTimeProps['useNewEndpoint']
+        >();
         expectTypeOf<typeof MutationsOverTimeComponent.prototype.pageSizes>().toEqualTypeOf<
             MutationsOverTimeProps['pageSizes']
         >();

--- a/components/src/web-components/visualization/gs-mutations-over-time.stories.ts
+++ b/components/src/web-components/visualization/gs-mutations-over-time.stories.ts
@@ -42,6 +42,7 @@ const meta: Meta<Required<MutationsOverTimeProps>> = {
         lapisDateField: { control: 'text' },
         displayMutations: { control: 'object' },
         initialMeanProportionInterval: { control: 'object' },
+        useNewEndpoint: { control: 'boolean' },
         pageSizes: { control: 'object' },
     },
     args: {
@@ -52,6 +53,7 @@ const meta: Meta<Required<MutationsOverTimeProps>> = {
         granularity: 'month',
         lapisDateField: 'date',
         initialMeanProportionInterval: { min: 0.05, max: 0.9 },
+        useNewEndpoint: false,
         pageSizes: [10, 20, 30, 40, 50],
     },
     parameters: withComponentDocs({
@@ -99,6 +101,7 @@ const Template: StoryObj<Required<MutationsOverTimeProps>> = {
                 .displayMutations=${args.displayMutations}
                 .initialMeanProportionInterval=${args.initialMeanProportionInterval}
                 .pageSizes=${args.pageSizes}
+                .useNewEndpoint=${args.useNewEndpoint}
             ></gs-mutations-over-time>
         </gs-app>
     `,

--- a/components/src/web-components/visualization/gs-mutations-over-time.tsx
+++ b/components/src/web-components/visualization/gs-mutations-over-time.tsx
@@ -114,6 +114,14 @@ export class MutationsOverTimeComponent extends PreactLitAdapterWithGridJsStyles
     initialMeanProportionInterval: { min: number; max: number } = { min: 0.05, max: 0.9 };
 
     /**
+     * Whether to use the mutationsOverTime endpoint from LAPIS.
+     * If true, use the endpoint, if false, compute component data as before.
+     * Eventually, the new endpoint will become the default.
+     */
+    @property({ type: Boolean })
+    useNewEndpoint?: boolean = false;
+
+    /**
      * The number of rows per page, which can be selected by the user.
      */
     @property({ type: Array })
@@ -138,6 +146,7 @@ export class MutationsOverTimeComponent extends PreactLitAdapterWithGridJsStyles
                     lapisDateField={this.lapisDateField}
                     displayMutations={this.displayMutations}
                     initialMeanProportionInterval={this.initialMeanProportionInterval}
+                    useNewEndpoint={this.useNewEndpoint}
                     pageSizes={this.pageSizes}
                 />
             </MutationAnnotationsContextProvider>

--- a/components/vitest.setup.ts
+++ b/components/vitest.setup.ts
@@ -9,9 +9,16 @@ import {
     aggregatedEndpoint,
     detailsEndpoint,
     lineageDefinitionEndpoint,
+    mutationsOverTimeEndpoint,
     substitutionsOrDeletionsEndpoint,
 } from './src/lapisApi/lapisApi';
-import { type LapisBaseRequest, type MutationsRequest, type MutationsResponse } from './src/lapisApi/lapisTypes';
+import {
+    MutationsOverTimeRequest,
+    MutationsOverTimeResponse,
+    type LapisBaseRequest,
+    type MutationsRequest,
+    type MutationsResponse,
+} from './src/lapisApi/lapisTypes';
 
 export const DUMMY_LAPIS_URL = 'http://lapis.dummy';
 
@@ -78,6 +85,17 @@ export const lapisRequestMocks = {
     ) => {
         testServer.use(
             http.post(substitutionsOrDeletionsEndpoint(DUMMY_LAPIS_URL, sequenceType), postResolver(expectedRequests)),
+        );
+    },
+    mutationsOverTime: (
+        expectedRequests: {
+            body: MutationsOverTimeRequest;
+            response: MutationsOverTimeResponse;
+        }[],
+        sequenceType: 'nucleotide' | 'amino acid',
+    ) => {
+        testServer.use(
+            http.post(mutationsOverTimeEndpoint(DUMMY_LAPIS_URL, sequenceType), postResolver(expectedRequests)),
         );
     },
     lineageDefinition: (response: LineageDefinitionResponse, lineageField: string, statusCode: number = 200) => {


### PR DESCRIPTION
### Summary
This PR implements a new method to fetch the data for the _MutationsOverTime_ component. A new LAPIS endpoint was implemented which directly provides the data that the plot needs (see https://github.com/GenSpectrum/LAPIS/pull/1229).
The new endpoint can be used in the component with a boolean switch called `useNewEndpoint`, it defaults to `false`.

With the new endpoint, the plot behaves a little bit different:
- the new endpoint does not generate `null` and `belowThreshold`cells anymore.
- when selecting and end date like 2022-08-12 and selecting granularity monthly, the old calculating method presented counts for the whole month of August, whereas the new endpoint only shows data up to the selected `dateTo`. This is actually more in line with how other plots work.

#### Testing
I've added a new dedicated test file for the new endpoint.

I've manually checked that the storybook demos still work when setting the new parameter to true.

### Screenshot
n/a

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
