### PR TITLE
feat(components): allow disabling counts

### DIFF
--- a/components/src/preact/lineageFilter/lineage-filter.stories.tsx
+++ b/components/src/preact/lineageFilter/lineage-filter.stories.tsx
@@ -74,6 +74,11 @@ const meta: Meta = {
                 type: 'object',
             },
         },
+        hideCounts: {
+            control: {
+                type: 'boolean',
+            },
+        },
     },
 
     args: {
@@ -84,6 +89,7 @@ const meta: Meta = {
         placeholderText: 'Enter a lineage',
         value: 'A.1',
         width: '100%',
+        hideCounts: false,
     },
 };
 
@@ -159,6 +165,24 @@ export const WithNoLapisField: StoryObj<LineageFilterProps> = {
     play: async ({ canvasElement, step }) => {
         await step('expect error message', async () => {
             await expectInvalidAttributesErrorMessage(canvasElement, 'String must contain at least 1 character(s)');
+        });
+    },
+};
+
+export const WithHideCountsTrue: StoryObj<LineageFilterProps> = {
+    ...Default,
+    args: {
+        ...Default.args,
+        hideCounts: true,
+    },
+    play: async ({ canvasElement, step }) => {
+        const { canvas } = await prepare(canvasElement, step);
+
+        await step('visible without counts', async () => {
+            const input = await inputField(canvas);
+            await userEvent.clear(input);
+            await userEvent.type(input, 'B.1');
+            await expect(canvas.getByRole('option', { name: 'B.1' })).toBeVisible();
         });
     },
 };

--- a/components/src/preact/lineageFilter/lineage-filter.tsx
+++ b/components/src/preact/lineageFilter/lineage-filter.tsx
@@ -16,6 +16,7 @@ const lineageSelectorPropsSchema = z.object({
     lapisField: z.string().min(1),
     placeholderText: z.string().optional(),
     value: z.string(),
+    hideCounts: z.boolean().optional(),
 });
 const lineageFilterInnerPropsSchema = lineageSelectorPropsSchema.extend({
     lapisFilter: lapisFilterSchema,
@@ -46,6 +47,7 @@ const LineageFilterInner: FunctionComponent<LineageFilterInnerProps> = ({
     placeholderText,
     value,
     lapisFilter,
+    hideCounts,
 }) => {
     const lapisUrl = useLapisUrl();
 
@@ -62,7 +64,15 @@ const LineageFilterInner: FunctionComponent<LineageFilterInnerProps> = ({
         throw error;
     }
 
-    return <LineageSelector lapisField={lapisField} value={value} placeholderText={placeholderText} data={data} />;
+    return (
+        <LineageSelector
+            lapisField={lapisField}
+            value={value}
+            placeholderText={placeholderText}
+            data={data}
+            hideCounts={hideCounts}
+        />
+    );
 };
 
 const LineageSelector = ({
@@ -70,6 +80,7 @@ const LineageSelector = ({
     value,
     placeholderText,
     data,
+    hideCounts = false,
 }: LineageSelectorProps & {
     data: LineageItem[];
 }) => {
@@ -88,7 +99,7 @@ const LineageSelector = ({
             formatItemInList={(item: LineageItem) => (
                 <p>
                     <span>{item.lineage}</span>
-                    <span className='ml-2 text-gray-500'>({item.count})</span>
+                    {!hideCounts && <span className='ml-2 text-gray-500'>({item.count})</span>}
                 </p>
             )}
         />

--- a/components/src/preact/locationFilter/location-filter.stories.tsx
+++ b/components/src/preact/locationFilter/location-filter.stories.tsx
@@ -44,6 +44,7 @@ const meta: Meta<LocationFilterProps> = {
         lapisFilter: {
             age: 18,
         },
+        hideCounts: false,
     },
     argTypes: {
         fields: {
@@ -64,6 +65,11 @@ const meta: Meta<LocationFilterProps> = {
         placeholderText: {
             control: {
                 type: 'text',
+            },
+        },
+        hideCounts: {
+            control: {
+                type: 'boolean',
             },
         },
         lapisFilter: {
@@ -142,6 +148,24 @@ export const OnBlurInput: StoryObj<LocationFilterProps> = {
                     location: undefined,
                 });
             });
+        });
+    },
+};
+
+export const WithHideCountsTrue: StoryObj<LocationFilterProps> = {
+    ...Primary,
+    args: {
+        ...Primary.args,
+        hideCounts: true,
+    },
+    play: async ({ canvasElement, step }) => {
+        const { canvas } = await prepare(canvasElement, step);
+
+        await step('visible without counts', async () => {
+            const input = await inputField(canvas);
+            await userEvent.clear(input);
+            await userEvent.type(input, 'Adajan');
+            await expect(canvas.getByRole('option', { name: 'Adajan Asia / India / Gujarat / Adajan' })).toBeVisible();
         });
     },
 };

--- a/components/src/preact/locationFilter/location-filter.tsx
+++ b/components/src/preact/locationFilter/location-filter.tsx
@@ -16,6 +16,7 @@ const locationSelectorPropsSchema = z.object({
     value: lapisLocationFilterSchema.optional(),
     placeholderText: z.string().optional(),
     fields: z.array(z.string()).min(1),
+    hideCounts: z.boolean().optional(),
 });
 const locationFilterInnerPropsSchema = locationSelectorPropsSchema.extend({ lapisFilter: lapisFilterSchema });
 const locationFilterPropsSchema = locationFilterInnerPropsSchema.extend({
@@ -39,7 +40,13 @@ export const LocationFilter: FunctionComponent<LocationFilterProps> = (props) =>
     );
 };
 
-export const LocationFilterInner = ({ value, fields, placeholderText, lapisFilter }: LocationFilterInnerProps) => {
+export const LocationFilterInner = ({
+    value,
+    fields,
+    placeholderText,
+    lapisFilter,
+    hideCounts,
+}: LocationFilterInnerProps) => {
     const lapis = useLapisUrl();
 
     const { data, error, isLoading } = useQuery(
@@ -54,7 +61,15 @@ export const LocationFilterInner = ({ value, fields, placeholderText, lapisFilte
         throw error;
     }
 
-    return <LocationSelector fields={fields} value={value} placeholderText={placeholderText} locationData={data} />;
+    return (
+        <LocationSelector
+            fields={fields}
+            value={value}
+            placeholderText={placeholderText}
+            locationData={data}
+            hideCounts={hideCounts}
+        />
+    );
 };
 
 type SelectItem = {
@@ -69,6 +84,7 @@ const LocationSelector = ({
     value,
     placeholderText,
     locationData,
+    hideCounts = false,
 }: LocationSelectorProps & {
     locationData: LocationEntry[];
 }) => {
@@ -96,7 +112,7 @@ const LocationSelector = ({
                 <>
                     <p>
                         <span>{item.label}</span>
-                        <span className='ml-2 text-gray-500'>({item.count})</span>
+                        {!hideCounts && <span className='ml-2 text-gray-500'>({item.count})</span>}
                     </p>
                     <span className='text-sm text-gray-500'>{item.description}</span>
                 </>

--- a/components/src/preact/textFilter/text-filter.stories.tsx
+++ b/components/src/preact/textFilter/text-filter.stories.tsx
@@ -46,6 +46,11 @@ const meta: Meta<TextFilterProps> = {
                 type: 'text',
             },
         },
+        hideCounts: {
+            control: {
+                type: 'boolean',
+            },
+        },
         value: {
             control: {
                 type: 'text',
@@ -75,6 +80,7 @@ export const Default: StoryObj<TextFilterProps> = {
     args: {
         lapisField: 'host',
         placeholderText: 'Enter a host name',
+        hideCounts: false,
         value: '',
         width: '100%',
         lapisFilter: {
@@ -128,10 +134,6 @@ export const KeepsPartialInputInInputField: StoryObj<TextFilterProps> = {
             </LapisUrlContextProvider>
         </>
     ),
-    args: {
-        ...Default.args,
-        value: '',
-    },
     play: async ({ canvasElement, step }) => {
         const canvas = within(canvasElement);
 
@@ -172,6 +174,29 @@ export const KeepsPartialInputInInputField: StoryObj<TextFilterProps> = {
                     }),
                 );
             });
+        });
+    },
+};
+
+export const WithHideCountsTrue: StoryObj<TextFilterProps> = {
+    ...Default,
+    args: {
+        ...Default.args,
+        hideCounts: true,
+    },
+    play: async ({ canvasElement, step }) => {
+        const canvas = within(canvasElement);
+        const inputField = () => canvas.getByPlaceholderText('Enter a host name', { exact: false });
+
+        await waitFor(async () => {
+            await expect(inputField()).toHaveValue('');
+        });
+
+        await step('visible without counts', async () => {
+            const input = inputField();
+            await userEvent.clear(input);
+            await userEvent.type(input, 'Homo');
+            await expect(canvas.getByRole('option', { name: 'Homo' })).toBeVisible();
         });
     },
 };

--- a/components/src/preact/textFilter/text-filter.tsx
+++ b/components/src/preact/textFilter/text-filter.tsx
@@ -15,6 +15,7 @@ const textSelectorPropsSchema = z.object({
     lapisField: z.string().min(1),
     placeholderText: z.string().optional(),
     value: z.string().optional(),
+    hideCounts: z.boolean().optional(),
 });
 const textFilterInnerPropsSchema = textSelectorPropsSchema.extend({ lapisFilter: lapisFilterSchema });
 const textFilterPropsSchema = textFilterInnerPropsSchema.extend({
@@ -42,6 +43,7 @@ const TextFilterInner: FunctionComponent<TextFilterInnerProps> = ({
     value,
     lapisField,
     placeholderText,
+    hideCounts,
     lapisFilter,
 }) => {
     const lapis = useLapisUrl();
@@ -59,7 +61,15 @@ const TextFilterInner: FunctionComponent<TextFilterInnerProps> = ({
         throw error;
     }
 
-    return <TextSelector lapisField={lapisField} value={value} placeholderText={placeholderText} data={data} />;
+    return (
+        <TextSelector
+            lapisField={lapisField}
+            value={value}
+            placeholderText={placeholderText}
+            hideCounts={hideCounts}
+            data={data}
+        />
+    );
 };
 
 type SelectItem = {
@@ -72,6 +82,7 @@ const TextSelector = ({
     value,
     placeholderText,
     data,
+    hideCounts = false,
 }: TextSelectorProps & {
     data: SelectItem[];
 }) => {
@@ -89,7 +100,7 @@ const TextSelector = ({
                 return (
                     <p>
                         <span>{item.value}</span>
-                        <span className='ml-2 text-gray-500'>({item.count})</span>
+                        {!hideCounts && <span className='ml-2 text-gray-500'>({item.count})</span>}
                     </p>
                 );
             }}

--- a/components/src/web-components/input/gs-lineage-filter.stories.ts
+++ b/components/src/web-components/input/gs-lineage-filter.stories.ts
@@ -92,6 +92,11 @@ const meta: Meta<Required<LineageFilterProps>> = {
                 type: 'object',
             },
         },
+        hideCounts: {
+            control: {
+                type: 'boolean',
+            },
+        },
     },
 };
 
@@ -105,6 +110,7 @@ const Template: StoryObj<Required<LineageFilterProps>> = {
                     .lapisField=${args.lapisField}
                     .lapisFilter=${args.lapisFilter}
                     .placeholderText=${args.placeholderText}
+                    .hideCounts=${args.hideCounts}
                     .value=${args.value}
                     .width=${args.width}
                 ></gs-lineage-filter>
@@ -119,6 +125,7 @@ const Template: StoryObj<Required<LineageFilterProps>> = {
         placeholderText: 'Enter a lineage',
         value: 'B.1.1.7',
         width: '100%',
+        hideCounts: false,
     },
 };
 

--- a/components/src/web-components/input/gs-lineage-filter.tsx
+++ b/components/src/web-components/input/gs-lineage-filter.tsx
@@ -73,6 +73,13 @@ export class LineageFilterComponent extends PreactLitAdapter {
     @property({ type: String })
     width: string = '100%';
 
+    /**
+     * Whether to hide counts behind lineage options in the drop down selection.
+     * Defaults to false.
+     */
+    @property({ type: Boolean })
+    hideCounts: boolean | undefined = false;
+
     override render() {
         return (
             <LineageFilter
@@ -81,6 +88,7 @@ export class LineageFilterComponent extends PreactLitAdapter {
                 placeholderText={this.placeholderText}
                 value={this.value}
                 width={this.width}
+                hideCounts={this.hideCounts}
             />
         );
     }

--- a/components/src/web-components/input/gs-location-filter.stories.ts
+++ b/components/src/web-components/input/gs-location-filter.stories.ts
@@ -56,6 +56,11 @@ const meta: Meta = {
                 type: 'text',
             },
         },
+        hideCounts: {
+            control: {
+                type: 'boolean',
+            },
+        },
         lapisFilter: {
             age: 18,
         },
@@ -75,6 +80,7 @@ const Template: StoryObj<LocationFilterProps> = {
                     .value=${args.value}
                     .width=${args.width}
                     placeholderText=${ifDefined(args.placeholderText)}
+                    .hideCounts=${args.hideCounts}
                 ></gs-location-filter>
             </div>
         </gs-app>`;
@@ -87,6 +93,7 @@ const Template: StoryObj<LocationFilterProps> = {
         value: undefined,
         width: '100%',
         placeholderText: 'Enter a location',
+        hideCounts: false,
     },
 };
 

--- a/components/src/web-components/input/gs-location-filter.tsx
+++ b/components/src/web-components/input/gs-location-filter.tsx
@@ -74,8 +74,15 @@ export class LocationFilterComponent extends PreactLitAdapter {
     /**
      * The placeholder text to display in the input field, if it is empty.
      */
-    @property()
+    @property({ type: String })
     placeholderText: string | undefined = undefined;
+
+    /**
+     * Whether to hide counts behind location options in the drop down selection.
+     * Defaults to false.
+     */
+    @property({ type: Boolean })
+    hideCounts: boolean | undefined = false;
 
     override render() {
         return (
@@ -85,6 +92,7 @@ export class LocationFilterComponent extends PreactLitAdapter {
                 lapisFilter={this.lapisFilter}
                 width={this.width}
                 placeholderText={this.placeholderText}
+                hideCounts={this.hideCounts}
             />
         );
     }

--- a/components/src/web-components/input/gs-text-filter.stories.ts
+++ b/components/src/web-components/input/gs-text-filter.stories.ts
@@ -63,6 +63,11 @@ const meta: Meta<Required<TextFilterProps>> = {
                 type: 'text',
             },
         },
+        hideCounts: {
+            control: {
+                type: 'boolean',
+            },
+        },
         value: {
             control: {
                 type: 'text',
@@ -92,6 +97,7 @@ export const Default: StoryObj<Required<TextFilterProps>> = {
                     .lapisField=${args.lapisField}
                     .lapisFilter=${args.lapisFilter}
                     .placeholderText=${args.placeholderText}
+                    .hideCounts=${args.hideCounts}
                     .value=${args.value}
                     .width=${args.width}
                 ></gs-text-filter>
@@ -102,6 +108,7 @@ export const Default: StoryObj<Required<TextFilterProps>> = {
         lapisField: 'host',
         lapisFilter: { country: 'Germany' },
         placeholderText: 'Enter host name',
+        hideCounts: false,
         value: 'Homo sapiens',
         width: '100%',
     },

--- a/components/src/web-components/input/gs-text-filter.tsx
+++ b/components/src/web-components/input/gs-text-filter.tsx
@@ -60,6 +60,13 @@ export class TextFilterComponent extends PreactLitAdapter {
     placeholderText: string | undefined = undefined;
 
     /**
+     * Whether to hide counts behind options in the drop down selection.
+     * Defaults to false.
+     */
+    @property({ type: Boolean })
+    hideCounts: boolean | undefined = false;
+
+    /**
      * The width of the component.
      *
      * Visit https://genspectrum.github.io/dashboard-components/?path=/docs/concepts-size-of-components--docs for more information.
@@ -73,6 +80,7 @@ export class TextFilterComponent extends PreactLitAdapter {
                 lapisField={this.lapisField}
                 lapisFilter={this.lapisFilter}
                 placeholderText={this.placeholderText}
+                hideCounts={this.hideCounts}
                 value={this.value}
                 width={this.width}
             />


### PR DESCRIPTION
resolves #970 

### Summary
Adds a `showCounts` prop to the filter components (Lineage, Location, Text) to allow enabling/disabling the grey counts behind the options. It defaults to true, so behavior is unchanged.

I've added storybook tests.

### Screenshot

<img width="592" height="449" alt="image" src="https://github.com/user-attachments/assets/0513fcff-f9d4-4f39-9f03-d0ee2b8d761b" />


### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
