### PR TITLE
fix(components): coverage now calculated correctly

### DIFF
--- a/components/src/preact/mutationsOverTime/getFilteredMutationsOverTimeData.ts
+++ b/components/src/preact/mutationsOverTime/getFilteredMutationsOverTimeData.ts
@@ -68,7 +68,7 @@ export function getFilteredMutationOverTimeData({
     if (hideGaps) {
         const dateRangesToFilterOut = filteredData.getSecondAxisKeys().filter((dateRange) => {
             const vals = filteredData.getColumn(dateRange);
-            return !vals.some((v) => v?.type === 'value' && v.totalCount > 0);
+            return !vals.some((v) => (v?.type === 'value' || v?.type === 'valueWithCoverage') && v.totalCount > 0);
         });
         dateRangesToFilterOut.forEach((dateRange) => filteredData.deleteColumn(dateRange));
     }

--- a/components/src/preact/mutationsOverTime/mutations-over-time-grid-tooltip.stories.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time-grid-tooltip.stories.tsx
@@ -67,6 +67,53 @@ export const WithValue: StoryObj<MutationsOverTimeGridTooltipProps> = {
 
         await expect(canvas.getByText('50.00%')).toBeVisible();
         await expect(canvas.getByText('100')).toBeVisible();
+        await expect(canvas.getByText('have the mutation A500-.')).toBeVisible();
+        await expect(canvas.getByText('200')).toBeVisible();
+        await expect(canvas.getByText('have coverage at position 500.')).toBeVisible();
+        await expect(canvas.getByText('300')).toBeVisible();
+        await expect(canvas.getByText('total in this date range.')).toBeVisible();
+    },
+};
+
+export const WithValueWithZero: StoryObj<MutationsOverTimeGridTooltipProps> = {
+    ...Template,
+    args: {
+        ...Template.args,
+        value: {
+            type: 'value',
+            proportion: 0,
+            count: 0,
+            totalCount: 300,
+        },
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        await expect(canvas.getByText('0.00%')).toBeVisible();
+        await expect(canvas.getByText('0')).toBeVisible();
+        await expect(canvas.getByText('have the mutation A500-.')).toBeVisible();
+        await expect(canvas.queryByText('with coverage at position 500.')).not.toBeInTheDocument();
+        await expect(canvas.getByText('300')).toBeVisible();
+        await expect(canvas.getByText('total in this date range.')).toBeVisible();
+    },
+};
+
+export const WithValueWithCoverage: StoryObj<MutationsOverTimeGridTooltipProps> = {
+    ...Template,
+    args: {
+        ...Template.args,
+        value: {
+            type: 'valueWithCoverage',
+            count: 100,
+            coverage: 200,
+            totalCount: 300,
+        },
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        await expect(canvas.getByText('50.00%')).toBeVisible();
+        await expect(canvas.getByText('100')).toBeVisible();
         await expect(canvas.getByText('have the mutation A500- out of')).toBeVisible();
         await expect(canvas.getByText('200')).toBeVisible();
         await expect(canvas.getByText('with coverage at position 500.')).toBeVisible();

--- a/components/src/preact/mutationsOverTime/mutations-over-time-grid.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time-grid.tsx
@@ -4,7 +4,7 @@ import z from 'zod';
 
 import { type MutationOverTimeDataMap } from './MutationOverTimeData';
 import { MutationsOverTimeGridTooltip } from './mutations-over-time-grid-tooltip';
-import { type MutationOverTimeMutationValue } from '../../query/queryMutationsOverTime';
+import { getProportion, type MutationOverTimeMutationValue } from '../../query/queryMutationsOverTime';
 import { type SequenceType } from '../../types';
 import { type Deletion, type Substitution } from '../../utils/mutations';
 import { type Temporal } from '../../utils/temporalClass';
@@ -211,7 +211,7 @@ const ProportionCell: FunctionComponent<{
     colorScale: ColorScale;
     tooltipPortalTarget: HTMLElement | null;
 }> = ({ value, mutation, date, tooltipPosition, colorScale, tooltipPortalTarget }) => {
-    const proportion = value?.type === 'belowThreshold' ? undefined : value?.proportion;
+    const proportion = getProportion(value);
 
     return (
         <div className={'py-1 w-full h-full'}>

--- a/components/src/preact/mutationsOverTime/mutations-over-time.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.tsx
@@ -12,7 +12,7 @@ import {
 } from './getFilteredMutationsOverTimeData';
 import { type MutationOverTimeWorkerResponse } from './mutationOverTimeWorker';
 import MutationsOverTimeGrid, { customColumnSchema } from './mutations-over-time-grid';
-import { type MutationOverTimeQuery } from '../../query/queryMutationsOverTime';
+import { getProportion, type MutationOverTimeQuery } from '../../query/queryMutationsOverTime';
 import {
     lapisFilterSchema,
     sequenceTypeSchema,
@@ -356,7 +356,7 @@ function getDownloadData(filteredData: MutationOverTimeDataMap) {
         return dates.reduce(
             (accumulated, date) => {
                 const value = filteredData.get(mutation, date);
-                const proportion = value?.type === 'value' || value?.type === 'wastewaterValue' ? value.proportion : '';
+                const proportion = getProportion(value ?? null) ?? '';
                 return {
                     ...accumulated,
                     [date.dateString]: proportion,

--- a/components/src/query/queryMutationsOverTime.ts
+++ b/components/src/query/queryMutationsOverTime.ts
@@ -50,6 +50,12 @@ export type MutationOverTimeMutationValue =
           totalCount: number;
       }
     | {
+          type: 'valueWithCoverage';
+          count: number;
+          coverage: number;
+          totalCount: number;
+      }
+    | {
           type: 'wastewaterValue';
           proportion: number;
       }
@@ -58,6 +64,19 @@ export type MutationOverTimeMutationValue =
           totalCount: number | null;
       }
     | null;
+
+export function getProportion(value: MutationOverTimeMutationValue) {
+    switch (value?.type) {
+        case 'value':
+        case 'wastewaterValue':
+            return value.proportion;
+        case 'valueWithCoverage':
+            return value.count / value.coverage;
+        case 'belowThreshold':
+            return undefined;
+    }
+    return undefined;
+}
 
 const MAX_NUMBER_OF_GRID_COLUMNS = 200;
 export const MUTATIONS_OVER_TIME_MIN_PROPORTION = 0.001;
@@ -316,9 +335,9 @@ async function queryMutationsOverTimeDataDirectEndpoint(
                         return [
                             date.dateString,
                             {
-                                type: 'value',
-                                proportion: count / coverage,
+                                type: 'valueWithCoverage',
                                 count,
+                                coverage,
                                 totalCount,
                             },
                         ];

--- a/components/src/query/queryMutationsOverTimeNewEndpoint.spec.ts
+++ b/components/src/query/queryMutationsOverTimeNewEndpoint.spec.ts
@@ -120,14 +120,14 @@ describe('queryMutationsOverTimeNewEndpoint', () => {
 
         const expectedData = [
             [
-                { type: 'value', proportion: 0.4, count: 4, totalCount: 11 },
-                { type: 'value', proportion: 0, count: 0, totalCount: 12 },
-                { type: 'value', proportion: 0, count: 0, totalCount: 13 },
+                { type: 'valueWithCoverage', count: 4, coverage: 10, totalCount: 11 },
+                { type: 'valueWithCoverage', count: 0, coverage: 10, totalCount: 12 },
+                { type: 'valueWithCoverage', count: 0, coverage: 10, totalCount: 13 },
             ],
             [
-                { type: 'value', proportion: 0.1, count: 1, totalCount: 11 },
-                { type: 'value', proportion: 0.2, count: 2, totalCount: 12 },
-                { type: 'value', proportion: 0.3, count: 3, totalCount: 13 },
+                { type: 'valueWithCoverage', count: 1, coverage: 10, totalCount: 11 },
+                { type: 'valueWithCoverage', count: 2, coverage: 10, totalCount: 12 },
+                { type: 'valueWithCoverage', count: 3, coverage: 10, totalCount: 13 },
             ],
         ];
         expect(mutationOverTimeData.getAsArray()).to.deep.equal(expectedData);
@@ -289,14 +289,14 @@ describe('queryMutationsOverTimeNewEndpoint', () => {
 
         expect(mutationOverTimeData.getAsArray()).to.deep.equal([
             [
-                { type: 'value', proportion: 0.4, count: 4, totalCount: 11 },
+                { type: 'valueWithCoverage', count: 4, coverage: 10, totalCount: 11 },
                 null,
-                { type: 'value', proportion: 0, count: 0, totalCount: 13 },
+                { type: 'valueWithCoverage', count: 0, coverage: 10, totalCount: 13 },
             ],
             [
-                { type: 'value', proportion: 0.1, count: 1, totalCount: 11 },
+                { type: 'valueWithCoverage', count: 1, coverage: 10, totalCount: 11 },
                 null,
-                { type: 'value', proportion: 0.3, count: 3, totalCount: 13 },
+                { type: 'valueWithCoverage', count: 3, coverage: 10, totalCount: 13 },
             ],
         ]);
 
@@ -523,8 +523,8 @@ describe('queryMutationsOverTimeNewEndpoint', () => {
 
         expect(mutationOverTimeData.getAsArray()).to.deep.equal([
             [
-                { type: 'value', proportion: 0.2, count: 2, totalCount: 11 },
-                { type: 'value', proportion: 0.3, count: 3, totalCount: 12 },
+                { type: 'valueWithCoverage', count: 2, coverage: 10, totalCount: 11 },
+                { type: 'valueWithCoverage', count: 3, coverage: 10, totalCount: 12 },
             ],
         ]);
 
@@ -635,8 +635,8 @@ describe('queryMutationsOverTimeNewEndpoint', () => {
 
         expect(mutationOverTimeData.getAsArray()).to.deep.equal([
             [
-                { type: 'value', proportion: 0.1, count: 1, totalCount: 11 },
-                { type: 'value', proportion: 0.2, count: 2, totalCount: 12 },
+                { type: 'valueWithCoverage', count: 1, coverage: 10, totalCount: 11 },
+                { type: 'valueWithCoverage', count: 2, coverage: 10, totalCount: 12 },
             ],
         ]);
 
@@ -726,7 +726,7 @@ describe('queryMutationsOverTimeNewEndpoint', () => {
         });
 
         expect(mutationOverTimeData.getAsArray()).to.deep.equal([
-            [{ type: 'value', proportion: 0.2, count: 2, totalCount: 11 }],
+            [{ type: 'valueWithCoverage', count: 2, coverage: 10, totalCount: 11 }],
         ]);
 
         const sequences = mutationOverTimeData.getFirstAxisKeys();
@@ -839,12 +839,12 @@ describe('queryMutationsOverTimeNewEndpoint', () => {
 
         expect(mutationOverTimeData.getAsArray()).to.deep.equal([
             [
-                { type: 'value', proportion: 0.2, count: 2, totalCount: 11 },
-                { type: 'value', proportion: 0.3, count: 3, totalCount: 12 },
+                { type: 'valueWithCoverage', count: 2, coverage: 10, totalCount: 11 },
+                { type: 'valueWithCoverage', count: 3, coverage: 10, totalCount: 12 },
             ],
             [
-                { type: 'value', proportion: 0.4, count: 4, totalCount: 11 },
-                { type: 'value', proportion: 0.5, count: 5, totalCount: 12 },
+                { type: 'valueWithCoverage', count: 4, coverage: 10, totalCount: 11 },
+                { type: 'valueWithCoverage', count: 5, coverage: 10, totalCount: 12 },
             ],
         ]);
 
@@ -1017,8 +1017,8 @@ describe('queryMutationsOverTimeNewEndpoint', () => {
                 { type: 'belowThreshold', totalCount: 12 },
             ],
             [
-                { type: 'value', proportion: 0.2, count: 2, totalCount: 11 },
-                { type: 'value', proportion: 0.3, count: 3, totalCount: 12 },
+                { type: 'valueWithCoverage', count: 2, coverage: 10, totalCount: 11 },
+                { type: 'valueWithCoverage', count: 3, coverage: 10, totalCount: 12 },
             ],
         ]);
 
@@ -1139,8 +1139,8 @@ describe('queryMutationsOverTimeNewEndpoint', () => {
                 { type: 'belowThreshold', totalCount: 12 },
             ],
             [
-                { type: 'value', proportion: 0.2, count: 2, totalCount: 11 },
-                { type: 'value', proportion: 0.3, count: 3, totalCount: 12 },
+                { type: 'valueWithCoverage', count: 2, coverage: 10, totalCount: 11 },
+                { type: 'valueWithCoverage', count: 3, coverage: 10, totalCount: 12 },
             ],
         ]);
 


### PR DESCRIPTION
resolves #1041 

### Summary
Add a new `valueWithCoverage` type to `MutationOverTimeMutationValue` that has `count` and `coverage` instead of `proportion`. This means, that even if count is zero, we can still display a coverage value.

We did not have this issue before, because the old method of getting the data never returned count zero and a coverage. It could only return a count, or "below threshold".

I have left the old `value` variant in place for now. I think it's not useful to do a partial refactor of the old code that is due to be removed entirely.

### Screenshot

<img width="546" height="258" alt="image" src="https://github.com/user-attachments/assets/e56dc45f-121c-4af4-83eb-a4d7775de6be" />

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
