### PR TITLE
docs(components): document test runner install info for MacOS

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -77,6 +77,15 @@ We primarily provide two kinds of components:
 npm ci
 ```
 
+> [!NOTE]  
+> **For Mac users**: By default, the `package-lock.json` installs linux dependencies for the
+> storybook test runner. To use it, you need to reinstall it:
+>
+> ```
+> npm uninstall @storybook/test-runner
+> npm install @storybook/test-runner --force
+> ```
+
 ### Custom Elements Manifest
 
 This package also ships a [Custom Elements Manifest](https://custom-elements-manifest.open-wc.org/),


### PR DESCRIPTION
related to #949

### Summary
Document that you need to reinstall the test-runner for MacOS to make it work.

### Screenshot
<img width="1008" height="215" alt="image" src="https://github.com/user-attachments/assets/9f85b954-ea54-40bb-916c-d753b8552423" />


### PR Checklist
- [x] All necessary documentation has been adapted.
- ~~The implemented feature is covered by an appropriate test.~~
