### PR TITLE
fix(components): reselecting a removed lineage chip now works

### DIFF
--- a/components/src/preact/components/downshift-combobox.tsx
+++ b/components/src/preact/components/downshift-combobox.tsx
@@ -190,46 +190,54 @@ export function DownshiftMultiCombobox<Item>({
         environment,
     });
 
-    const { isOpen, getToggleButtonProps, getMenuProps, getInputProps, highlightedIndex, getItemProps, closeMenu } =
-        useCombobox({
-            items: availableItems,
-            itemToString(item) {
-                return itemToString(item);
-            },
-            inputValue: itemsFilter,
-            onStateChange({ inputValue: newInputValue, type, selectedItem: newSelectedItem }) {
-                switch (type) {
-                    case useCombobox.stateChangeTypes.InputKeyDownEnter:
-                    case useCombobox.stateChangeTypes.ItemClick:
-                        if (newSelectedItem) {
-                            dispatchEvent([...selectedItems, newSelectedItem]);
-                            setItemsFilter('');
-                        }
-                        break;
-                    case useCombobox.stateChangeTypes.InputChange:
-                        setItemsFilter(newInputValue?.trim() ?? '');
-                        break;
-                    default:
-                        break;
-                }
-            },
-            stateReducer(state, actionAndChanges) {
-                const { changes, type } = actionAndChanges;
-                switch (type) {
-                    case useCombobox.stateChangeTypes.InputKeyDownEnter:
-                    case useCombobox.stateChangeTypes.ItemClick:
-                        return {
-                            ...changes,
-                            isOpen: true,
-                            highlightedIndex: state.highlightedIndex,
-                            inputValue: '',
-                        };
-                    default:
-                        return changes;
-                }
-            },
-            environment,
-        });
+    const {
+        isOpen,
+        getToggleButtonProps,
+        getMenuProps,
+        getInputProps,
+        highlightedIndex,
+        getItemProps,
+        closeMenu,
+        selectItem,
+    } = useCombobox({
+        items: availableItems,
+        itemToString(item) {
+            return itemToString(item);
+        },
+        inputValue: itemsFilter,
+        onStateChange({ inputValue: newInputValue, type, selectedItem: newSelectedItem }) {
+            switch (type) {
+                case useCombobox.stateChangeTypes.InputKeyDownEnter:
+                case useCombobox.stateChangeTypes.ItemClick:
+                    if (newSelectedItem) {
+                        dispatchEvent([...selectedItems, newSelectedItem]);
+                        setItemsFilter('');
+                    }
+                    break;
+                case useCombobox.stateChangeTypes.InputChange:
+                    setItemsFilter(newInputValue?.trim() ?? '');
+                    break;
+                default:
+                    break;
+            }
+        },
+        stateReducer(state, actionAndChanges) {
+            const { changes, type } = actionAndChanges;
+            switch (type) {
+                case useCombobox.stateChangeTypes.InputKeyDownEnter:
+                case useCombobox.stateChangeTypes.ItemClick:
+                    return {
+                        ...changes,
+                        isOpen: true,
+                        highlightedIndex: state.highlightedIndex,
+                        inputValue: '',
+                    };
+                default:
+                    return changes;
+            }
+        },
+        environment,
+    });
 
     const clearAll = () => {
         dispatchEvent([]);
@@ -259,7 +267,10 @@ export function DownshiftMultiCombobox<Item>({
                                 aria-label={`remove ${itemToString(selectedItem)}`}
                                 className='cursor-pointer hover:text-red-600'
                                 type='button'
-                                onClick={() => removeSelectedItem(selectedItem)}
+                                onClick={() => {
+                                    removeSelectedItem(selectedItem);
+                                    selectItem(null);
+                                }}
                                 tabIndex={-1}
                             >
                                 ×

--- a/components/src/preact/components/downshift-combobox.tsx
+++ b/components/src/preact/components/downshift-combobox.tsx
@@ -242,6 +242,7 @@ export function DownshiftMultiCombobox<Item>({
     const clearAll = () => {
         dispatchEvent([]);
         setItemsFilter('');
+        selectItem(null);
     };
 
     const buttonRef = useRef(null);

--- a/components/src/preact/lineageFilter/lineage-filter.stories.tsx
+++ b/components/src/preact/lineageFilter/lineage-filter.stories.tsx
@@ -422,6 +422,62 @@ export const MultiSelectClearAll: StoryObj<LineageFilterProps> = {
     },
 };
 
+export const MultiSelectReselectAfterClearAll: StoryObj<LineageFilterProps> = {
+    render: (args) => (
+        <LapisUrlContextProvider value={LAPIS_URL}>
+            <LineageFilter {...args} />
+        </LapisUrlContextProvider>
+    ),
+    args: {
+        ...Default.args,
+        multiSelect: true,
+        value: ['A.1', 'B.1'],
+        placeholderText: 'Select lineages',
+    },
+    play: async ({ canvasElement, step }) => {
+        const canvas = within(canvasElement);
+        const lineageChangedListenerMock = fn();
+
+        await step('Setup event listener mock', () => {
+            canvasElement.addEventListener(gsEventNames.lineageFilterMultiChanged, lineageChangedListenerMock);
+        });
+
+        await step('multi-select filter is rendered with initial values', async () => {
+            await waitFor(async () => {
+                await expect(canvas.getByText('A.1')).toBeVisible();
+                await expect(canvas.getByText('B.1')).toBeVisible();
+            });
+        });
+
+        await step('clear all selections', async () => {
+            const clearButton = canvas.getByLabelText('clear selection');
+            await userEvent.click(clearButton);
+
+            await waitFor(() => {
+                return expect(lineageChangedListenerMock.mock.calls.at(-1)![0].detail).toStrictEqual({
+                    pangoLineage: undefined,
+                });
+            });
+        });
+
+        await step('reselect A.1 from the dropdown', async () => {
+            const input = await canvas.findByPlaceholderText('Select lineages');
+            await userEvent.type(input, 'A.1');
+            await userEvent.click(canvas.getByRole('option', { name: 'A.1(2,574)' }));
+
+            await waitFor(() => {
+                return expect(lineageChangedListenerMock.mock.calls.at(-1)![0].detail).toStrictEqual({
+                    pangoLineage: ['A.1'],
+                });
+            });
+        });
+
+        await step('verify A.1 is shown', async () => {
+            await expect(canvas.getByText('A.1')).toBeVisible();
+        });
+    },
+};
+
 export const MultiSelectReselectAfterRemove: StoryObj<LineageFilterProps> = {
     render: (args) => (
         <LapisUrlContextProvider value={LAPIS_URL}>

--- a/components/src/preact/lineageFilter/lineage-filter.stories.tsx
+++ b/components/src/preact/lineageFilter/lineage-filter.stories.tsx
@@ -422,6 +422,63 @@ export const MultiSelectClearAll: StoryObj<LineageFilterProps> = {
     },
 };
 
+export const MultiSelectReselectAfterRemove: StoryObj<LineageFilterProps> = {
+    render: (args) => (
+        <LapisUrlContextProvider value={LAPIS_URL}>
+            <LineageFilter {...args} />
+        </LapisUrlContextProvider>
+    ),
+    args: {
+        ...Default.args,
+        multiSelect: true,
+        value: ['A.1', 'B.1'],
+        placeholderText: 'Select lineages',
+    },
+    play: async ({ canvasElement, step }) => {
+        const canvas = within(canvasElement);
+        const lineageChangedListenerMock = fn();
+
+        await step('Setup event listener mock', () => {
+            canvasElement.addEventListener(gsEventNames.lineageFilterMultiChanged, lineageChangedListenerMock);
+        });
+
+        await step('multi-select filter is rendered with initial values', async () => {
+            await waitFor(async () => {
+                await expect(canvas.getByText('A.1')).toBeVisible();
+                await expect(canvas.getByText('B.1')).toBeVisible();
+            });
+        });
+
+        await step('remove A.1', async () => {
+            const removeButton = canvas.getByLabelText('remove A.1');
+            await userEvent.click(removeButton);
+
+            await waitFor(() => {
+                return expect(lineageChangedListenerMock.mock.calls.at(-1)![0].detail).toStrictEqual({
+                    pangoLineage: ['B.1'],
+                });
+            });
+        });
+
+        await step('reselect A.1 from the dropdown', async () => {
+            const input = await canvas.findByPlaceholderText('Select lineages');
+            await userEvent.type(input, 'A.1');
+            await userEvent.click(canvas.getByRole('option', { name: 'A.1(2,574)' }));
+
+            await waitFor(() => {
+                return expect(lineageChangedListenerMock.mock.calls.at(-1)![0].detail).toStrictEqual({
+                    pangoLineage: ['B.1', 'A.1'],
+                });
+            });
+        });
+
+        await step('verify A.1 is shown again', async () => {
+            await expect(canvas.getByText('A.1')).toBeVisible();
+            await expect(canvas.getByText('B.1')).toBeVisible();
+        });
+    },
+};
+
 async function prepare(canvasElement: HTMLElement, step: StepFunction<PreactRenderer, unknown>) {
     const canvas = within(canvasElement);
 


### PR DESCRIPTION

Closes #1125

### Summary
After removing a chip from the multi-select lineage filter, downshift's internal selectedItem still held the removed value, so clicking that same item again produced no state change and no event. Resetting selectedItem to null in the stateReducer after each selection clears this stale reference.

Adds a regression story MultiSelectReselectAfterRemove that reproduces the original failure sequence.

### PR Checklist
<!-- Check completed items of strikethrough irrelevant items (using ~~text~~) -->
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
