### PR TITLE
fix(components): fix overflow of multi lineage filter

### DIFF
--- a/components/src/preact/components/resize-container.tsx
+++ b/components/src/preact/components/resize-container.tsx
@@ -4,11 +4,15 @@ import { forwardRef } from 'preact/compat';
 export type Size = {
     width: string;
     height?: string;
+    minHeight?: string;
 };
 
 export const ResizeContainer = forwardRef<HTMLDivElement, { size: Size; children: ComponentChildren }>(
     ({ size, children }, ref) => (
-        <div ref={ref} style={{ width: size.width, height: size.height, position: 'relative' }}>
+        <div
+            ref={ref}
+            style={{ width: size.width, height: size.height, minHeight: size.minHeight, position: 'relative' }}
+        >
             {children}
         </div>
     ),

--- a/components/src/preact/lineageFilter/lineage-filter.tsx
+++ b/components/src/preact/lineageFilter/lineage-filter.tsx
@@ -52,7 +52,7 @@ type LineageSelectorProps = z.infer<typeof lineageSelectorPropsSchema>;
 
 export const LineageFilter: FunctionComponent<LineageFilterProps> = (props) => {
     const { width, ...innerProps } = props;
-    const size = { width, height: '3rem' };
+    const size = { width, minHeight: '3rem' };
 
     return (
         <ErrorBoundary size={size} layout='horizontal' componentProps={props} schema={lineageFilterPropsSchema}>


### PR DESCRIPTION
### Summary

Use min-height instead of height to prevent overflow.

### Screenshot
currently:

<img width="371" height="243" alt="image" src="https://github.com/user-attachments/assets/bb141a22-e02a-4f20-86df-c4713bc2fea4" />

min `min-height`:

<img width="371" height="690" alt="image" src="https://github.com/user-attachments/assets/bf422967-644e-48b7-8a7f-4b124dbcea1a" />


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~ 
