### PR TITLE
feat(components): allow setting displayMutations to empty

### DIFF
--- a/components/src/preact/mutationsOverTime/getFilteredMutationsOverTimeData.ts
+++ b/components/src/preact/mutationsOverTime/getFilteredMutationsOverTimeData.ts
@@ -8,7 +8,7 @@ import { type useMutationAnnotationsProvider } from '../MutationAnnotationsConte
 import type { DisplayedMutationType } from '../components/mutation-type-selector';
 import type { DisplayedSegment } from '../components/segment-selector';
 
-export const displayMutationsSchema = z.array(z.string()).min(1);
+export const displayMutationsSchema = z.array(z.string());
 export type DisplayMutations = z.infer<typeof displayMutationsSchema>;
 
 export type MutationFilter = {


### PR DESCRIPTION
### Summary
While working on the wastewater dashboard, I noticed that I get an Error (`Error - Invalid component attributes`) when I set the `displayMutations` to empty. I think it's fine that if the user wants to have an empty component by giving an empty list, they should have it. There will be the text: "No data available for your filters."

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
