### PR TITLE
fix(components): make annotation list scrollable

### DIFF
--- a/components/src/preact/components/mutations-over-time-mutations-filter.tsx
+++ b/components/src/preact/components/mutations-over-time-mutations-filter.tsx
@@ -105,7 +105,7 @@ const AnnotationCheckboxes: FunctionComponent<MutationsOverTimeMutationsFilterPr
             <div className='divider mt-0.5 mb-0' />
             <div className='text-sm'>
                 <div className='font-bold mb-1'>Filter by annotations</div>
-                <div className='h-72 overflow-scroll'>
+                <div className='max-h-72 overflow-scroll'>
                     {mutationAnnotations.map((annotation, index) => (
                         <li className='flex flex-row items-center' key={annotation.name}>
                             <label>

--- a/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
@@ -64,14 +64,6 @@ const mutationAnnotations = [
     },
 ] satisfies MutationAnnotations;
 
-const manyMutationAnnotations = Array.from({ length: 300 }, (_, i) => ({
-    name: `Annotation ${i + 1}`,
-    description: `This is test annotation number ${i + 1} for testing many annotations.`,
-    symbol: String.fromCharCode(33 + (i % 94)), // Cycle through printable ASCII characters
-    nucleotideMutations: ['A23G'],
-    aminoAcidMutations: [],
-})) satisfies MutationAnnotations;
-
 export const Default: StoryObj<MutationsOverTimeProps> = {
     render: (args: MutationsOverTimeProps) => (
         <MutationAnnotationsContextProvider value={mutationAnnotations}>
@@ -287,54 +279,6 @@ export const WithNoLapisDateFieldField: StoryObj<MutationsOverTimeProps> = {
     play: async ({ canvasElement, step }) => {
         await step('expect error message', async () => {
             await expectInvalidAttributesErrorMessage(canvasElement, 'String must contain at least 1 character(s)');
-        });
-    },
-};
-
-export const WithManyMutationAnnotations: StoryObj<MutationsOverTimeProps> = {
-    render: (args: MutationsOverTimeProps) => (
-        <MutationAnnotationsContextProvider value={manyMutationAnnotations}>
-            <LapisUrlContextProvider value={LAPIS_URL}>
-                <ReferenceGenomeContext.Provider value={referenceGenome}>
-                    <MutationsOverTime {...args} />
-                </ReferenceGenomeContext.Provider>
-            </LapisUrlContextProvider>
-        </MutationAnnotationsContextProvider>
-    ),
-    args: {
-        ...Default.args,
-    },
-    play: async ({ canvas, step }) => {
-        await step('Open filter dropdown', async () => {
-            await waitFor(() => expect(canvas.getByText('Grid')).toBeVisible(), { timeout: 3000 });
-            const filterButton = canvas.getByRole('button', { name: 'Filter mutations' });
-            await userEvent.click(filterButton);
-        });
-
-        await step('Verify scroll container is scrollable', () => {
-            const scrollContainer = canvas
-                .getByText('Filter by annotations')
-                .parentElement!.querySelector('.overflow-scroll')!;
-            void expect(scrollContainer).toBeInTheDocument();
-
-            // Verify the container has scrollable content
-            void expect(scrollContainer.scrollHeight).toBeGreaterThan(scrollContainer.clientHeight);
-        });
-
-        await step('Scroll to bottom and verify we can scroll', async () => {
-            const scrollContainer = canvas
-                .getByText('Filter by annotations')
-                .parentElement!.querySelector('.overflow-scroll')!;
-
-            const initialScrollTop = scrollContainer.scrollTop;
-
-            // Scroll to the bottom
-            scrollContainer.scrollTop = scrollContainer.scrollHeight;
-
-            await waitFor(async () => {
-                // Verify that scrollTop actually changed
-                await expect(scrollContainer.scrollTop).toBeGreaterThan(initialScrollTop);
-            });
         });
     },
 };


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1011

### Summary

Add an `overflow-scroll`.

Not very happy with the test, maybe we could also just remove it, not sure if we even need a test here. I wanted to check that initially the last annotation isn't visible, then you scroll, and then it is, but I couldn't get it done.

### Screenshot

https://github.com/user-attachments/assets/f9c65db4-a79f-4d7a-87bf-6e948f7852a6

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~All necessary documentation has been adapted.~~ 
- [x] The implemented feature is covered by an appropriate test.
