### PR TITLE
WIP - fix tooltip not showing

### DIFF
--- a/components/src/preact/components/tooltip.tsx
+++ b/components/src/preact/components/tooltip.tsx
@@ -1,5 +1,7 @@
+import { computePosition, flip, offset, shift, type Placement } from '@floating-ui/dom';
 import { type FunctionComponent } from 'preact';
-import { type CSSProperties } from 'preact/compat';
+import { createPortal, type CSSProperties } from 'preact/compat';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import { type JSXInternal } from 'preact/src/jsx';
 
 export type TooltipPosition =
@@ -18,40 +20,72 @@ export type TooltipProps = {
     tooltipStyle?: CSSProperties;
 };
 
-function getPositionCss(position?: TooltipPosition) {
-    switch (position) {
-        case 'top':
-            return 'bottom-full translate-x-[-50%] left-1/2 mb-1';
-        case 'top-start':
-            return 'bottom-full mr-1 mb-1';
-        case 'top-end':
-            return 'bottom-full right-0 ml-1 mb-1';
-        case 'bottom':
-            return 'top-full translate-x-[-50%] left-1/2 mt-1';
-        case 'bottom-start':
-            return 'mr-1 mt-1';
-        case 'bottom-end':
-            return 'right-0 ml-1 mt-1';
-        case 'left':
-            return 'right-full translate-y-[-50%] top-1/2 mr-1';
-        case 'right':
-            return 'left-full translate-y-[-50%] top-1/2 ml-1';
-        case undefined:
-            return '';
-    }
-}
-
 const Tooltip: FunctionComponent<TooltipProps> = ({ children, content, position = 'bottom', tooltipStyle }) => {
+    const triggerRef = useRef<HTMLDivElement>(null);
+    const tooltipRef = useRef<HTMLDivElement>(null);
+    const [isHovered, setIsHovered] = useState(false);
+    const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 });
+
+    useEffect(() => {
+        if (!isHovered || !triggerRef.current || !tooltipRef.current) {
+            return;
+        }
+
+        const updatePosition = async () => {
+            if (!triggerRef.current || !tooltipRef.current) {
+                return;
+            }
+
+            const { x, y } = await computePosition(triggerRef.current, tooltipRef.current, {
+                placement: position ?? 'bottom',
+                middleware: [
+                    offset(8), // 8px gap between trigger and tooltip
+                    flip(), // Flip to opposite side if no space
+                    shift({ padding: 8 }), // Shift along the axis to keep it in view
+                ],
+            });
+
+            setTooltipPosition({ x, y });
+        };
+
+        updatePosition();
+    }, [isHovered, position]);
+
     return (
-        <div className={`relative group`}>
-            <div>{children}</div>
+        <>
             <div
-                className={`absolute z-10 w-max bg-white p-4 border border-gray-200 rounded-md invisible group-hover:visible ${getPositionCss(position)}`}
-                style={tooltipStyle}
+                ref={triggerRef}
+                onMouseEnter={() => setIsHovered(true)}
+                onMouseLeave={() => setIsHovered(false)}
             >
-                {content}
+                {children}
             </div>
-        </div>
+            {isHovered &&
+                createPortal(
+                    <div
+                        ref={tooltipRef}
+                        style={{
+                            position: 'absolute',
+                            top: 0,
+                            left: 0,
+                            transform: `translate(${Math.round(tooltipPosition.x)}px, ${Math.round(tooltipPosition.y)}px)`,
+                            zIndex: 9999,
+                            backgroundColor: 'white',
+                            padding: '1rem',
+                            border: '1px solid #e5e7eb',
+                            borderRadius: '0.375rem',
+                            maxWidth: '20rem',
+                            boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
+                            fontSize: '0.875rem',
+                            lineHeight: '1.25rem',
+                            ...tooltipStyle,
+                        }}
+                    >
+                        {content}
+                    </div>,
+                    document.body,
+                )}
+        </>
     );
 };
 


### PR DESCRIPTION
This PR adresses #984, #981

### Summary

#981 mentions that there is a problem with scroll bars/overflow inside the tab, and in #984 we found that the tooltips are cut off. This is actually the same problem: The tooltips cause the overflow, even when they are not visible.

With Claude I found a solution using Portals. This however breaks the styling.

I'm not sure if there are other, simpler ways to fix this; I think because we're working with web components, it's maybe not so easy?

### Screenshot

https://github.com/user-attachments/assets/428b9fa0-bd34-40e7-85b7-9374c92e4372

(styling is currently not working)

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
