### PR TITLE
feat(components): use digit grouping separators in dropdown filter counts

### DIFF
--- a/components/src/preact/lineageFilter/lineage-filter.stories.tsx
+++ b/components/src/preact/lineageFilter/lineage-filter.stories.tsx
@@ -108,7 +108,7 @@ export const Default: StoryObj<LineageFilterProps> = {
             const input = await inputField(canvas);
             await userEvent.clear(input);
             await userEvent.type(input, 'B.1');
-            await userEvent.click(canvas.getByRole('option', { name: 'B.1(53802)' }));
+            await userEvent.click(canvas.getByRole('option', { name: 'B.1(53,802)' }));
 
             await waitFor(() => {
                 return expect(lineageChangedListenerMock.mock.calls.at(-1)![0].detail).toStrictEqual({

--- a/components/src/preact/lineageFilter/lineage-filter.tsx
+++ b/components/src/preact/lineageFilter/lineage-filter.tsx
@@ -99,7 +99,7 @@ const LineageSelector = ({
             formatItemInList={(item: LineageItem) => (
                 <p>
                     <span>{item.lineage}</span>
-                    {!hideCounts && <span className='ml-2 text-gray-500'>({item.count})</span>}
+                    {!hideCounts && <span className='ml-2 text-gray-500'>({item.count.toLocaleString('en-US')})</span>}
                 </p>
             )}
         />

--- a/components/src/preact/locationFilter/location-filter.tsx
+++ b/components/src/preact/locationFilter/location-filter.tsx
@@ -112,7 +112,9 @@ const LocationSelector = ({
                 <>
                     <p>
                         <span>{item.label}</span>
-                        {!hideCounts && <span className='ml-2 text-gray-500'>({item.count})</span>}
+                        {!hideCounts && (
+                            <span className='ml-2 text-gray-500'>({item.count.toLocaleString('en-US')})</span>
+                        )}
                     </p>
                     <span className='text-sm text-gray-500'>{item.description}</span>
                 </>

--- a/components/src/preact/textFilter/text-filter.tsx
+++ b/components/src/preact/textFilter/text-filter.tsx
@@ -100,7 +100,9 @@ const TextSelector = ({
                 return (
                     <p>
                         <span>{item.value}</span>
-                        {!hideCounts && <span className='ml-2 text-gray-500'>({item.count})</span>}
+                        {!hideCounts && (
+                            <span className='ml-2 text-gray-500'>({item.count.toLocaleString('en-US')})</span>
+                        )}
                     </p>
                 );
             }}

--- a/components/src/web-components/input/gs-lineage-filter.stories.ts
+++ b/components/src/web-components/input/gs-lineage-filter.stories.ts
@@ -229,7 +229,7 @@ export const FiresEvent: StoryObj<Required<LineageFilterProps>> = {
 
         await step('Enter a valid lineage value', async () => {
             await userEvent.type(inputField(), 'B.1.1.7*');
-            await userEvent.click(canvas.getByRole('option', { name: 'B.1.1.7*(677146)' }));
+            await userEvent.click(canvas.getByRole('option', { name: 'B.1.1.7*(677,146)' }));
 
             await waitFor(() => {
                 return expect(listenerMock.mock.calls.at(-1)![0].detail).toStrictEqual({


### PR DESCRIPTION
resolves #969 

### Summary

- Adds `,` in separators. We're using a fixed locale because nothing is localized.

No screenshots need to be regenerated, because we only have screenshots for the plotting components (not the input components)

### Screenshot

<img width="409" height="393" alt="image" src="https://github.com/user-attachments/assets/15650305-f8dd-48cf-974e-0e0ccdb8111f" />

### PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
