### PR TITLE
fix(components): remove incorrect array type on LineageFilter

### DIFF
--- a/components/src/web-components/input/gs-lineage-filter.stories.ts
+++ b/components/src/web-components/input/gs-lineage-filter.stories.ts
@@ -155,6 +155,54 @@ export const LineageFilter: StoryObj<Required<LineageFilterProps>> = {
     },
 };
 
+export const LineageFilterStringValue: StoryObj<Required<LineageFilterProps>> = {
+    render: (args) => {
+        return html` <gs-app lapis="${LAPIS_URL}">
+            <div class="max-w-(--breakpoint-lg)">
+                <gs-lineage-filter
+                    lapisField="pangoLineage"
+                    placeholderText="Enter a lineage"
+                    value="B.1.1.7"
+                    .multiSelect=${args.multiSelect}
+                ></gs-lineage-filter>
+            </div>
+        </gs-app>`;
+    },
+    args: {
+        multiSelect: false,
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = await withinShadowRoot(canvasElement, 'gs-lineage-filter');
+        await waitFor(() => {
+            return expect(canvas.getByPlaceholderText('Enter a lineage')).toBeVisible();
+        });
+    },
+};
+
+export const LineageFilterArrayValue: StoryObj<Required<LineageFilterProps>> = {
+    render: (args) => {
+        return html` <gs-app lapis="${LAPIS_URL}">
+            <div class="max-w-(--breakpoint-lg)">
+                <gs-lineage-filter
+                    lapisField="pangoLineage"
+                    placeholderText="Enter a lineage"
+                    value='["B.1.1.7", "B.1.1.10"]'
+                    .multiSelect=${args.multiSelect}
+                ></gs-lineage-filter>
+            </div>
+        </gs-app>`;
+    },
+    args: {
+        multiSelect: true,
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = await withinShadowRoot(canvasElement, 'gs-lineage-filter');
+        await waitFor(() => {
+            return expect(canvas.getByPlaceholderText('Enter a lineage')).toBeVisible();
+        });
+    },
+};
+
 export const DelayToShowLoadingState: StoryObj<Required<LineageFilterProps>> = {
     ...Template,
     parameters: {

--- a/components/src/web-components/input/gs-lineage-filter.tsx
+++ b/components/src/web-components/input/gs-lineage-filter.tsx
@@ -103,6 +103,33 @@ export class LineageFilterComponent extends PreactLitAdapter {
     @property({ type: Boolean })
     hideCounts: boolean | undefined = false;
 
+    override updated(changedProps: Map<string, unknown>) {
+        if (changedProps.has('value') || changedProps.has('multiSelect')) {
+            if (this.multiSelect) {
+                if (typeof this.value === 'string') {
+                    let parsed: unknown;
+                    try {
+                        parsed = JSON.parse(this.value);
+                    } catch {
+                        parsed = this.value.split(',').map((s) => s.trim());
+                    }
+
+                    // type guard
+                    if (Array.isArray(parsed) && parsed.every((v) => typeof v === 'string')) {
+                        this.value = parsed;
+                    } else {
+                        this.value = [];
+                    }
+                }
+            } else {
+                // single select: ensure value is a string
+                if (Array.isArray(this.value)) {
+                    this.value = this.value[0] ?? '';
+                }
+            }
+        }
+    }
+
     override render() {
         return (
             <LineageFilter


### PR DESCRIPTION
### Summary

The `@property({ type: Array })` prevents regular strings from getting set as a value. I think we didn't notice this in our tests, because they bypass this mechanism from the HTML property by setting things directly:

```typescript
const Template: StoryObj<Required<LineageFilterProps>> = {
    render: (args) => {
        return html` <gs-app lapis="${LAPIS_URL}">
            <div class="max-w-(--breakpoint-lg)">
                <gs-lineage-filter
                    .lapisField=${args.lapisField}
                    .lapisFilter=${args.lapisFilter}
                    .placeholderText=${args.placeholderText}
                    .hideCounts=${args.hideCounts}
                    .value=${args.value}
                    .width=${args.width}
                    .multiSelect=${args.multiSelect}
                ></gs-lineage-filter>
            </div>
        </gs-app>`;
    },
    args: {
        lapisField: 'pangoLineage',
        lapisFilter: {
            country: 'Germany',
        },
        placeholderText: 'Enter a lineage',
        value: 'B.1.1.7',
        width: '100%',
        hideCounts: false,
        multiSelect: false,
    },
};
```

I have now added two tests where we set the HTML attributes directly, to check that things get parsed correctly. Example:

```typescript
    render: (args) => {
        return html` <gs-app lapis="${LAPIS_URL}">
            <div class="max-w-(--breakpoint-lg)">
                <gs-lineage-filter
                    lapisField="pangoLineage"
                    placeholderText="Enter a lineage"
                    value="B.1.1.7"
                    .multiSelect=${args.multiSelect}
                ></gs-lineage-filter>
            </div>
        </gs-app>`;
    },
```

I have also added an `updated` override, so we parse arrays correctly when needed. The default type of the property is still string.

For the Preact component underneath, no changes are needed.

---

I also checked, whether we could instead have two properties: `value` and `multiValue` so we wouldn't need this `updated` function. But then there's more complicated stuff going on further down the line, if I want to keep the Preact component the same. And I think in principle in Preact, it makes sense to have a single `value` property, because we can have a union type there. So I'd say that the `value` and `multiValue` approach isn't great.


- [x] covered by an appropriate test