### PR TITLE
feat(components): improved mutations-over-time tooltip

### DIFF
--- a/components/src/preact/mutationsOverTime/mutations-over-time-grid-tooltip.stories.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time-grid-tooltip.stories.tsx
@@ -45,7 +45,7 @@ export const NoValue: StoryObj<MutationsOverTimeGridTooltipProps> = {
         const canvas = within(canvasElement);
 
         await expect(canvas.getByText('2025', { exact: true })).toBeVisible();
-        await expect(canvas.getByText('(2025-01-01 - 2025-12-31)')).toBeVisible();
+        await expect(canvas.getByText('2025-01-01 - 2025-12-31')).toBeVisible();
         await expect(canvas.getByText('A500-')).toBeVisible();
         await expect(canvas.getByText('No data')).toBeVisible();
     },
@@ -65,9 +65,13 @@ export const WithValue: StoryObj<MutationsOverTimeGridTooltipProps> = {
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
-        await expect(canvas.getByText('Proportion: 50.00%')).toBeVisible();
-        await expect(canvas.getByText('300 samples are in the timeframe')).toBeVisible();
-        await expect(canvas.getByText('200 have coverage, of those 100 have the mutation')).toBeVisible();
+        await expect(canvas.getByText('50.00%')).toBeVisible();
+        await expect(canvas.getByText('100')).toBeVisible();
+        await expect(canvas.getByText('have the mutation A500- out of')).toBeVisible();
+        await expect(canvas.getByText('200')).toBeVisible();
+        await expect(canvas.getByText('with coverage at position 500.')).toBeVisible();
+        await expect(canvas.getByText('300')).toBeVisible();
+        await expect(canvas.getByText('total in this date range.')).toBeVisible();
     },
 };
 
@@ -83,9 +87,10 @@ export const WithValueBelowThreshold: StoryObj<MutationsOverTimeGridTooltipProps
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
-        await expect(canvas.getByText('Proportion: <0.10%')).toBeVisible();
-        await expect(canvas.getByText('300 samples are in the timeframe')).toBeVisible();
-        await expect(canvas.getByText('none or less than 0.10% have the mutation')).toBeVisible();
+        await expect(canvas.getByText('<0.10%')).toBeVisible();
+        await expect(canvas.getByText('None or less than 0.10% have the mutation.')).toBeVisible();
+        await expect(canvas.getByText('300')).toBeVisible();
+        await expect(canvas.getByText('total in this date range.')).toBeVisible();
     },
 };
 
@@ -101,8 +106,8 @@ export const WithWastewaterValue: StoryObj<MutationsOverTimeGridTooltipProps> = 
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
-        await expect(canvas.getByText('Proportion: 50.00%')).toBeVisible();
-        await expect(canvas.queryByText('samples are in the timeframe')).not.toBeInTheDocument();
-        await expect(canvas.queryByText('have coverage')).not.toBeInTheDocument();
+        await expect(canvas.getByText('50.00%')).toBeVisible();
+        await expect(canvas.queryByText('total in this date range.')).not.toBeInTheDocument();
+        await expect(canvas.queryByText('coverage')).not.toBeInTheDocument();
     },
 };

--- a/components/src/preact/mutationsOverTime/mutations-over-time-grid-tooltip.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time-grid-tooltip.tsx
@@ -40,9 +40,7 @@ export const MutationsOverTimeGridTooltip: FunctionComponent<MutationsOverTimeGr
                     <span className='text-gray-600'>{timeIntervalDisplay(dateClass)}</span>
                 </div>
             </div>
-            {value === null ? (
-                <p className='mt-2'>No data</p>
-            ) : (
+            {value !== null && (
                 <TooltipValueCountsDescription
                     value={value}
                     mutationCode={mutation.code}


### PR DESCRIPTION
resolves #1038 

### Summary
Improve the tooltip:
- New layout
- Mention mutation and position explicitly in text
- Change sentence order and remove 'samples' wording. New sentence order implies what the total count refers to.

I hope this resolves #1038, by simply removing the word _samples_. I think with the new wording it's still clear what we're talking about.

### Screenshot

<img width="838" height="355" alt="image" src="https://github.com/user-attachments/assets/4d65ef8a-9159-4ce1-81ca-46722644c4a9" />

#### before

<img width="903" height="355" alt="image" src="https://github.com/user-attachments/assets/368e240e-662c-4407-96bc-45ae7805e450" />


### PR Checklist
- [x] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
