### PR TITLE
chore(ci): update Playwright snapshot workflow

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -1,7 +1,11 @@
+# GitHub Action to update Playwright snapshots when a PR is labeled "update-snapshots"
 name: Update Playwright Snapshots
+run-name: "Update Playwright Snapshots for PR #${{ github.event.pull_request.number }}"
 
 on:
-  workflow_dispatch:
+  pull_request:
+    types:
+      - labeled
 
 defaults:
   run:
@@ -10,9 +14,13 @@ defaults:
 jobs:
   storybook_tests:
     name: Run storybook tests
+    if: github.event.label.name == 'update-snapshots'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
@@ -66,8 +74,20 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add .
-          git commit -m "Squash me: Update Playwright snapshots"
-          git push
+          if ! git diff --cached --quiet; then
+            git commit -m "test(components): update Playwright snapshots"
+            git push
+          else
+            echo "No changes to commit"
+          fi
+
+      - name: Remove 'update-snapshots' label
+        if: success()
+        run: |
+          curl -s -X DELETE \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/update-snapshots
 
       - name: Upload Test Results
         if: always()


### PR DESCRIPTION
### Summary
You can now add the `update-snapshots` label to a PR, which will trigger a workflow to run playwright to update the snapshots. It will then make a commit, and remove the label. If no changes are there, it will still remove the label.

### Screenshot
<img width="860" height="244" alt="image" src="https://github.com/user-attachments/assets/6eaa46d7-1df5-46b9-9f49-5e97bcc72301" />

### PR Checklist
- [x] All necessary documentation has been adapted.
- ~~The implemented feature is covered by an appropriate test.~~
