### PR TITLE
feat(components): add mutation link templates

### DIFF
--- a/components/src/preact/MutationLinkTemplateContext.tsx
+++ b/components/src/preact/MutationLinkTemplateContext.tsx
@@ -1,0 +1,56 @@
+import { createContext, type Provider } from 'preact';
+import { useContext, useMemo } from 'preact/hooks';
+
+import type { SequenceType } from '../types';
+import type { Deletion, Substitution } from '../utils/mutations';
+import { mutationLinkTemplateSchema } from '../web-components/mutation-link-template-context';
+import { ErrorDisplay } from './components/error-display';
+import { ResizeContainer } from './components/resize-container';
+
+type MutationLinkTemplate = {
+    nucleotideMutation?: string;
+    aminoAcidMutation?: string;
+};
+
+const MutationLinkTemplateContext = createContext<MutationLinkTemplate>({
+    nucleotideMutation: undefined,
+    aminoAcidMutation: undefined,
+});
+
+export const MutationLinkTemplateContextProvider: Provider<MutationLinkTemplate> = ({ value, children }) => {
+    const parseResult = useMemo(() => mutationLinkTemplateSchema.safeParse(value), [value]);
+
+    if (!parseResult.success) {
+        return (
+            <ResizeContainer size={{ width: '100%' }}>
+                <ErrorDisplay error={parseResult.error} layout='vertical' />
+            </ResizeContainer>
+        );
+    }
+
+    return (
+        <MutationLinkTemplateContext.Provider value={parseResult.data}>{children}</MutationLinkTemplateContext.Provider>
+    );
+};
+
+export function useMutationLinkProvider() {
+    const linkTemplate = useContext(MutationLinkTemplateContext);
+
+    return (mutation: Substitution | Deletion, sequenceType: SequenceType) => {
+        switch (sequenceType) {
+            case 'nucleotide': {
+                if (linkTemplate.nucleotideMutation !== undefined) {
+                    return linkTemplate.nucleotideMutation.replace('{{mutation}}', encodeURIComponent(mutation.code));
+                }
+                return undefined;
+            }
+
+            case 'amino acid': {
+                if (linkTemplate.aminoAcidMutation !== undefined) {
+                    return linkTemplate.aminoAcidMutation.replace('{{mutation}}', encodeURIComponent(mutation.code));
+                }
+                return undefined;
+            }
+        }
+    };
+}

--- a/components/src/preact/mutationComparison/mutation-comparison-table.tsx
+++ b/components/src/preact/mutationComparison/mutation-comparison-table.tsx
@@ -6,6 +6,7 @@ import { type Dataset } from '../../operator/Dataset';
 import type { SequenceType } from '../../types';
 import { type DeletionClass, type SubstitutionClass } from '../../utils/mutations';
 import { useMutationAnnotationsProvider } from '../MutationAnnotationsContext';
+import { useMutationLinkProvider } from '../MutationLinkTemplateContext';
 import { GridJsAnnotatedMutation } from '../components/annotated-mutation';
 import { type ProportionInterval } from '../components/proportion-selector';
 import { Table } from '../components/table';
@@ -26,6 +27,7 @@ export const MutationComparisonTable: FunctionComponent<MutationsTableProps> = (
     sequenceType,
 }) => {
     const annotationsProvider = useMutationAnnotationsProvider();
+    const linkProvider = useMutationLinkProvider();
 
     const headers = [
         {
@@ -38,6 +40,7 @@ export const MutationComparisonTable: FunctionComponent<MutationsTableProps> = (
                     mutation={cell}
                     sequenceType={sequenceType}
                     annotationsProvider={annotationsProvider}
+                    linkProvider={linkProvider}
                 />
             ),
         },

--- a/components/src/preact/mutations/mutations-table.tsx
+++ b/components/src/preact/mutations/mutations-table.tsx
@@ -5,6 +5,7 @@ import { getMutationsTableData } from './getMutationsTableData';
 import { type SequenceType, type SubstitutionOrDeletionEntry } from '../../types';
 import { type DeletionClass, type SubstitutionClass } from '../../utils/mutations';
 import { useMutationAnnotationsProvider } from '../MutationAnnotationsContext';
+import { useMutationLinkProvider } from '../MutationLinkTemplateContext';
 import { GridJsAnnotatedMutation } from '../components/annotated-mutation';
 import type { ProportionInterval } from '../components/proportion-selector';
 import { Table } from '../components/table';
@@ -29,6 +30,7 @@ const MutationsTable: FunctionComponent<MutationsTableProps> = ({
     sequenceType,
 }) => {
     const annotationsProvider = useMutationAnnotationsProvider();
+    const linkProvider = useMutationLinkProvider();
 
     const headers = [
         {
@@ -43,6 +45,7 @@ const MutationsTable: FunctionComponent<MutationsTableProps> = ({
                     mutation={cell}
                     sequenceType={sequenceType}
                     annotationsProvider={annotationsProvider}
+                    linkProvider={linkProvider}
                 />
             ),
         },

--- a/components/src/preact/shared/stories/expectMutationAnnotation.ts
+++ b/components/src/preact/shared/stories/expectMutationAnnotation.ts
@@ -6,7 +6,9 @@ export async function expectMutationAnnotation(canvasElement: HTMLElement, mutat
     await waitFor(async () => {
         const annotatedMutation = canvas.getAllByText(mutation)[0];
         await expect(annotatedMutation).toBeVisible();
-        await userEvent.click(annotatedMutation);
+        const button = within(annotatedMutation).getByRole('button');
+        await expect(button).toBeVisible();
+        await userEvent.click(button);
     });
 
     await waitFor(() => expect(canvas.getByText(`Annotations for ${mutation}`)).toBeVisible());

--- a/components/src/web-components/gs-app.spec-d.ts
+++ b/components/src/web-components/gs-app.spec-d.ts
@@ -2,9 +2,16 @@ import { describe, expectTypeOf, test } from 'vitest';
 
 import { AppComponent } from './gs-app';
 import { type MutationAnnotations } from './mutation-annotations-context';
+import { type MutationLinkTemplate } from './mutation-link-template-context';
 
 describe('gs-app types', () => {
     test('mutationAnnotations type should match', () => {
         expectTypeOf(AppComponent.prototype).toHaveProperty('mutationAnnotations').toEqualTypeOf<MutationAnnotations>();
+    });
+
+    test('mutationLinkTemplate type should match', () => {
+        expectTypeOf(AppComponent.prototype)
+            .toHaveProperty('mutationLinkTemplate')
+            .toEqualTypeOf<MutationLinkTemplate>();
     });
 });

--- a/components/src/web-components/gs-app.ts
+++ b/components/src/web-components/gs-app.ts
@@ -7,6 +7,7 @@ import z from 'zod';
 
 import { lapisContext } from './lapis-context';
 import { mutationAnnotationsContext } from './mutation-annotations-context';
+import { mutationLinkTemplateContext } from './mutation-link-template-context';
 import { referenceGenomeContext } from './reference-genome-context';
 import { type ReferenceGenome } from '../lapisApi/ReferenceGenome';
 import { fetchReferenceGenome } from '../lapisApi/lapisApi';
@@ -58,6 +59,22 @@ export class AppComponent extends LitElement {
         aminoAcidMutations?: string[];
         aminoAcidPositions?: string[];
     }[] = [];
+
+    /**
+     * Supply a link template for nucleotide and amino acid mutations.
+     * The template should include '{{mutation}}' where the mutation code will be inserted, for example:
+     *
+     *     https://my-site.org/query?nucleotideMutation={{mutation}}
+     */
+    @provide({ context: mutationLinkTemplateContext })
+    @property({ type: Object })
+    mutationLinkTemplate: {
+        nucleotideMutation?: string;
+        aminoAcidMutation?: string;
+    } = {
+        nucleotideMutation: undefined,
+        aminoAcidMutation: undefined,
+    };
 
     /**
      * @internal

--- a/components/src/web-components/mutation-link-template-context.ts
+++ b/components/src/web-components/mutation-link-template-context.ts
@@ -1,0 +1,13 @@
+import { createContext } from '@lit/context';
+import z from 'zod';
+
+export const mutationLinkTemplateSchema = z.object({
+    nucleotideMutation: z.string().optional(),
+    aminoAcidMutation: z.string().optional(),
+});
+
+export type MutationLinkTemplate = z.infer<typeof mutationLinkTemplateSchema>;
+
+export const mutationLinkTemplateContext = createContext<MutationLinkTemplate>(
+    Symbol('mutation-link-template-context'),
+);

--- a/components/src/web-components/mutationLinks.mdx
+++ b/components/src/web-components/mutationLinks.mdx
@@ -1,0 +1,27 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title='Concepts/External Mutation Links' />
+
+# External Mutation Links
+
+When inspecting mutations, you might want to be able to quickly look up a mutation somewhere else.
+For this, it's possible to supply a _link template_ which will then lead to mutation labels being clickable using
+that link template.
+
+The mutation link template can be (optionally) supplied to `gs-app` as a JSON object:
+
+```html
+<gs-app
+    lapis="https://your.lapis.url"
+    mutationLinkTemplate='{
+        "nucleotideMutation": "https://cov-spectrum.org/explore/Switzerland/AllSamples/Past6M/variants?nucMutations={{mutation}}",
+        "aminoAcidMutation": "https://cov-spectrum.org/explore/Switzerland/AllSamples/Past6M/variants?aaMutations={{mutation}}",
+    }'
+>
+    {/* children... */}
+</gs-app>
+```
+
+For example (like in the code above) you can directly link to cov-spectrum.
+
+Your link needs to have the placeholder `{{mutation}}` in it, which will then be replaced with the mutation code.

--- a/components/src/web-components/visualization/gs-mutation-comparison.tsx
+++ b/components/src/web-components/visualization/gs-mutation-comparison.tsx
@@ -3,10 +3,12 @@ import { customElement, property } from 'lit/decorators.js';
 import type { DetailedHTMLProps, HTMLAttributes } from 'react';
 
 import { MutationAnnotationsContextProvider } from '../../preact/MutationAnnotationsContext';
+import { MutationLinkTemplateContextProvider } from '../../preact/MutationLinkTemplateContext';
 import { MutationComparison, type MutationComparisonProps } from '../../preact/mutationComparison/mutation-comparison';
 import { type Equals, type Expect } from '../../utils/typeAssertions';
 import { PreactLitAdapterWithGridJsStyles } from '../PreactLitAdapterWithGridJsStyles';
 import { type MutationAnnotations, mutationAnnotationsContext } from '../mutation-annotations-context';
+import { type MutationLinkTemplate, mutationLinkTemplateContext } from '../mutation-link-template-context';
 
 /**
  * ## Context
@@ -103,17 +105,25 @@ export class MutationComparisonComponent extends PreactLitAdapterWithGridJsStyle
     @consume({ context: mutationAnnotationsContext, subscribe: true })
     mutationAnnotations: MutationAnnotations = [];
 
+    /**
+     * @internal
+     */
+    @consume({ context: mutationLinkTemplateContext, subscribe: true })
+    mutationLinkTemplate: MutationLinkTemplate = {};
+
     override render() {
         return (
             <MutationAnnotationsContextProvider value={this.mutationAnnotations}>
-                <MutationComparison
-                    lapisFilters={this.lapisFilters}
-                    sequenceType={this.sequenceType}
-                    views={this.views}
-                    width={this.width}
-                    height={this.height}
-                    pageSize={this.pageSize}
-                />
+                <MutationLinkTemplateContextProvider value={this.mutationLinkTemplate}>
+                    <MutationComparison
+                        lapisFilters={this.lapisFilters}
+                        sequenceType={this.sequenceType}
+                        views={this.views}
+                        width={this.width}
+                        height={this.height}
+                        pageSize={this.pageSize}
+                    />
+                </MutationLinkTemplateContextProvider>
             </MutationAnnotationsContextProvider>
         );
     }

--- a/components/src/web-components/visualization/gs-mutations-over-time.stories.ts
+++ b/components/src/web-components/visualization/gs-mutations-over-time.stories.ts
@@ -89,9 +89,20 @@ const mutationAnnotations = [
     },
 ];
 
+const mutationLinkTemplate = {
+    nucleotideMutation:
+        'https://cov-spectrum.org/explore/Switzerland/AllSamples/Past6M/variants?nucMutations={{mutation}}',
+    aminoAcidMutation:
+        'https://cov-spectrum.org/explore/Switzerland/AllSamples/Past6M/variants?aaMutations={{mutation}}',
+};
+
 const Template: StoryObj<Required<MutationsOverTimeProps>> = {
     render: (args) => html`
-        <gs-app lapis="${LAPIS_URL}" .mutationAnnotations=${mutationAnnotations}>
+        <gs-app
+            lapis="${LAPIS_URL}"
+            .mutationAnnotations=${mutationAnnotations}
+            .mutationLinkTemplate=${mutationLinkTemplate}
+        >
             <gs-mutations-over-time
                 .lapisFilter=${args.lapisFilter}
                 .sequenceType=${args.sequenceType}

--- a/components/src/web-components/visualization/gs-mutations-over-time.tsx
+++ b/components/src/web-components/visualization/gs-mutations-over-time.tsx
@@ -3,9 +3,11 @@ import { customElement, property } from 'lit/decorators.js';
 import type { DetailedHTMLProps, HTMLAttributes } from 'react';
 
 import { MutationAnnotationsContextProvider } from '../../preact/MutationAnnotationsContext';
+import { MutationLinkTemplateContextProvider } from '../../preact/MutationLinkTemplateContext';
 import { MutationsOverTime } from '../../preact/mutationsOverTime/mutations-over-time';
 import { PreactLitAdapterWithGridJsStyles } from '../PreactLitAdapterWithGridJsStyles';
 import { type MutationAnnotations, mutationAnnotationsContext } from '../mutation-annotations-context';
+import { type MutationLinkTemplate, mutationLinkTemplateContext } from '../mutation-link-template-context';
 
 /**
  * ## Context
@@ -140,23 +142,31 @@ export class MutationsOverTimeComponent extends PreactLitAdapterWithGridJsStyles
     @consume({ context: mutationAnnotationsContext, subscribe: true })
     mutationAnnotations: MutationAnnotations = [];
 
+    /**
+     * @internal
+     */
+    @consume({ context: mutationLinkTemplateContext, subscribe: true })
+    mutationLinkTemplate: MutationLinkTemplate = {};
+
     override render() {
         return (
             <MutationAnnotationsContextProvider value={this.mutationAnnotations}>
-                <MutationsOverTime
-                    lapisFilter={this.lapisFilter}
-                    sequenceType={this.sequenceType}
-                    views={this.views}
-                    width={this.width}
-                    height={this.height}
-                    granularity={this.granularity}
-                    lapisDateField={this.lapisDateField}
-                    displayMutations={this.displayMutations}
-                    initialMeanProportionInterval={this.initialMeanProportionInterval}
-                    hideGaps={this.hideGaps}
-                    useNewEndpoint={this.useNewEndpoint}
-                    pageSizes={this.pageSizes}
-                />
+                <MutationLinkTemplateContextProvider value={this.mutationLinkTemplate}>
+                    <MutationsOverTime
+                        lapisFilter={this.lapisFilter}
+                        sequenceType={this.sequenceType}
+                        views={this.views}
+                        width={this.width}
+                        height={this.height}
+                        granularity={this.granularity}
+                        lapisDateField={this.lapisDateField}
+                        displayMutations={this.displayMutations}
+                        initialMeanProportionInterval={this.initialMeanProportionInterval}
+                        hideGaps={this.hideGaps}
+                        useNewEndpoint={this.useNewEndpoint}
+                        pageSizes={this.pageSizes}
+                    />
+                </MutationLinkTemplateContextProvider>
             </MutationAnnotationsContextProvider>
         );
     }

--- a/components/src/web-components/visualization/gs-mutations.tsx
+++ b/components/src/web-components/visualization/gs-mutations.tsx
@@ -3,10 +3,12 @@ import { customElement, property } from 'lit/decorators.js';
 import type { DetailedHTMLProps, HTMLAttributes } from 'react';
 
 import { MutationAnnotationsContextProvider } from '../../preact/MutationAnnotationsContext';
+import { MutationLinkTemplateContextProvider } from '../../preact/MutationLinkTemplateContext';
 import { Mutations, type MutationsProps } from '../../preact/mutations/mutations';
 import type { Equals, Expect } from '../../utils/typeAssertions';
 import { PreactLitAdapterWithGridJsStyles } from '../PreactLitAdapterWithGridJsStyles';
 import { type MutationAnnotations, mutationAnnotationsContext } from '../mutation-annotations-context';
+import { type MutationLinkTemplate, mutationLinkTemplateContext } from '../mutation-link-template-context';
 
 /**
  * ## Context
@@ -134,18 +136,26 @@ export class MutationsComponent extends PreactLitAdapterWithGridJsStyles {
     @consume({ context: mutationAnnotationsContext, subscribe: true })
     mutationAnnotations: MutationAnnotations = [];
 
+    /**
+     * @internal
+     */
+    @consume({ context: mutationLinkTemplateContext, subscribe: true })
+    mutationLinkTemplate: MutationLinkTemplate = {};
+
     override render() {
         return (
             <MutationAnnotationsContextProvider value={this.mutationAnnotations}>
-                <Mutations
-                    lapisFilter={this.lapisFilter}
-                    sequenceType={this.sequenceType}
-                    views={this.views}
-                    width={this.width}
-                    height={this.height}
-                    pageSize={this.pageSize}
-                    baselineLapisFilter={this.baselineLapisFilter}
-                />
+                <MutationLinkTemplateContextProvider value={this.mutationLinkTemplate}>
+                    <Mutations
+                        lapisFilter={this.lapisFilter}
+                        sequenceType={this.sequenceType}
+                        views={this.views}
+                        width={this.width}
+                        height={this.height}
+                        pageSize={this.pageSize}
+                        baselineLapisFilter={this.baselineLapisFilter}
+                    />
+                </MutationLinkTemplateContextProvider>
             </MutationAnnotationsContextProvider>
         );
     }

--- a/components/src/web-components/wastewaterVisualization/gs-wastewater-mutations-over-time.tsx
+++ b/components/src/web-components/wastewaterVisualization/gs-wastewater-mutations-over-time.tsx
@@ -3,9 +3,11 @@ import { customElement, property } from 'lit/decorators.js';
 import { type DetailedHTMLProps, type HTMLAttributes } from 'react';
 
 import { MutationAnnotationsContextProvider } from '../../preact/MutationAnnotationsContext';
+import { MutationLinkTemplateContextProvider } from '../../preact/MutationLinkTemplateContext';
 import { WastewaterMutationsOverTime } from '../../preact/wastewater/mutationsOverTime/wastewater-mutations-over-time';
 import { PreactLitAdapterWithGridJsStyles } from '../PreactLitAdapterWithGridJsStyles';
 import { type MutationAnnotations, mutationAnnotationsContext } from '../mutation-annotations-context';
+import { type MutationLinkTemplate, mutationLinkTemplateContext } from '../mutation-link-template-context';
 
 /**
  * ## Context
@@ -79,16 +81,24 @@ export class WastewaterMutationsOverTimeComponent extends PreactLitAdapterWithGr
     @consume({ context: mutationAnnotationsContext, subscribe: true })
     mutationAnnotations: MutationAnnotations = [];
 
+    /**
+     * @internal
+     */
+    @consume({ context: mutationLinkTemplateContext, subscribe: true })
+    mutationLinkTemplate: MutationLinkTemplate = {};
+
     override render() {
         return (
             <MutationAnnotationsContextProvider value={this.mutationAnnotations}>
-                <WastewaterMutationsOverTime
-                    lapisFilter={this.lapisFilter}
-                    sequenceType={this.sequenceType}
-                    width={this.width}
-                    height={this.height}
-                    pageSizes={this.pageSizes}
-                />
+                <MutationLinkTemplateContextProvider value={this.mutationLinkTemplate}>
+                    <WastewaterMutationsOverTime
+                        lapisFilter={this.lapisFilter}
+                        sequenceType={this.sequenceType}
+                        width={this.width}
+                        height={this.height}
+                        pageSizes={this.pageSizes}
+                    />
+                </MutationLinkTemplateContextProvider>
             </MutationAnnotationsContextProvider>
         );
     }


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #985 

### Summary

Adds a new attribute to `gs-app`, `mutationLinkTemplate`:


```html
<gs-app
    lapis="https://your.lapis.url"
    mutationLinkTemplate="{
        nucleotideMutation: 'https://cov-spectrum.org/explore/Switzerland/AllSamples/Past6M/variants?nucMutations={{mutation}}',
        aminoAcidMutation: 'https://cov-spectrum.org/explore/Switzerland/AllSamples/Past6M/variants?aaMutations={{mutation}}'
    }"
>
    {/* children... */}
</gs-app>
```

where you can put a link with the placeholder `{{mutation}}` which will then be replaced by the mutation code.

The `AnnotatedMutation` component has been extended to also take the links into account.

Annotations are now only clickable by clicking the annotation itself, not the whole mutation.

#### Testing

added new tests to the `storybook-preact`

### Screenshot

<img width="524" height="334" alt="image" src="https://github.com/user-attachments/assets/481aff97-04f7-44d7-aa6b-02723d9a276e" />

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
