### PR TITLE
fix(components): fix non-resetting lineage filter

### DIFF
--- a/components/src/preact/components/downshift-combobox.tsx
+++ b/components/src/preact/components/downshift-combobox.tsx
@@ -64,6 +64,7 @@ export function DownshiftCombobox<Item>({
         getItemProps,
         inputValue,
         closeMenu,
+        reset,
     } = useCombobox({
         onInputValueChange({ inputValue }) {
             setInputIsInvalid(false);
@@ -97,7 +98,7 @@ export function DownshiftCombobox<Item>({
     };
 
     const clearInput = () => {
-        selectItem(null);
+        reset();
     };
 
     const buttonRef = useRef(null);

--- a/components/src/preact/lineageFilter/lineage-filter.stories.tsx
+++ b/components/src/preact/lineageFilter/lineage-filter.stories.tsx
@@ -187,6 +187,62 @@ export const WithHideCountsTrue: StoryObj<LineageFilterProps> = {
     },
 };
 
+export const EnterAndClearMultipleTimes: StoryObj<LineageFilterProps> = {
+    ...Default,
+    play: async ({ canvasElement, step }) => {
+        const { canvas, lineageChangedListenerMock } = await prepare(canvasElement, step);
+        const input = await inputField(canvas);
+        const inputContainer = canvas.getByRole('combobox').parentElement;
+        const clearSelectionButton = await canvas.findByLabelText('clear selection');
+
+        await step('clear field initially', async () => {
+            await userEvent.clear(input);
+        });
+
+        await step('enter F in the input field', async () => {
+            await userEvent.type(input, 'F');
+        });
+
+        await step('clear selection using clear button', async () => {
+            await userEvent.click(clearSelectionButton);
+
+            await waitFor(() => {
+                return expect(lineageChangedListenerMock.mock.calls.at(-1)![0].detail).toStrictEqual({
+                    pangoLineage: undefined,
+                });
+            });
+        });
+
+        await step('verify input field is empty after clearing', async () => {
+            await expect(input).toHaveValue('');
+        });
+
+        await step('verify no red border after clearing', async () => {
+            await expect(inputContainer).not.toHaveClass('input-error');
+        });
+
+        // do it again
+
+        await step('enter F in the input field again', async () => {
+            await userEvent.type(input, 'F');
+        });
+
+        await step('clear selection using clear button again', async () => {
+            await userEvent.click(clearSelectionButton);
+
+            await waitFor(() => {
+                return expect(lineageChangedListenerMock.mock.calls.at(-1)![0].detail).toStrictEqual({
+                    pangoLineage: undefined,
+                });
+            });
+        });
+
+        await step('verify input field is empty after clearing again', async () => {
+            await expect(input).toHaveValue('');
+        });
+    },
+};
+
 async function prepare(canvasElement: HTMLElement, step: StepFunction<PreactRenderer, unknown>) {
     const canvas = within(canvasElement);
 

--- a/components/src/web-components/input/gs-text-filter.stories.ts
+++ b/components/src/web-components/input/gs-text-filter.stories.ts
@@ -162,7 +162,7 @@ export const FiresEvents: StoryObj<Required<TextFilterProps>> = {
         await step('Remove initial value', async () => {
             await userEvent.click(canvas.getByRole('button', { name: 'clear selection' }));
 
-            await expect(listenerMock).toHaveBeenLastCalledWith(
+            await expect(listenerMock).toHaveBeenCalledWith(
                 expect.objectContaining({
                     detail: {
                         host: undefined,


### PR DESCRIPTION
resolves #929

### Summary

- use the downshift provided `reset` function to fix the issue.
- Add a test for it. It's pretty elaborate, because I had other solutions first that fixed things partially. I'd like to keep the test structure the way it is.

### Screenshot

https://github.com/user-attachments/assets/39bb9b91-f6eb-4085-aafe-7e4b90600325

### PR Checklist
- ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
