### PR TITLE
feat(components): mutation filter: Make type of mutations configurable

### DIFF
--- a/components/src/web-components/input/gs-mutation-filter.stories.ts
+++ b/components/src/web-components/input/gs-mutation-filter.stories.ts
@@ -38,6 +38,11 @@ const meta: Meta<MutationFilterProps> = {
             },
         },
         width: { control: 'text' },
+        enabledMutationTypes: {
+            control: {
+                type: 'object',
+            },
+        },
     },
     tags: ['autodocs'],
 };
@@ -48,7 +53,11 @@ const Template: StoryObj<MutationFilterProps> = {
     render: (args) => {
         return html` <gs-app lapis="${LAPIS_URL}">
             <div class="max-w-(--breakpoint-lg)">
-                <gs-mutation-filter .initialValue=${args.initialValue} .width=${args.width}></gs-mutation-filter>
+                <gs-mutation-filter
+                    .initialValue=${args.initialValue}
+                    .width=${args.width}
+                    .enabledMutationTypes=${args.enabledMutationTypes}
+                ></gs-mutation-filter>
             </div>
         </gs-app>`;
     },
@@ -100,6 +109,25 @@ export const FiresFilterChangedEvent: StoryObj<MutationFilterProps> = {
                     }),
                 ),
             );
+        });
+    },
+};
+
+export const RestrictEnabledMutationTypes: StoryObj<MutationFilterProps> = {
+    ...Template,
+    args: {
+        ...Template.args,
+        enabledMutationTypes: ['nucleotideMutations', 'aminoAcidMutations'],
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = await withinShadowRoot(canvasElement, 'gs-mutation-filter');
+
+        const inputField = () => canvas.getByPlaceholderText('Enter a mutation', { exact: false });
+
+        await waitFor(async () => {
+            const placeholderText = inputField().getAttribute('placeholder');
+
+            await expect(placeholderText).toEqual('Enter a mutation (e.g. 23T, E:57Q)');
         });
     },
 };

--- a/components/src/web-components/input/gs-mutation-filter.tsx
+++ b/components/src/web-components/input/gs-mutation-filter.tsx
@@ -2,7 +2,11 @@ import { customElement, property } from 'lit/decorators.js';
 import type { DetailedHTMLProps, HTMLAttributes } from 'react';
 
 import { ReferenceGenomesAwaiter } from '../../preact/components/ReferenceGenomesAwaiter';
-import { MutationFilter, type MutationFilterProps } from '../../preact/mutationFilter/mutation-filter';
+import {
+    MutationFilter,
+    type MutationType,
+    type MutationFilterProps,
+} from '../../preact/mutationFilter/mutation-filter';
 import type { MutationsFilter } from '../../types';
 import { type gsEventNames } from '../../utils/gsEventNames';
 import type { Equals, Expect } from '../../utils/typeAssertions';
@@ -43,6 +47,11 @@ import { PreactLitAdapter } from '../PreactLitAdapter';
  *
  * Examples: `ins_S:614:G`, `ins_614:G`
  *
+ * ### Enabled mutation types
+ *
+ * After parsing, the entered mutation/insertion also has to match the enabled mutation types,
+ * which are configured with the `enabledMutationTypes` attribute.
+ *
  * @fires {CustomEvent<{
  *      nucleotideMutations: string[],
  *      aminoAcidMutations: string[],
@@ -81,10 +90,28 @@ export class MutationFilterComponent extends PreactLitAdapter {
     @property({ type: String })
     width: string = '100%';
 
+    /**
+     * Which mutation types this input will accept.
+     * Any (or all) of the following can be given in a list:
+     *
+     * - `nucleotideMutations`
+     * - `nucleotideInsertions`
+     * - `aminoAcidMutations`
+     * - `aminoAcidInsertions`
+     *
+     * By default or if none are given, all types are accepted.
+     */
+    @property({ type: Object })
+    enabledMutationTypes: MutationType[] | undefined = undefined;
+
     override render() {
         return (
             <ReferenceGenomesAwaiter>
-                <MutationFilter initialValue={this.initialValue} width={this.width} />
+                <MutationFilter
+                    initialValue={this.initialValue}
+                    width={this.width}
+                    enabledMutationTypes={this.enabledMutationTypes}
+                />
             </ReferenceGenomesAwaiter>
         );
     }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #963 

### Summary

Adds a new property `enabledMutationTypes` which is a list of strings, which can have these:

 - `nucleotideMutations`
 - `nucleotideInsertions`
 - `aminoAcidMutations`
 - `aminoAcidInsertions`

The help modal has not been adjusted, I believe it is not necessary to adjust the text.

#### Testing

I've added a few spot tests to the storybook tests

### Screenshot

https://github.com/user-attachments/assets/c76b30c7-9b6f-4b79-b154-2ac45c7bf8cf


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
