### PR TITLE
chore(components): export utility types

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -178,3 +178,7 @@ workers that return mocked data. The mock workers are enabled in the package.jso
 Node.js [subpath imports](https://nodejs.org/api/packages.html#subpath-imports), following the guide
 from [storybook](https://storybook.js.org/docs/writing-stories/mocking-data-and-modules/mocking-modules). This ensures
 that when importing the worker in the component, the mock worker is used inside Storybook instead of the real worker.
+
+### Exporting types into the final build
+
+This project uses `vite build`. The release config is `vite.release.config.ts`. In there, the lib export entrypoints are defined. If you want to export a utility type for your component, re-export it inside of `utilEntrypoint.ts`.

--- a/components/src/preact/mutationFilter/mutation-filter.stories.tsx
+++ b/components/src/preact/mutationFilter/mutation-filter.stories.tsx
@@ -6,6 +6,7 @@ import { MutationFilter, type MutationFilterProps } from './mutation-filter';
 import { previewHandles } from '../../../.storybook/preview';
 import { LAPIS_URL } from '../../constants';
 import referenceGenome from '../../lapisApi/__mockData__/referenceGenome.json';
+import { mutationType } from '../../types';
 import { gsEventNames } from '../../utils/gsEventNames';
 import { LapisUrlContextProvider } from '../LapisUrlContext';
 import { ReferenceGenomeContext } from '../ReferenceGenomeContext';
@@ -230,7 +231,7 @@ export const FiltersOutDisabledMutationTypes: StoryObj<MutationFilterProps> = {
     ...Default,
     args: {
         ...Default.args,
-        enabledMutationTypes: ['nucleotideMutations'],
+        enabledMutationTypes: [mutationType.nucleotideMutations],
     },
     play: async ({ canvasElement, step }) => {
         const { canvas, changedListenerMock } = await prepare(canvasElement, step);

--- a/components/src/preact/mutationFilter/mutation-filter.tsx
+++ b/components/src/preact/mutationFilter/mutation-filter.tsx
@@ -7,22 +7,19 @@ import { getExampleMutation } from './ExampleMutation';
 import { MutationFilterInfo } from './mutation-filter-info';
 import { parseAndValidateMutation } from './parseAndValidateMutation';
 import { type ReferenceGenome } from '../../lapisApi/ReferenceGenome';
-import { type MutationsFilter, mutationsFilterSchema } from '../../types';
+import {
+    type MutationsFilter,
+    mutationsFilterSchema,
+    mutationType,
+    mutationTypeSchema,
+    type MutationType,
+} from '../../types';
 import { gsEventNames } from '../../utils/gsEventNames';
 import { type DeletionClass, type InsertionClass, type SubstitutionClass } from '../../utils/mutations';
 import { ReferenceGenomeContext } from '../ReferenceGenomeContext';
 import { ErrorBoundary } from '../components/error-boundary';
 import { UserFacingError } from '../components/error-display';
 import { singleGraphColorRGBByName } from '../shared/charts/colors';
-
-const mutationTypeSchema = z.enum([
-    'nucleotideMutations',
-    'aminoAcidMutations',
-    'nucleotideInsertions',
-    'aminoAcidInsertions',
-]);
-
-export type MutationType = z.infer<typeof mutationTypeSchema>;
 
 const mutationFilterInnerPropsSchema = z.object({
     initialValue: z.union([mutationsFilterSchema.optional(), z.array(z.string()), z.undefined()]),
@@ -37,22 +34,22 @@ export type MutationFilterInnerProps = z.infer<typeof mutationFilterInnerPropsSc
 export type MutationFilterProps = z.infer<typeof mutationFilterPropsSchema>;
 
 type SelectedNucleotideMutation = {
-    type: 'nucleotideMutations';
+    type: typeof mutationType.nucleotideMutations;
     value: SubstitutionClass | DeletionClass;
 };
 
 type SelectedAminoAcidMutation = {
-    type: 'aminoAcidMutations';
+    type: typeof mutationType.aminoAcidMutations;
     value: SubstitutionClass | DeletionClass;
 };
 
 type SelectedNucleotideInsertion = {
-    type: 'nucleotideInsertions';
+    type: typeof mutationType.nucleotideInsertions;
     value: InsertionClass;
 };
 
 type SelectedAminoAcidInsertion = {
-    type: 'aminoAcidInsertions';
+    type: typeof mutationType.aminoAcidInsertions;
     value: InsertionClass;
 };
 
@@ -80,7 +77,7 @@ export const MutationFilter: FunctionComponent<MutationFilterProps> = (props) =>
 
 function MutationFilterInner({
     initialValue,
-    enabledMutationTypes = ['nucleotideMutations', 'nucleotideInsertions', 'aminoAcidMutations', 'aminoAcidInsertions'],
+    enabledMutationTypes = Object.values(mutationType),
 }: MutationFilterInnerProps) {
     const referenceGenome = useContext(ReferenceGenomeContext);
     const filterRef = useRef<HTMLDivElement>(null);
@@ -309,16 +306,16 @@ function getInitialState(
 function getPlaceholder(referenceGenome: ReferenceGenome, enabledMutationTypes: MutationType[]) {
     const exampleMutationList = [];
 
-    if (enabledMutationTypes.includes('nucleotideMutations')) {
+    if (enabledMutationTypes.includes(mutationType.nucleotideMutations)) {
         exampleMutationList.push(getExampleMutation(referenceGenome, 'nucleotide', 'substitution'));
     }
-    if (enabledMutationTypes.includes('nucleotideInsertions')) {
+    if (enabledMutationTypes.includes(mutationType.nucleotideInsertions)) {
         exampleMutationList.push(getExampleMutation(referenceGenome, 'nucleotide', 'insertion'));
     }
-    if (enabledMutationTypes.includes('aminoAcidMutations')) {
+    if (enabledMutationTypes.includes(mutationType.aminoAcidMutations)) {
         exampleMutationList.push(getExampleMutation(referenceGenome, 'amino acid', 'substitution'));
     }
-    if (enabledMutationTypes.includes('aminoAcidInsertions')) {
+    if (enabledMutationTypes.includes(mutationType.aminoAcidInsertions)) {
         exampleMutationList.push(getExampleMutation(referenceGenome, 'amino acid', 'insertion'));
     }
 
@@ -329,13 +326,13 @@ function getPlaceholder(referenceGenome: ReferenceGenome, enabledMutationTypes: 
 
 const backgroundColorMap = (data: MutationFilterItem, alpha: number = 0.4) => {
     switch (data.type) {
-        case 'nucleotideMutations':
+        case mutationType.nucleotideMutations:
             return singleGraphColorRGBByName('green', alpha);
-        case 'aminoAcidMutations':
+        case mutationType.aminoAcidMutations:
             return singleGraphColorRGBByName('teal', alpha);
-        case 'nucleotideInsertions':
+        case mutationType.nucleotideInsertions:
             return singleGraphColorRGBByName('indigo', alpha);
-        case 'aminoAcidInsertions':
+        case mutationType.aminoAcidInsertions:
             return singleGraphColorRGBByName('purple', alpha);
     }
 };
@@ -370,13 +367,13 @@ function mapToMutationFilterStrings(selectedFilters: MutationFilterItem[]) {
     return selectedFilters.reduce<MutationsFilter>(
         (acc, filter) => {
             switch (filter.type) {
-                case 'nucleotideMutations':
+                case mutationType.nucleotideMutations:
                     return { ...acc, nucleotideMutations: [...acc.nucleotideMutations, filter.value.toString()] };
-                case 'aminoAcidMutations':
+                case mutationType.aminoAcidMutations:
                     return { ...acc, aminoAcidMutations: [...acc.aminoAcidMutations, filter.value.toString()] };
-                case 'nucleotideInsertions':
+                case mutationType.nucleotideInsertions:
                     return { ...acc, nucleotideInsertions: [...acc.nucleotideInsertions, filter.value.toString()] };
-                case 'aminoAcidInsertions':
+                case mutationType.aminoAcidInsertions:
                     return { ...acc, aminoAcidInsertions: [...acc.aminoAcidInsertions, filter.value.toString()] };
             }
         },

--- a/components/src/preact/mutationFilter/parseAndValidateMutation.ts
+++ b/components/src/preact/mutationFilter/parseAndValidateMutation.ts
@@ -1,7 +1,7 @@
 import { type MutationFilterItem } from './mutation-filter';
 import { sequenceTypeFromSegment } from './sequenceTypeFromSegment';
 import type { ReferenceGenome } from '../../lapisApi/ReferenceGenome';
-import type { SequenceType } from '../../types';
+import { type SequenceType, mutationType } from '../../types';
 import { DeletionClass, InsertionClass, type Mutation, SubstitutionClass } from '../../utils/mutations';
 
 export const parseAndValidateMutation = (
@@ -22,11 +22,11 @@ export const parseAndValidateMutation = (
 
 const getSequenceType = (type: MutationFilterItem['type']) => {
     switch (type) {
-        case 'nucleotideInsertions':
-        case 'nucleotideMutations':
+        case mutationType.nucleotideInsertions:
+        case mutationType.nucleotideMutations:
             return 'nucleotide';
-        case 'aminoAcidInsertions':
-        case 'aminoAcidMutations':
+        case mutationType.aminoAcidInsertions:
+        case mutationType.aminoAcidMutations:
             return 'amino acid';
     }
 };
@@ -37,10 +37,10 @@ const parseMutation = (value: string, referenceGenome: ReferenceGenome): Mutatio
         const sequenceType = sequenceTypeFromSegment(possibleInsertion.segment, referenceGenome);
         switch (sequenceType) {
             case 'nucleotide': {
-                return { type: 'nucleotideInsertions', value: possibleInsertion };
+                return { type: mutationType.nucleotideInsertions, value: possibleInsertion };
             }
             case 'amino acid':
-                return { type: 'aminoAcidInsertions', value: possibleInsertion };
+                return { type: mutationType.aminoAcidInsertions, value: possibleInsertion };
             case undefined:
                 return null;
         }
@@ -51,9 +51,9 @@ const parseMutation = (value: string, referenceGenome: ReferenceGenome): Mutatio
         const sequenceType = sequenceTypeFromSegment(possibleDeletion.segment, referenceGenome);
         switch (sequenceType) {
             case 'nucleotide':
-                return { type: 'nucleotideMutations', value: possibleDeletion };
+                return { type: mutationType.nucleotideMutations, value: possibleDeletion };
             case 'amino acid':
-                return { type: 'aminoAcidMutations', value: possibleDeletion };
+                return { type: mutationType.aminoAcidMutations, value: possibleDeletion };
             case undefined:
                 return null;
         }
@@ -64,10 +64,10 @@ const parseMutation = (value: string, referenceGenome: ReferenceGenome): Mutatio
         const sequenceType = sequenceTypeFromSegment(possibleSubstitution.segment, referenceGenome);
         switch (sequenceType) {
             case 'nucleotide': {
-                return { type: 'nucleotideMutations', value: possibleSubstitution };
+                return { type: mutationType.nucleotideMutations, value: possibleSubstitution };
             }
             case 'amino acid': {
-                return { type: 'aminoAcidMutations', value: possibleSubstitution };
+                return { type: mutationType.aminoAcidMutations, value: possibleSubstitution };
             }
 
             case undefined:

--- a/components/src/preact/mutationFilter/parseMutation.spec.ts
+++ b/components/src/preact/mutationFilter/parseMutation.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { parseAndValidateMutation } from './parseAndValidateMutation';
+import { mutationType } from '../../types';
 import { DeletionClass, InsertionClass, SubstitutionClass } from '../../utils/mutations';
 
 describe('parseMutation', () => {
@@ -28,32 +29,32 @@ describe('parseMutation', () => {
             {
                 name: 'should parse nucleotide insertions',
                 input: 'ins_3:ACGT',
-                expected: { type: 'nucleotideInsertions', value: new InsertionClass(undefined, 3, 'ACGT') },
+                expected: { type: mutationType.nucleotideInsertions, value: new InsertionClass(undefined, 3, 'ACGT') },
             },
             {
                 name: 'should parse amino acid insertions',
                 input: 'ins_gene1:3:ACGT',
-                expected: { type: 'aminoAcidInsertions', value: new InsertionClass('gene1', 3, 'ACGT') },
+                expected: { type: mutationType.aminoAcidInsertions, value: new InsertionClass('gene1', 3, 'ACGT') },
             },
             {
                 name: 'should parse amino acid insertions in all upper case',
                 input: 'INS_GENE1:3:ACGT',
-                expected: { type: 'aminoAcidInsertions', value: new InsertionClass('GENE1', 3, 'ACGT') },
+                expected: { type: mutationType.aminoAcidInsertions, value: new InsertionClass('GENE1', 3, 'ACGT') },
             },
             {
                 name: 'should parse amino acid insertions in all lower case',
                 input: 'ins_gene1:3:acgt',
-                expected: { type: 'aminoAcidInsertions', value: new InsertionClass('gene1', 3, 'acgt') },
+                expected: { type: mutationType.aminoAcidInsertions, value: new InsertionClass('gene1', 3, 'acgt') },
             },
             {
                 name: 'should parse amino acid insertion with LAPIS-style wildcard',
                 input: 'ins_gene1:3:?AC?GT',
-                expected: { type: 'aminoAcidInsertions', value: new InsertionClass('gene1', 3, '?AC?GT') },
+                expected: { type: mutationType.aminoAcidInsertions, value: new InsertionClass('gene1', 3, '?AC?GT') },
             },
             {
                 name: 'should parse amino acid insertion with SILO-style wildcard',
                 input: 'ins_gene1:3:.*AC.*GT',
-                expected: { type: 'aminoAcidInsertions', value: new InsertionClass('gene1', 3, '.*AC.*GT') },
+                expected: { type: mutationType.aminoAcidInsertions, value: new InsertionClass('gene1', 3, '.*AC.*GT') },
             },
             {
                 name: 'should return null for insertion with segment not in reference genome',
@@ -71,42 +72,42 @@ describe('parseMutation', () => {
             {
                 name: 'should parse nucleotide deletion in single segmented reference genome, when no segment is given',
                 input: 'A3-',
-                expected: { type: 'nucleotideMutations', value: new DeletionClass(undefined, 'A', 3) },
+                expected: { type: mutationType.nucleotideMutations, value: new DeletionClass(undefined, 'A', 3) },
             },
             {
                 name: 'should parse nucleotide deletion without valueAtReference when no segment is given',
                 input: '3-',
-                expected: { type: 'nucleotideMutations', value: new DeletionClass(undefined, undefined, 3) },
+                expected: { type: mutationType.nucleotideMutations, value: new DeletionClass(undefined, undefined, 3) },
             },
             {
                 name: 'should parse nucleotide deletion',
                 input: 'nuc1:A3-',
-                expected: { type: 'nucleotideMutations', value: new DeletionClass('nuc1', 'A', 3) },
+                expected: { type: mutationType.nucleotideMutations, value: new DeletionClass('nuc1', 'A', 3) },
             },
             {
                 name: 'should parse nucleotide deletion without valueAtReference',
                 input: 'nuc1:3-',
-                expected: { type: 'nucleotideMutations', value: new DeletionClass('nuc1', undefined, 3) },
+                expected: { type: mutationType.nucleotideMutations, value: new DeletionClass('nuc1', undefined, 3) },
             },
             {
                 name: 'should parse amino acid deletion',
                 input: 'gene1:A3-',
-                expected: { type: 'aminoAcidMutations', value: new DeletionClass('gene1', 'A', 3) },
+                expected: { type: mutationType.aminoAcidMutations, value: new DeletionClass('gene1', 'A', 3) },
             },
             {
                 name: 'should parse amino acid deletion in all upper case',
                 input: 'GENE1:A3-',
-                expected: { type: 'aminoAcidMutations', value: new DeletionClass('GENE1', 'A', 3) },
+                expected: { type: mutationType.aminoAcidMutations, value: new DeletionClass('GENE1', 'A', 3) },
             },
             {
                 name: 'should parse amino acid deletion in all lower case',
                 input: 'gene1:a3-',
-                expected: { type: 'aminoAcidMutations', value: new DeletionClass('gene1', 'a', 3) },
+                expected: { type: mutationType.aminoAcidMutations, value: new DeletionClass('gene1', 'a', 3) },
             },
             {
                 name: 'should parse amino acid deletion without valueAtReference',
                 input: 'gene1:3-',
-                expected: { type: 'aminoAcidMutations', value: new DeletionClass('gene1', undefined, 3) },
+                expected: { type: mutationType.aminoAcidMutations, value: new DeletionClass('gene1', undefined, 3) },
             },
             {
                 name: 'should return null for deletion with segment not in reference genome',
@@ -123,45 +124,54 @@ describe('parseMutation', () => {
             {
                 name: 'should parse nucleotide substitution in single segmented reference genome, when no segment is given',
                 input: 'A3T',
-                expected: { type: 'nucleotideMutations', value: new SubstitutionClass(undefined, 'A', 'T', 3) },
+                expected: {
+                    type: mutationType.nucleotideMutations,
+                    value: new SubstitutionClass(undefined, 'A', 'T', 3),
+                },
             },
             {
                 name: 'should parse substitution without valueAtReference',
                 input: '3T',
-                expected: { type: 'nucleotideMutations', value: new SubstitutionClass(undefined, undefined, 'T', 3) },
+                expected: {
+                    type: mutationType.nucleotideMutations,
+                    value: new SubstitutionClass(undefined, undefined, 'T', 3),
+                },
             },
             {
                 name: 'should parse substitution with neither valueAtReference not substitutionValue',
                 input: '3',
                 expected: {
-                    type: 'nucleotideMutations',
+                    type: mutationType.nucleotideMutations,
                     value: new SubstitutionClass(undefined, undefined, undefined, 3),
                 },
             },
             {
                 name: 'should parse a "no mutation" substitution',
                 input: '3.',
-                expected: { type: 'nucleotideMutations', value: new SubstitutionClass(undefined, undefined, '.', 3) },
+                expected: {
+                    type: mutationType.nucleotideMutations,
+                    value: new SubstitutionClass(undefined, undefined, '.', 3),
+                },
             },
             {
                 name: 'should parse nucleotide substitution',
                 input: 'nuc1:A3T',
-                expected: { type: 'nucleotideMutations', value: new SubstitutionClass('nuc1', 'A', 'T', 3) },
+                expected: { type: mutationType.nucleotideMutations, value: new SubstitutionClass('nuc1', 'A', 'T', 3) },
             },
             {
                 name: 'should parse amino acid substitution',
                 input: 'gene1:A3T',
-                expected: { type: 'aminoAcidMutations', value: new SubstitutionClass('gene1', 'A', 'T', 3) },
+                expected: { type: mutationType.aminoAcidMutations, value: new SubstitutionClass('gene1', 'A', 'T', 3) },
             },
             {
                 name: 'should parse amino acid substitution in all upper case',
                 input: 'GENE1:A3T',
-                expected: { type: 'aminoAcidMutations', value: new SubstitutionClass('GENE1', 'A', 'T', 3) },
+                expected: { type: mutationType.aminoAcidMutations, value: new SubstitutionClass('GENE1', 'A', 'T', 3) },
             },
             {
                 name: 'should parse amino acid substitution in all lower case',
                 input: 'gene1:a3t',
-                expected: { type: 'aminoAcidMutations', value: new SubstitutionClass('gene1', 'a', 't', 3) },
+                expected: { type: mutationType.aminoAcidMutations, value: new SubstitutionClass('gene1', 'a', 't', 3) },
             },
             {
                 name: 'should return null for substitution with segment not in reference genome',

--- a/components/src/preact/mutationsOverTime/mutations-over-time.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.tsx
@@ -47,6 +47,12 @@ import { useWebWorker } from '../webWorkers/useWebWorker';
 const mutationsOverTimeViewSchema = z.literal(views.grid);
 export type MutationsOverTimeView = z.infer<typeof mutationsOverTimeViewSchema>;
 
+const meanProportionIntervalSchema = z.object({
+    min: z.number().min(0).max(1),
+    max: z.number().min(0).max(1),
+});
+export type MeanProportionInterval = z.infer<typeof meanProportionIntervalSchema>;
+
 const mutationOverTimeSchema = z.object({
     lapisFilter: lapisFilterSchema,
     sequenceType: sequenceTypeSchema,
@@ -55,10 +61,7 @@ const mutationOverTimeSchema = z.object({
     lapisDateField: z.string().min(1),
     useNewEndpoint: z.boolean().optional(),
     displayMutations: displayMutationsSchema.optional(),
-    initialMeanProportionInterval: z.object({
-        min: z.number().min(0).max(1),
-        max: z.number().min(0).max(1),
-    }),
+    initialMeanProportionInterval: meanProportionIntervalSchema,
     hideGaps: z.boolean().optional(),
     width: z.string(),
     height: z.string().optional(),

--- a/components/src/types.ts
+++ b/components/src/types.ts
@@ -44,7 +44,7 @@ export type SequenceType = z.infer<typeof sequenceTypeSchema>;
 
 export type SubstitutionOrDeletion = 'substitution' | 'deletion';
 
-export type MutationType = SubstitutionOrDeletion | 'insertion';
+export type SubstitutionOrDeletionOrInsertion = SubstitutionOrDeletion | 'insertion';
 
 export type SubstitutionEntry<T extends Substitution = SubstitutionClass> = {
     type: 'substitution';
@@ -79,3 +79,19 @@ export const views = {
     bubble: 'bubble',
     map: 'map',
 } as const;
+
+export const mutationType = {
+    nucleotideMutations: 'nucleotideMutations',
+    nucleotideInsertions: 'nucleotideInsertions',
+    aminoAcidMutations: 'aminoAcidMutations',
+    aminoAcidInsertions: 'aminoAcidInsertions',
+} as const;
+
+export const mutationTypeSchema = z.enum([
+    mutationType.nucleotideMutations,
+    mutationType.nucleotideInsertions,
+    mutationType.aminoAcidMutations,
+    mutationType.aminoAcidInsertions,
+]);
+
+export type MutationType = z.infer<typeof mutationTypeSchema>;

--- a/components/src/utilEntrypoint.ts
+++ b/components/src/utilEntrypoint.ts
@@ -12,6 +12,8 @@ export {
     views,
     type TemporalGranularity,
     type MutationsFilter,
+    mutationType,
+    type MutationType,
 } from './types';
 
 export type { MutationComparisonView, MutationComparisonProps } from './preact/mutationComparison/mutation-comparison';
@@ -47,3 +49,5 @@ export {
     NumberRangeFilterChangedEvent,
     NumberRangeValueChangedEvent,
 } from './preact/numberRangeFilter/NumberRangeFilterChangedEvent';
+
+export { type MeanProportionInterval } from './preact/mutationsOverTime/mutations-over-time';

--- a/components/src/utils/mutations.ts
+++ b/components/src/utils/mutations.ts
@@ -1,9 +1,9 @@
-import { type MutationType, type SequenceType } from '../types';
+import { type SubstitutionOrDeletionOrInsertion, type SequenceType } from '../types';
 
 export interface Mutation {
     readonly position: number;
     readonly code: string;
-    readonly type: MutationType;
+    readonly type: SubstitutionOrDeletionOrInsertion;
     readonly segment?: string;
 }
 

--- a/components/src/web-components/input/gs-mutation-filter.stories.ts
+++ b/components/src/web-components/input/gs-mutation-filter.stories.ts
@@ -7,6 +7,7 @@ import { previewHandles } from '../../../.storybook/preview';
 import { LAPIS_URL, REFERENCE_GENOME_ENDPOINT } from '../../constants';
 import '../gs-app';
 import { type MutationFilterProps } from '../../preact/mutationFilter/mutation-filter';
+import { mutationType } from '../../types';
 import { gsEventNames } from '../../utils/gsEventNames';
 import { withinShadowRoot } from '../withinShadowRoot.story';
 import './gs-mutation-filter';
@@ -117,7 +118,7 @@ export const RestrictEnabledMutationTypes: StoryObj<MutationFilterProps> = {
     ...Template,
     args: {
         ...Template.args,
-        enabledMutationTypes: ['nucleotideMutations', 'aminoAcidMutations'],
+        enabledMutationTypes: [mutationType.nucleotideMutations, mutationType.aminoAcidMutations],
     },
     play: async ({ canvasElement }) => {
         const canvas = await withinShadowRoot(canvasElement, 'gs-mutation-filter');

--- a/components/src/web-components/input/gs-mutation-filter.tsx
+++ b/components/src/web-components/input/gs-mutation-filter.tsx
@@ -2,12 +2,8 @@ import { customElement, property } from 'lit/decorators.js';
 import type { DetailedHTMLProps, HTMLAttributes } from 'react';
 
 import { ReferenceGenomesAwaiter } from '../../preact/components/ReferenceGenomesAwaiter';
-import {
-    MutationFilter,
-    type MutationType,
-    type MutationFilterProps,
-} from '../../preact/mutationFilter/mutation-filter';
-import type { MutationsFilter } from '../../types';
+import { MutationFilter, type MutationFilterProps } from '../../preact/mutationFilter/mutation-filter';
+import type { MutationType, MutationsFilter } from '../../types';
 import { type gsEventNames } from '../../utils/gsEventNames';
 import type { Equals, Expect } from '../../utils/typeAssertions';
 import { PreactLitAdapter } from '../PreactLitAdapter';


### PR DESCRIPTION
resolves #983 , also relevant for https://github.com/GenSpectrum/dashboards/pull/833

### Summary

Export `MeanProportionInterval` and `MutationType`.

Add a little README snippet about exporting types.

### Screenshot
n/a

### PR Checklist
- [x] All necessary documentation has been adapted.
- ~~The implemented feature is covered by an appropriate test.~~
