### PR TITLE
feat(components): mutations over time: prevent layout shift when loading a page lazily

### DIFF
--- a/components/src/preact/components/features-over-time-grid.tsx
+++ b/components/src/preact/components/features-over-time-grid.tsx
@@ -85,7 +85,7 @@ export interface FeaturesOverTimeGridServerPaginatedProps<F> {
     data: TemporalDataMap<F> | null;
     isLoading: boolean;
     /** Labels to show in the row label column while the page data is loading. */
-    loadingRowLabels?: string[];
+    loadingRowLabels: string[];
     /** Date columns to show in the header while loading */
     requestedDateRanges: Temporal[];
     colorScale: ColorScale;
@@ -152,8 +152,7 @@ export function FeaturesOverTimeGridServerPaginated<F>({
         <FeaturesOverTimeGridDisplay
             table={table}
             pageSizes={pageSizes}
-            isLoading={isLoading}
-            loadingRowLabels={loadingRowLabels}
+            loadingState={{ isLoading, loadingRowLabels }}
             totalRows={totalRows}
         />
     );
@@ -255,21 +254,24 @@ function useGridTableData<F>(
     }, [data, customColumns, featureRenderer]);
 }
 
-interface FeaturesOverTimeGridDisplayProps<F> {
+type FeaturesOverTimeGridDisplayProps<F> = {
     table: Table<RowType<F>>;
     pageSizes: PageSizes;
-    isLoading?: boolean;
-    /** Labels to render in the row label column while loading. One skeleton row is shown per label. */
-    loadingRowLabels?: string[];
     /** Override for the pagination row count (server-driven pagination). */
     totalRows?: number;
-}
+    loadingState?:
+        | {
+              isLoading: boolean;
+              /** Labels to render in the row label column while loading. One skeleton row is shown per label. */
+              loadingRowLabels: string[];
+          }
+        | { isLoading: false; loadingRowLabels?: never };
+};
 
 function FeaturesOverTimeGridDisplay<F>({
     table,
     pageSizes,
-    isLoading = false,
-    loadingRowLabels,
+    loadingState,
     totalRows,
 }: FeaturesOverTimeGridDisplayProps<F>) {
     const displayedTotalRows = totalRows ?? table.getCoreRowModel().rows.length;
@@ -291,31 +293,21 @@ function FeaturesOverTimeGridDisplay<F>({
                     ))}
                 </thead>
                 <tbody>
-                    {isLoading ? (
-                        loadingRowLabels !== undefined && loadingRowLabels.length > 0 ? (
-                            loadingRowLabels.map((label, rowIndex) => (
-                                <tr key={label}>
-                                    <td className='text-center'>{label}</td>
-                                    {rowIndex === 0 && (
-                                        <td
-                                            rowSpan={loadingRowLabels.length}
-                                            colSpan={table.getFlatHeaders().length - 1}
-                                            className='text-center'
-                                        >
-                                            <span className='loading loading-spinner loading-sm' />
-                                        </td>
-                                    )}
-                                </tr>
-                            ))
-                        ) : (
-                            <tr>
-                                <td colSpan={table.getFlatHeaders().length}>
-                                    <div className={'text-center py-4'}>
+                    {loadingState?.isLoading ? (
+                        loadingState.loadingRowLabels.map((label, rowIndex) => (
+                            <tr key={label}>
+                                <td className='text-center'>{label}</td>
+                                {rowIndex === 0 && (
+                                    <td
+                                        rowSpan={loadingState.loadingRowLabels.length}
+                                        colSpan={table.getFlatHeaders().length - 1}
+                                        className='text-center'
+                                    >
                                         <span className='loading loading-spinner loading-sm' />
-                                    </div>
-                                </td>
+                                    </td>
+                                )}
                             </tr>
-                        )
+                        ))
                     ) : (
                         <>
                             {table.getRowModel().rows.map((row) => (

--- a/components/src/preact/components/features-over-time-grid.tsx
+++ b/components/src/preact/components/features-over-time-grid.tsx
@@ -84,6 +84,8 @@ export interface FeaturesOverTimeGridServerPaginatedProps<F> {
     rowLabelHeader: string;
     data: TemporalDataMap<F> | null;
     isLoading: boolean;
+    /** Labels to show in the row label column while the page data is loading. */
+    loadingRowLabels?: string[];
     /** Date columns to show in the header while loading */
     requestedDateRanges: Temporal[];
     colorScale: ColorScale;
@@ -102,6 +104,7 @@ export function FeaturesOverTimeGridServerPaginated<F>({
     rowLabelHeader,
     data,
     isLoading,
+    loadingRowLabels,
     requestedDateRanges,
     colorScale,
     pageSizes,
@@ -146,7 +149,13 @@ export function FeaturesOverTimeGridServerPaginated<F>({
     });
 
     return (
-        <FeaturesOverTimeGridDisplay table={table} pageSizes={pageSizes} isLoading={isLoading} totalRows={totalRows} />
+        <FeaturesOverTimeGridDisplay
+            table={table}
+            pageSizes={pageSizes}
+            isLoading={isLoading}
+            loadingRowLabels={loadingRowLabels}
+            totalRows={totalRows}
+        />
     );
 }
 
@@ -250,6 +259,8 @@ interface FeaturesOverTimeGridDisplayProps<F> {
     table: Table<RowType<F>>;
     pageSizes: PageSizes;
     isLoading?: boolean;
+    /** Labels to render in the row label column while loading. One skeleton row is shown per label. */
+    loadingRowLabels?: string[];
     /** Override for the pagination row count (server-driven pagination). */
     totalRows?: number;
 }
@@ -258,6 +269,7 @@ function FeaturesOverTimeGridDisplay<F>({
     table,
     pageSizes,
     isLoading = false,
+    loadingRowLabels,
     totalRows,
 }: FeaturesOverTimeGridDisplayProps<F>) {
     const displayedTotalRows = totalRows ?? table.getCoreRowModel().rows.length;
@@ -280,11 +292,28 @@ function FeaturesOverTimeGridDisplay<F>({
                 </thead>
                 <tbody>
                     {isLoading ? (
-                        <tr>
-                            <td colSpan={table.getFlatHeaders().length}>
-                                <div className={'text-center py-4'}>Loading...</div>
-                            </td>
-                        </tr>
+                        loadingRowLabels !== undefined && loadingRowLabels.length > 0 ? (
+                            loadingRowLabels.map((label) => (
+                                <tr key={label}>
+                                    <td className='text-center'>{label}</td>
+                                    {table.getFlatHeaders().slice(1).map((header) => (
+                                        <td key={header.id}>
+                                            <div className='py-1 w-full h-full'>
+                                                <div className='w-full h-full text-xs text-base-content/20 text-center'>
+                                                    —
+                                                </div>
+                                            </div>
+                                        </td>
+                                    ))}
+                                </tr>
+                            ))
+                        ) : (
+                            <tr>
+                                <td colSpan={table.getFlatHeaders().length}>
+                                    <div className={'text-center py-4'}>Loading...</div>
+                                </td>
+                            </tr>
+                        )
                     ) : (
                         <>
                             {table.getRowModel().rows.map((row) => (

--- a/components/src/preact/components/features-over-time-grid.tsx
+++ b/components/src/preact/components/features-over-time-grid.tsx
@@ -293,24 +293,26 @@ function FeaturesOverTimeGridDisplay<F>({
                 <tbody>
                     {isLoading ? (
                         loadingRowLabels !== undefined && loadingRowLabels.length > 0 ? (
-                            loadingRowLabels.map((label) => (
+                            loadingRowLabels.map((label, rowIndex) => (
                                 <tr key={label}>
                                     <td className='text-center'>{label}</td>
-                                    {table.getFlatHeaders().slice(1).map((header) => (
-                                        <td key={header.id}>
-                                            <div className='py-1 w-full h-full'>
-                                                <div className='w-full h-full text-xs text-base-content/20 text-center'>
-                                                    —
-                                                </div>
-                                            </div>
+                                    {rowIndex === 0 && (
+                                        <td
+                                            rowSpan={loadingRowLabels.length}
+                                            colSpan={table.getFlatHeaders().length - 1}
+                                            className='text-center'
+                                        >
+                                            <span className='loading loading-spinner loading-sm' />
                                         </td>
-                                    ))}
+                                    )}
                                 </tr>
                             ))
                         ) : (
                             <tr>
                                 <td colSpan={table.getFlatHeaders().length}>
-                                    <div className={'text-center py-4'}>Loading...</div>
+                                    <div className={'text-center py-4'}>
+                                        <span className='loading loading-spinner loading-sm' />
+                                    </div>
                                 </td>
                             </tr>
                         )

--- a/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
@@ -384,7 +384,7 @@ export const UsesPagination: StoryObj<MutationsOverTimeProps> = {
     play: async ({ canvas, step }) => {
         const mutationOnFirstPage = 'C44T';
         const mutationOnSecondPage = 'C21654-';
-        await expectMutationOnPage(canvas, mutationOnFirstPage);
+        await expectMutationOnPage(canvas, 'C774T');
 
         await step('Navigate to next page', async () => {
             canvas.getByRole('button', { name: 'Next page' }).click();
@@ -398,7 +398,7 @@ export const UsesPagination: StoryObj<MutationsOverTimeProps> = {
             await userEvent.type(gotoPageInput, '1');
             await userEvent.tab();
 
-            await expectMutationOnPage(canvas, mutationOnFirstPage);
+            await expectMutationOnPage(canvas, 'C774T');
         });
 
         await step('Change number of rows per page', async () => {

--- a/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
@@ -384,7 +384,7 @@ export const UsesPagination: StoryObj<MutationsOverTimeProps> = {
     play: async ({ canvas, step }) => {
         const mutationOnFirstPage = 'C44T';
         const mutationOnSecondPage = 'C21654-';
-        await expect(canvas.getByText('Mutation')).toBeVisible();
+        await waitFor(async () => await expect(canvas.getByText('Mutation')).toBeVisible(), { timeout: 10000 });
         await expectMutationOnPage(canvas, 'C774T');
 
         await step('Navigate to next page', async () => {
@@ -506,13 +506,10 @@ export const WithCustomColumns: StoryObj<MutationsOverTimeProps> = {
 };
 
 async function expectMutationOnPage(canvas: Canvas, mutation: string) {
-    await waitFor(
-        async () => {
-            const mutationOnFirstPage = canvas.getAllByText(mutation)[0];
-            await expect(mutationOnFirstPage).toBeVisible();
-        },
-        { timeout: 5000 },
-    );
+    await waitFor(async () => {
+        const mutationOnFirstPage = canvas.getAllByText(mutation)[0];
+        await expect(mutationOnFirstPage).toBeVisible();
+    });
 }
 
 async function expectDateRangeOnPage(canvas: Canvas, dateRange: string) {

--- a/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
@@ -384,8 +384,7 @@ export const UsesPagination: StoryObj<MutationsOverTimeProps> = {
     play: async ({ canvas, step }) => {
         const mutationOnFirstPage = 'C44T';
         const mutationOnSecondPage = 'C21654-';
-        await waitFor(async () => await expect(canvas.getByText('Mutation')).toBeVisible(), { timeout: 10000 });
-        await expectMutationOnPage(canvas, 'A13121T');
+        await expectMutationOnPage(canvas, mutationOnFirstPage);
 
         await step('Navigate to next page', async () => {
             canvas.getByRole('button', { name: 'Next page' }).click();
@@ -394,12 +393,9 @@ export const UsesPagination: StoryObj<MutationsOverTimeProps> = {
         });
 
         await step('Use goto page input', async () => {
-            const gotoPageInput = canvas.getByRole('spinbutton', { name: 'Enter page number to go to' });
-            await userEvent.clear(gotoPageInput);
-            await userEvent.type(gotoPageInput, '1');
-            await userEvent.tab();
+            canvas.getByRole('button', { name: 'Previous page' }).click();
 
-            await expectMutationOnPage(canvas, 'C7113T');
+            await expectMutationOnPage(canvas, mutationOnFirstPage);
         });
 
         await step('Change number of rows per page', async () => {
@@ -506,13 +502,10 @@ export const WithCustomColumns: StoryObj<MutationsOverTimeProps> = {
 };
 
 async function expectMutationOnPage(canvas: Canvas, mutation: string) {
-    await waitFor(
-        async () => {
-            const mutationOnFirstPage = canvas.getAllByText(mutation)[0];
-            await expect(mutationOnFirstPage).toBeVisible();
-        },
-        { timeout: 10000 },
-    );
+    await waitFor(async () => {
+        const mutationOnFirstPage = canvas.getAllByText(mutation)[0];
+        await expect(mutationOnFirstPage).toBeVisible();
+    });
 }
 
 async function expectDateRangeOnPage(canvas: Canvas, dateRange: string) {

--- a/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
@@ -384,6 +384,7 @@ export const UsesPagination: StoryObj<MutationsOverTimeProps> = {
     play: async ({ canvas, step }) => {
         const mutationOnFirstPage = 'C44T';
         const mutationOnSecondPage = 'C21654-';
+        await expect(canvas.getByText('Mutation')).toBeVisible();
         await expectMutationOnPage(canvas, 'C774T');
 
         await step('Navigate to next page', async () => {

--- a/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
@@ -505,10 +505,13 @@ export const WithCustomColumns: StoryObj<MutationsOverTimeProps> = {
 };
 
 async function expectMutationOnPage(canvas: Canvas, mutation: string) {
-    await waitFor(async () => {
-        const mutationOnFirstPage = canvas.getAllByText(mutation)[0];
-        await expect(mutationOnFirstPage).toBeVisible();
-    });
+    await waitFor(
+        async () => {
+            const mutationOnFirstPage = canvas.getAllByText(mutation)[0];
+            await expect(mutationOnFirstPage).toBeVisible();
+        },
+        { timeout: 5000 },
+    );
 }
 
 async function expectDateRangeOnPage(canvas: Canvas, dateRange: string) {

--- a/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
@@ -392,7 +392,7 @@ export const UsesPagination: StoryObj<MutationsOverTimeProps> = {
             await expectMutationOnPage(canvas, mutationOnSecondPage);
         });
 
-        await step('Use goto page input', async () => {
+        await step('Go to previous page', async () => {
             canvas.getByRole('button', { name: 'Previous page' }).click();
 
             await expectMutationOnPage(canvas, mutationOnFirstPage);

--- a/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.stories.tsx
@@ -385,7 +385,7 @@ export const UsesPagination: StoryObj<MutationsOverTimeProps> = {
         const mutationOnFirstPage = 'C44T';
         const mutationOnSecondPage = 'C21654-';
         await waitFor(async () => await expect(canvas.getByText('Mutation')).toBeVisible(), { timeout: 10000 });
-        await expectMutationOnPage(canvas, 'C774T');
+        await expectMutationOnPage(canvas, 'A13121T');
 
         await step('Navigate to next page', async () => {
             canvas.getByRole('button', { name: 'Next page' }).click();
@@ -399,7 +399,7 @@ export const UsesPagination: StoryObj<MutationsOverTimeProps> = {
             await userEvent.type(gotoPageInput, '1');
             await userEvent.tab();
 
-            await expectMutationOnPage(canvas, 'C774T');
+            await expectMutationOnPage(canvas, 'C7113T');
         });
 
         await step('Change number of rows per page', async () => {
@@ -506,10 +506,13 @@ export const WithCustomColumns: StoryObj<MutationsOverTimeProps> = {
 };
 
 async function expectMutationOnPage(canvas: Canvas, mutation: string) {
-    await waitFor(async () => {
-        const mutationOnFirstPage = canvas.getAllByText(mutation)[0];
-        await expect(mutationOnFirstPage).toBeVisible();
-    });
+    await waitFor(
+        async () => {
+            const mutationOnFirstPage = canvas.getAllByText(mutation)[0];
+            await expect(mutationOnFirstPage).toBeVisible();
+        },
+        { timeout: 10000 },
+    );
 }
 
 async function expectDateRangeOnPage(canvas: Canvas, dateRange: string) {

--- a/components/src/preact/mutationsOverTime/mutations-over-time.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.tsx
@@ -199,7 +199,11 @@ const MutationsOverTimeTabs: FunctionComponent<MutationOverTimeTabsProps> = ({
     }, [filteredMutationCodes, setPageIndex]);
 
     const totalFilteredRows = filteredMutationCodes.length;
-    const { isLoading: isPageLoading, data: pageData, pageMutationCodes } = useMutationsOverTimePageData(
+    const {
+        isLoading: isPageLoading,
+        data: pageData,
+        pageMutationCodes,
+    } = useMutationsOverTimePageData(
         filteredMutationCodes,
         pageIndex,
         pageSize,

--- a/components/src/preact/mutationsOverTime/mutations-over-time.tsx
+++ b/components/src/preact/mutationsOverTime/mutations-over-time.tsx
@@ -199,7 +199,7 @@ const MutationsOverTimeTabs: FunctionComponent<MutationOverTimeTabsProps> = ({
     }, [filteredMutationCodes, setPageIndex]);
 
     const totalFilteredRows = filteredMutationCodes.length;
-    const { isLoading: isPageLoading, data: pageData } = useMutationsOverTimePageData(
+    const { isLoading: isPageLoading, data: pageData, pageMutationCodes } = useMutationsOverTimePageData(
         filteredMutationCodes,
         pageIndex,
         pageSize,
@@ -237,6 +237,7 @@ const MutationsOverTimeTabs: FunctionComponent<MutationOverTimeTabsProps> = ({
                             rowLabelHeader='Mutation'
                             data={pageData}
                             isLoading={isPageLoading}
+                            loadingRowLabels={pageMutationCodes}
                             requestedDateRanges={requestedDateRanges}
                             colorScale={colorScale}
                             pageSizes={originalComponentProps.pageSizes}

--- a/components/src/preact/mutationsOverTime/useMutationsOverTimePageData.ts
+++ b/components/src/preact/mutationsOverTime/useMutationsOverTimePageData.ts
@@ -6,7 +6,9 @@ import { type LapisFilter } from '../../types';
 import { Map2dView } from '../../utils/map2d';
 import { useQuery } from '../useQuery';
 
-type MutationsOverTimePageQuery = { isLoading: true; data: null } | { isLoading: false; data: MutationOverTimeDataMap };
+type MutationsOverTimePageQuery =
+    | { isLoading: true; data: null; pageMutationCodes: string[] }
+    | { isLoading: false; data: MutationOverTimeDataMap; pageMutationCodes: string[] };
 
 /**
  * Fetches the data for a single page of the mutations-over-time grid.
@@ -82,11 +84,11 @@ export function useMutationsOverTimePageData(
 
     return useMemo(() => {
         if (isLoading) {
-            return { isLoading: true, data: null };
+            return { isLoading: true, data: null, pageMutationCodes };
         }
 
-        return { isLoading: false, data: handleHideGaps(pageData, hideGaps) };
-    }, [pageData, hideGaps, isLoading]);
+        return { isLoading: false, data: handleHideGaps(pageData, hideGaps), pageMutationCodes };
+    }, [pageData, hideGaps, isLoading, pageMutationCodes]);
 }
 
 /**


### PR DESCRIPTION
<!-- Mention the issue that this PR resolves. Delete if there is no corresponding issue -->
resolves #1102

### Summary
<!-- 
Add a few sentences describing the main changes introduced in this PR
This is only relevant, if there is no issue that already contains the information
-->

Anticipate the vertical size, already show all rows while loading, so that the component keeps its height after the data finished loading.

### Screenshot
<!-- 
When applicable, add a screenshot showing the main effect this PR has, even if "trivial":
e.g. changed layout, changed button text, different logging in backend.
This helps others quickly grasping what you did even if they are not familiar with the code base.
-->

https://github.com/user-attachments/assets/f27dea72-2e14-4f9b-950e-ee475a6267ba


### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
