### PR TITLE
refactor(components): refactor mutations-over-time-grid into generic features-over-time-grid

### DIFF
--- a/components/src/preact/mutationsOverTime/MutationOverTimeData.ts
+++ b/components/src/preact/mutationsOverTime/MutationOverTimeData.ts
@@ -1,5 +1,5 @@
 import {
-    type MutationOverTimeMutationValue,
+    type ProportionValue,
     serializeSubstitutionOrDeletion,
     serializeTemporal,
 } from '../../query/queryMutationsOverTime';
@@ -7,18 +7,20 @@ import { type Map2d, Map2dBase, type Map2DContents } from '../../utils/map2d';
 import type { Deletion, Substitution } from '../../utils/mutations';
 import type { Temporal, TemporalClass } from '../../utils/temporalClass';
 
+export type TemporalDataMap<D, T extends Temporal | TemporalClass = Temporal> = Map2d<D, T, ProportionValue>;
+
 export type MutationOverTimeDataMap<T extends Temporal | TemporalClass = Temporal> = Map2d<
     Substitution | Deletion,
     T,
-    MutationOverTimeMutationValue
+    ProportionValue
 >;
 
 export class BaseMutationOverTimeDataMap<T extends Temporal | TemporalClass = Temporal> extends Map2dBase<
     Substitution | Deletion,
     T,
-    MutationOverTimeMutationValue
+    ProportionValue
 > {
-    constructor(initialContent?: Map2DContents<Substitution | Deletion, T, MutationOverTimeMutationValue>) {
+    constructor(initialContent?: Map2DContents<Substitution | Deletion, T, ProportionValue>) {
         super(serializeSubstitutionOrDeletion, serializeTemporal, initialContent);
     }
 }

--- a/components/src/preact/mutationsOverTime/getFilteredMutationsOverTime.spec.ts
+++ b/components/src/preact/mutationsOverTime/getFilteredMutationsOverTime.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { BaseMutationOverTimeDataMap } from './MutationOverTimeData';
 import { getFilteredMutationOverTimeData, type MutationFilter } from './getFilteredMutationsOverTimeData';
-import { type MutationOverTimeMutationValue } from '../../query/queryMutationsOverTime';
+import { type ProportionValue } from '../../query/queryMutationsOverTime';
 import { type DeletionEntry, type SubstitutionEntry } from '../../types';
 import { type Deletion, type Substitution } from '../../utils/mutations';
 import { type TemporalClass } from '../../utils/temporalClass';
@@ -392,13 +392,13 @@ describe('getFilteredMutationOverTimeData', () => {
         count: 1,
         proportion: inFilter,
         totalCount: 10,
-    } satisfies MutationOverTimeMutationValue;
+    } satisfies ProportionValue;
     const emptyMutationOverTimeValue = {
         type: 'value',
         count: 0,
         proportion: NaN,
         totalCount: 0,
-    } satisfies MutationOverTimeMutationValue;
+    } satisfies ProportionValue;
 
     function prepareMutationOverTimeData(
         mutationEntries: (SubstitutionEntry<Substitution> | DeletionEntry<Deletion>)[],

--- a/components/src/preact/mutationsOverTime/mutations-over-time-grid-tooltip.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time-grid-tooltip.tsx
@@ -1,9 +1,6 @@
 import type { FunctionComponent } from 'preact';
 
-import {
-    type MutationOverTimeMutationValue,
-    MUTATIONS_OVER_TIME_MIN_PROPORTION,
-} from '../../query/queryMutationsOverTime';
+import { type ProportionValue, MUTATIONS_OVER_TIME_MIN_PROPORTION } from '../../query/queryMutationsOverTime';
 import type { Deletion, Substitution } from '../../utils/mutations';
 import { type Temporal, type TemporalClass, toTemporalClass, YearMonthDayClass } from '../../utils/temporalClass';
 import { formatProportion } from '../shared/table/formatProportion';
@@ -11,7 +8,7 @@ import { formatProportion } from '../shared/table/formatProportion';
 export type MutationsOverTimeGridTooltipProps = {
     mutation: Substitution | Deletion;
     date: Temporal;
-    value: MutationOverTimeMutationValue;
+    value: ProportionValue;
 };
 
 export const MutationsOverTimeGridTooltip: FunctionComponent<MutationsOverTimeGridTooltipProps> = ({
@@ -66,7 +63,7 @@ export const MutationsOverTimeGridTooltip: FunctionComponent<MutationsOverTimeGr
 };
 
 const TooltipValueCountsDescription: FunctionComponent<{
-    value: NonNullable<MutationOverTimeMutationValue>;
+    value: NonNullable<ProportionValue>;
     mutationCode: string;
     mutationPosition: number;
 }> = ({ value, mutationCode, mutationPosition }) => {

--- a/components/src/preact/wastewater/mutationsOverTime/wastewater-mutations-over-time.tsx
+++ b/components/src/preact/wastewater/mutationsOverTime/wastewater-mutations-over-time.tsx
@@ -3,14 +3,19 @@ import { type Dispatch, type StateUpdater, useMemo, useState, useRef } from 'pre
 import z from 'zod';
 
 import { computeWastewaterMutationsOverTimeDataPerLocation } from './computeWastewaterMutationsOverTimeDataPerLocation';
+import { type ProportionValue } from '../../../query/queryMutationsOverTime';
 import { lapisFilterSchema, type SequenceType, sequenceTypeSchema } from '../../../types';
 import { Map2dView } from '../../../utils/map2d';
+import { type Deletion, type Substitution } from '../../../utils/mutations';
+import { type Temporal } from '../../../utils/temporalClass';
 import { useDispatchFinishedLoadingEvent } from '../../../utils/useDispatchFinishedLoadingEvent';
 import { useLapisUrl } from '../../LapisUrlContext';
 import { useMutationAnnotationsProvider } from '../../MutationAnnotationsContext';
+import { AnnotatedMutation } from '../../components/annotated-mutation';
 import { type ColorScale } from '../../components/color-scale-selector';
 import { ColorScaleSelectorDropdown } from '../../components/color-scale-selector-dropdown';
 import { ErrorBoundary } from '../../components/error-boundary';
+import FeaturesOverTimeGrid from '../../components/features-over-time-grid';
 import { Fullscreen } from '../../components/fullscreen';
 import Info, { InfoComponentCode, InfoHeadline1, InfoParagraph } from '../../components/info';
 import { LoadingDisplay } from '../../components/loading-display';
@@ -24,7 +29,7 @@ import {
     type MutationFilter,
     mutationOrAnnotationDoNotMatchFilter,
 } from '../../mutationsOverTime/getFilteredMutationsOverTimeData';
-import MutationsOverTimeGrid from '../../mutationsOverTime/mutations-over-time-grid';
+import { MutationsOverTimeGridTooltip } from '../../mutationsOverTime/mutations-over-time-grid-tooltip';
 import { pageSizesSchema } from '../../shared/tanstackTable/pagination';
 import { PageSizeContextProvider } from '../../shared/tanstackTable/pagination-context';
 import { useQuery } from '../../useQuery';
@@ -166,7 +171,8 @@ const MutationsOverTimeTabs: FunctionComponent<MutationOverTimeTabsProps> = ({
             mutationOverTimeDataPerLocation.map(({ location, data }) => ({
                 title: location,
                 content: (
-                    <MutationsOverTimeGrid
+                    <FeaturesOverTimeGrid
+                        rowLabelHeader='Mutation'
                         data={getFilteredMutationOverTimeData({
                             data,
                             displayedSegments,
@@ -176,7 +182,28 @@ const MutationsOverTimeTabs: FunctionComponent<MutationOverTimeTabsProps> = ({
                         })}
                         colorScale={colorScale}
                         pageSizes={originalComponentProps.pageSizes}
-                        sequenceType={originalComponentProps.sequenceType}
+                        featureRenderer={{
+                            asString: (value: Substitution | Deletion) => value.code,
+                            renderRowLabel: (value: Substitution | Deletion) => (
+                                <div className={'text-center'}>
+                                    <AnnotatedMutation
+                                        mutation={value}
+                                        sequenceType={originalComponentProps.sequenceType}
+                                    />
+                                </div>
+                            ),
+                            renderTooltip: (
+                                value: Substitution | Deletion,
+                                temporal: Temporal,
+                                proportionValue: ProportionValue,
+                            ) => (
+                                <MutationsOverTimeGridTooltip
+                                    mutation={value}
+                                    date={temporal}
+                                    value={proportionValue}
+                                />
+                            ),
+                        }}
                         tooltipPortalTarget={tooltipPortalTargetRef.current}
                     />
                 ),

--- a/components/src/query/queryMutationsOverTime.ts
+++ b/components/src/query/queryMutationsOverTime.ts
@@ -14,7 +14,7 @@ import { type Map2DContents } from '../utils/map2d';
 import { type Deletion, type Substitution, DeletionClass, SubstitutionClass } from '../utils/mutations';
 import { type Temporal } from '../utils/temporalClass';
 
-export type MutationOverTimeMutationValue =
+export type ProportionValue =
     | {
           type: 'value';
           proportion: number;
@@ -37,7 +37,7 @@ export type MutationOverTimeMutationValue =
       }
     | null;
 
-export function getProportion(value: MutationOverTimeMutationValue) {
+export function getProportion(value: ProportionValue) {
     switch (value?.type) {
         case 'value':
         case 'wastewaterValue':
@@ -211,14 +211,14 @@ export async function queryMutationsOverTimeData(
         }
     });
 
-    const mutationOverTimeData: Map2DContents<Substitution | Deletion, Temporal, MutationOverTimeMutationValue> = {
+    const mutationOverTimeData: Map2DContents<Substitution | Deletion, Temporal, ProportionValue> = {
         keysFirstAxis: new Map(responseMutations.map((mutation) => [mutation.code, mutation])),
         keysSecondAxis: new Map(requestedDateRanges.map((date) => [date.dateString, date])),
         data: new Map(
             responseMutations.map((mutation, i) => [
                 mutation.code,
                 new Map(
-                    requestedDateRanges.map((date, j): [string, MutationOverTimeMutationValue] => {
+                    requestedDateRanges.map((date, j): [string, ProportionValue] => {
                         if (totalCounts[j] === 0) {
                             return [date.dateString, null];
                         }

--- a/components/src/utilEntrypoint.ts
+++ b/components/src/utilEntrypoint.ts
@@ -51,4 +51,4 @@ export {
 } from './preact/numberRangeFilter/NumberRangeFilterChangedEvent';
 
 export { type MeanProportionInterval } from './preact/mutationsOverTime/mutations-over-time';
-export { type CustomColumn } from './preact/mutationsOverTime/mutations-over-time-grid';
+export { type CustomColumn } from './preact/components/features-over-time-grid';


### PR DESCRIPTION
This is working towards a new `queries-over-time` component, by refactoring the `mutations-over-time-grid` into a reusable component.

### Summary

Rename `MutationsOverTimeGrid` to `FeaturesOverTimeGrid` and make it generic. You now need to also supply a:

```typescript
FeatureRenderer<D> {
    asString(value: D): string;
    renderRowLabel(value: D): JSX.Element;
    renderTooltip(value: D, temporal: Temporal, proportionValue: ProportionValue | undefined): JSX.Element;
}
```

Rename `MutationOverTimeMutationValue` to `ProportionValue` as it's not mutation specific.

### Screenshot
n/a

### PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
