### PR TITLE
ci(components): use "trusted publishing" via OIDC for publishing to npm

### DIFF
--- a/.github/workflows/release-components.yml
+++ b/.github/workflows/release-components.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write  # Required for OIDC to NPM - https://docs.npmjs.com/trusted-publishers#supported-cicd-providers
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -46,6 +47,4 @@ jobs:
       - name: Publish
         if: ${{ steps.release.outputs.components--release_created }}
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         working-directory: components


### PR DESCRIPTION


### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

When creating a new token in npm, it prompted me to use "Trusted publishers" instead: https://docs.npmjs.com/trusted-publishers#supported-cicd-providers I configured the publisher in NPM. Let's see whether it works. Then we wouldn't need the tokens anymore.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
~~- [ ] The implemented feature is covered by an appropriate test.~~
