### PR TITLE
fix(components): use null values instead of undefined for wastewater-over-time plots

### DIFF
--- a/components/src/preact/components/features-over-time-grid.tsx
+++ b/components/src/preact/components/features-over-time-grid.tsx
@@ -30,7 +30,7 @@ export type CustomColumn = z.infer<typeof customColumnSchema>;
 export interface FeatureRenderer<D> {
     asString(value: D): string;
     renderRowLabel(value: D): JSX.Element;
-    renderTooltip(value: D, temporal: Temporal, proportionValue: ProportionValue | undefined): JSX.Element;
+    renderTooltip(value: D, temporal: Temporal, proportionValue: ProportionValue): JSX.Element;
 }
 
 export interface FeaturesOverTimeGridProps<F> {
@@ -99,11 +99,19 @@ function FeaturesOverTimeGrid<F>({
                     </div>
                 ),
                 cell: ({ getValue, row, column, table }) => {
-                    const value = getValue();
+                    const valueRaw = getValue();
+                    const value = valueRaw ?? null;
                     const rowIndex = row.index;
                     const columnIndex = column.getIndex();
                     const numberOfRows = table.getRowModel().rows.length;
                     const numberOfColumns = table.getAllColumns().length;
+
+                    if (valueRaw === undefined) {
+                        // eslint-disable-next-line no-console -- We want to warn that something might be wrong.
+                        console.error(
+                            `Found undefined value for ${row.original.feature} - ${date.dateString}. This shouldn't happen.`,
+                        );
+                    }
 
                     const tooltip = featureRenderer.renderTooltip(row.original.feature, date, value);
 

--- a/components/src/preact/wastewater/mutationsOverTime/computeWastewaterMutationsOverTimeDataPerLocation.ts
+++ b/components/src/preact/wastewater/mutationsOverTime/computeWastewaterMutationsOverTimeDataPerLocation.ts
@@ -21,20 +21,46 @@ export async function computeWastewaterMutationsOverTimeDataPerLocation(
 
 export function groupMutationDataByLocation(data: WastewaterData, sequenceType: 'nucleotide' | 'amino acid') {
     const locationMap = new Map<string, MutationOverTimeDataMap<TemporalClass>>();
+    // Track all unique mutations and dates per location for backfilling
+    const locationMutations = new Map<string, Set<string>>();
+    const locationDates = new Map<string, Set<string>>();
+
+    // First pass: populate sparse data and track all keys
     for (const row of data) {
         if (!locationMap.has(row.location)) {
             locationMap.set(row.location, new BaseMutationOverTimeDataMap<TemporalClass>());
+            locationMutations.set(row.location, new Set());
+            locationDates.set(row.location, new Set());
         }
         const map = locationMap.get(row.location)!;
+        const mutations = locationMutations.get(row.location)!;
+        const dates = locationDates.get(row.location)!;
 
         const mutationFrequencies =
             sequenceType === 'nucleotide' ? row.nucleotideMutationFrequency : row.aminoAcidMutationFrequency;
         for (const mutation of mutationFrequencies) {
+            dates.add(row.date.dateString);
+            mutations.add(mutation.mutation.code);
             map.set(
                 mutation.mutation,
                 row.date,
                 mutation.proportion !== null ? { type: 'wastewaterValue', proportion: mutation.proportion } : null,
             );
+        }
+    }
+
+    // Second pass: backfill missing cells with explicit null
+    for (const [location, map] of locationMap.entries()) {
+        const allMutations = Array.from(locationMutations.get(location)!);
+        const allDates = Array.from(locationDates.get(location)!).map((dateStr) => map.keysSecondAxis.get(dateStr)!);
+
+        for (const mutationCode of allMutations) {
+            const mutation = map.keysFirstAxis.get(mutationCode)!;
+            for (const date of allDates) {
+                if (map.get(mutation, date) === undefined) {
+                    map.set(mutation, date, null);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This resolves a bug we currently have on prod GenSpectrum.

### Summary

The Tooltip expects the value to be `null` or a `ProportionValue`.
The code that fetches the wastewater data doesn't use null for missing values, but instead uses undefined. This PR changes that so it's in line with the mutations-over-time fetching code.

I've also added a defensive check that issues a console warning if there is an undefined value again. But this is not triggered at the moment - Because of the interface used, the type allows `undefined` at that point, so we have to deal with potential undefined values somehow. I think a console log is appropriate.

### Screenshot
<img width="1512" height="503" alt="image" src="https://github.com/user-attachments/assets/23ef8fa7-913d-4c2f-8d00-d975abc73aad" />


### PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
