### PR TITLE
fix(components): use converter instead of updated function

### DIFF
--- a/components/src/web-components/input/gs-lineage-filter.tsx
+++ b/components/src/web-components/input/gs-lineage-filter.tsx
@@ -51,7 +51,7 @@ export class LineageFilterComponent extends PreactLitAdapter {
      */
     @property({
         converter: (value) => {
-            if (value === null || Array.isArray(value)) {
+            if (value === null) {
                 return value;
             }
             try {
@@ -61,10 +61,6 @@ export class LineageFilterComponent extends PreactLitAdapter {
                 }
                 return value;
             } catch {
-                // If JSON parsing fails, try comma-separated values
-                if (typeof value === 'string' && value.includes(',')) {
-                    return value.split(',').map((s) => s.trim());
-                }
                 return value;
             }
         },


### PR DESCRIPTION
Follow up for https://github.com/GenSpectrum/dashboard-components/pull/1031#issuecomment-3501103308

### Summary

We want to use a converter because this converts the value right at the attribute-property boundary, which is cleaner than using the `updated` function.

### Screenshot
n/a

### PR Checklist
- ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
