### PR TITLE
fix(components): set bg color as white in fullscreen

### DIFF
--- a/components/src/preact/components/tabs.tsx
+++ b/components/src/preact/components/tabs.tsx
@@ -40,7 +40,7 @@ const Tabs = forwardRef<HTMLDivElement, ComponentTabsProps>(({ tabs, toolbar }, 
     const toolbarElement = typeof toolbar === 'function' ? toolbar(activeTab) : toolbar;
 
     return (
-        <div ref={ref} className='h-full w-full flex flex-col'>
+        <div ref={ref} className='h-full w-full flex flex-col bg-white'>
             <div className='flex flex-row justify-between flex-wrap'>
                 {tabElements}
                 {toolbar && <div className='py-2 flex flex-wrap gap-y-1'>{toolbarElement}</div>}


### PR DESCRIPTION
resolves #930 

### Work in progress - thoughts

I have a simple fix: I'm just setting the background color of our tabs container; we use it everywhere, and that works:

<img width="1512" height="956" alt="image" src="https://github.com/user-attachments/assets/c9a156fe-6773-498a-bc3b-024d2a599e35" />

But further research showed that there's also `#container:backdrop` which one can set (https://stackoverflow.com/questions/16163089/background-element-goes-black-when-entering-fullscreen-with-html5) - and I think we could possibly add this as a custom class and then attach it dynamically to the fullscreened element. Then, we could fullscreen arbitrary components.

Would that be "better"? Arguably it's simpler to just set the bg color on the root element.

I feel like the user of the component library would be in charge of setting the background color on the fullscreen panel, it's not really our job of the component. So maybe it's the proper way to go to specify a bg color for our components?

### Summary
This PR sets a fixed background color for the `Tabs` element, so when it is fullscreened, it still has a white background and is readable.

### Testing
I didn't add specific tests yet - do we want tests that check that components are readable in fullscreen?

### Screenshot
<img width="1512" height="956" alt="image" src="https://github.com/user-attachments/assets/c9a156fe-6773-498a-bc3b-024d2a599e35" />

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
